### PR TITLE
using time.Since instead time.Now().Sub(t)

### DIFF
--- a/resource/job.go
+++ b/resource/job.go
@@ -127,7 +127,7 @@ func (*Job) toDuration(status v1.JobStatus) string {
 	switch {
 	case status.StartTime == nil:
 	case status.CompletionTime == nil:
-		return duration.HumanDuration(time.Now().Sub(status.StartTime.Time))
+		return duration.HumanDuration(time.Since(status.StartTime.Time))
 	}
 	return duration.HumanDuration(status.CompletionTime.Sub(status.StartTime.Time))
 }


### PR DESCRIPTION
Hi! I've just made a little change for replace `time.Now().Sub(t)` to [time.Since](https://golang.org/src/time/time.go?s=28315:28342#L900), because its a just shortcut for this