### PR TITLE
Add Gocenter as goproxy

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,7 @@ builds:
     goarch:
       - 386
       - amd64
-       - arm
+      - arm
       - arm64
     goarm:
       - 6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,7 @@
 project_name: k9s
+env:
+  - GO111MODULE=on
+  - GOPROXY=https://gocenter.io
 before:
   hooks:
     - go mod download
@@ -17,7 +20,7 @@ builds:
     goarch:
       - 386
       - amd64
-      - arm
+       - arm
       - arm64
     goarm:
       - 6
@@ -80,3 +83,4 @@ snapcraft:
   apps:
     k9s:
       plugs: ["home", "network"]
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install: true
 
 env:
   - GO111MODULE=on
+  - GOPROXY=https://gocenter.io
 
 script:
   - go build

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,19 @@ DATE    := $(shell date +%FT%T%Z)
 
 default: help
 
+test: export GO111MODULE=on
+test: export GOPROXY=https://gocenter.io
 test:      ## Run all tests
 	@go test ./...
 
+cover: export GO111MODULE=on
+cover: export GOPROXY=https://gocenter.io
 cover:     ## Run test coverage suite
 	@go test ./... --coverprofile=cov.out
 	@go tool cover --html=cov.out
 
+build: export GO111MODULE=on
+build: export GOPROXY=https://gocenter.io
 build:     ## Builds the CLI
 	@go build \
 	-ldflags "-w -X ${PACKAGE}/cmd.version=${VERSION} -X ${PACKAGE}/cmd.commit=${GIT} -X ${PACKAGE}/cmd.date=${DATE}" \


### PR DESCRIPTION
Using https://gocenter.io as `goproxy` provides the ability to resolve a module through a public go proxy including the ability to search for modules via a hosted free service.
Also modules stored there are for live, so you always receive the same version whenever you download it. As well modules download speed is much quicker comparing with the github.