### PR TITLE
Add missing backtick to wrap namespace name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 k9s.log
 .envrc
 cov.out

--- a/internal/config/ns.go
+++ b/internal/config/ns.go
@@ -35,8 +35,8 @@ func (n *Namespace) Validate(c Connection, ks KubeSettings) {
 	}
 	nn := ks.NamespaceNames(nns)
 	if !n.isAllNamespace() && !InList(nn, n.Active) {
-		log.Error().Msgf("[Config] Validation error active namespace `%s does not exists", n.Active)
-		panic(fmt.Errorf("Invalid namespace. The provided namespace `%s does not exists", n.Active))
+		log.Error().Msgf("[Config] Validation error active namespace `%s` does not exists", n.Active)
+		panic(fmt.Errorf("Invalid namespace. The provided namespace `%s` does not exists", n.Active))
 	}
 
 	for _, ns := range n.Favorites {

--- a/internal/config/ns.go
+++ b/internal/config/ns.go
@@ -35,8 +35,8 @@ func (n *Namespace) Validate(c Connection, ks KubeSettings) {
 	}
 	nn := ks.NamespaceNames(nns)
 	if !n.isAllNamespace() && !InList(nn, n.Active) {
-		log.Error().Msgf("[Config] Validation error active namespace `%s` does not exists", n.Active)
-		panic(fmt.Errorf("Invalid namespace. The provided namespace `%s` does not exists", n.Active))
+		log.Error().Msgf("[Config] Validation error active namespace `%s` does not exist", n.Active)
+		panic(fmt.Errorf("Invalid namespace. The provided namespace `%s` does not exist", n.Active))
 	}
 
 	for _, ns := range n.Favorites {


### PR DESCRIPTION
1. Add missing backtick in an error message.
2. Add `.idea` to **.gitignore**