### PR TITLE
[WIP] Fix conflict between alias command and table key binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ brew tap derailed/k9s && brew install k9s
 ## Commands
 
 + K9s uses 2 or 3 letters alias to navigate most K8s resource
-+ At any time you can use `?<Enter>` to look up the various commands
-+ Use `alias<Enter>` to activate a resource under that alias
++ At any time you can use `:?<Enter>` to look up the various commands
++ Use `:alias<Enter>` to activate a resource under that alias
 + `Ctrl` sequences are used to view, edit, delete, ssh ...
 + Use `ctx<Enter>` to switch between clusters
 + Use `Q` or `Ctrl-C` to Quit.

--- a/views/app.go
+++ b/views/app.go
@@ -45,6 +45,7 @@ type (
 		focusChanged focusHandler
 		cancel       context.CancelFunc
 		cmdBuff      []rune
+		isCmd        bool
 	}
 )
 
@@ -129,13 +130,18 @@ func (a *appView) keyboard(evt *tcell.EventKey) *tcell.EventKey {
 	case tcell.KeyTab:
 		a.nextFocus()
 	case tcell.KeyRune:
-		a.cmdBuff = append([]rune(a.cmdBuff), evt.Rune())
+		if evt.Rune() == ':' {
+			a.isCmd = true
+		} else if a.isCmd {
+			a.cmdBuff = append([]rune(a.cmdBuff), evt.Rune())
+		}
 	}
 	return evt
 }
 
 func (a *appView) resetCmd() {
 	a.cmdBuff = []rune{}
+	a.isCmd = false
 }
 
 func (a *appView) showPage(p string) {


### PR DESCRIPTION
Hi there,

Thank you for such a awesome tool. I was looking for this!

I found that alias commands conflicted with table key bindings.
https://github.com/k8sland/tview/blob/6d988e28392ee307fcc0a7c8c2213c799c97b13c/table.go#L175-L187

![k9s](https://user-images.githubusercontent.com/2253692/52252052-899fa700-2943-11e9-8469-2b0dc1e331d0.gif)

I tried implementing it to require a colon before alias like vim.
Of course, I know this is a major change, but I did not come up with a better way.

Are there any good ideas?