### PR TITLE
Use delete key on Windows/Linux to delete resources

### DIFF
--- a/views/resource.go
+++ b/views/resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -343,7 +344,12 @@ func (v *resourceView) refreshActions() {
 	}
 
 	if v.list.Access(resource.DeleteAccess) {
-		aa[tcell.KeyBackspace2] = newKeyHandler("Delete", v.delete)
+		kd := tcell.KeyDelete
+		if runtime.GOOS == "darwin" {
+			kd = tcell.KeyBackspace2
+		}
+
+		aa[kd] = newKeyHandler("Delete", v.delete)
 	}
 	if v.list.Access(resource.ViewAccess) {
 		aa[tcell.KeyCtrlV] = newKeyHandler("View", v.view)


### PR DESCRIPTION
This will use the actual Delete key on Linux/Windows instead of Backspace. macOS behaviour should not have been changed, though I cannot test this personally (no access to a macOS machine).