### PR TITLE
Make table of colors less obnoxiously long

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Available color names are defined below:
 | steelblue            | tan                  | thistle              | tomato               | turquoise            |
 | violet               | wheat                | whitesmoke           | yellowgreen          | grey                 |
 | dimgrey              | darkgrey             | darkslategrey        | lightgrey            | lightslategrey       |
-| slategrey            | | | | |
+| slategrey            |                      |                      |                      |                      |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -318,154 +318,38 @@ k9s:
 
 Available color names are defined below:
 
-| Color Names          |
-|----------------------|
-| black                |
-| maroon               |
-| green                |
-| olive                |
-| navy                 |
-| purple               |
-| teal                 |
-| silver               |
-| gray                 |
-| red                  |
-| lime                 |
-| yellow               |
-| blue                 |
-| fuchsia              |
-| aqua                 |
-| white                |
-| aliceblue            |
-| antiquewhite         |
-| aquamarine           |
-| azure                |
-| beige                |
-| bisque               |
-| blanchedalmond       |
-| blueviolet           |
-| brown                |
-| burlywood            |
-| cadetblue            |
-| chartreuse           |
-| chocolate            |
-| coral                |
-| cornflowerblue       |
-| cornsilk             |
-| crimson              |
-| darkblue             |
-| darkcyan             |
-| darkgoldenrod        |
-| darkgray             |
-| darkgreen            |
-| darkkhaki            |
-| darkmagenta          |
-| darkolivegreen       |
-| darkorange           |
-| darkorchid           |
-| darkred              |
-| darksalmon           |
-| darkseagreen         |
-| darkslateblue        |
-| darkslategray        |
-| darkturquoise        |
-| darkviolet           |
-| deeppink             |
-| deepskyblue          |
-| dimgray              |
-| dodgerblue           |
-| firebrick            |
-| floralwhite          |
-| forestgreen          |
-| gainsboro            |
-| ghostwhite           |
-| gold                 |
-| goldenrod            |
-| greenyellow          |
-| honeydew             |
-| hotpink              |
-| indianred            |
-| indigo               |
-| ivory                |
-| khaki                |
-| lavender             |
-| lavenderblush        |
-| lawngreen            |
-| lemonchiffon         |
-| lightblue            |
-| lightcoral           |
-| lightcyan            |
-| lightgoldenrodyellow |
-| lightgray            |
-| lightgreen           |
-| lightpink            |
-| lightsalmon          |
-| lightseagreen        |
-| lightskyblue         |
-| lightslategray       |
-| lightsteelblue       |
-| lightyellow          |
-| limegreen            |
-| linen                |
-| mediumaquamarine     |
-| mediumblue           |
-| mediumorchid         |
-| mediumpurple         |
-| mediumseagreen       |
-| mediumslateblue      |
-| mediumspringgreen    |
-| mediumturquoise      |
-| mediumvioletred      |
-| midnightblue         |
-| mintcream            |
-| mistyrose            |
-| moccasin             |
-| navajowhite          |
-| oldlace              |
-| olivedrab            |
-| orange               |
-| orangered            |
-| orchid               |
-| palegoldenrod        |
-| palegreen            |
-| paleturquoise        |
-| palevioletred        |
-| papayawhip           |
-| peachpuff            |
-| peru                 |
-| pink                 |
-| plum                 |
-| powderblue           |
-| rebeccapurple        |
-| rosybrown            |
-| royalblue            |
-| saddlebrown          |
-| salmon               |
-| sandybrown           |
-| seagreen             |
-| seashell             |
-| sienna               |
-| skyblue              |
-| slateblue            |
-| slategray            |
-| snow                 |
-| springgreen          |
-| steelblue            |
-| tan                  |
-| thistle              |
-| tomato               |
-| turquoise            |
-| violet               |
-| wheat                |
-| whitesmoke           |
-| yellowgreen          |
-| grey                 |
-| dimgrey              |
-| darkgrey             |
-| darkslategrey        |
-| lightgrey            |
-| lightslategrey       |
-| slategrey            |
+| Color Names          |                      |                      |                      |                      |
+|----------------------|----------------------|----------------------|----------------------|----------------------|
+| black                | maroon               | green                | olive                | navy                 |
+| purple               | teal                 | silver               | gray                 | red                  |
+| lime                 | yellow               | blue                 | fuchsia              | aqua                 |
+| white                | aliceblue            | antiquewhite         | aquamarine           | azure                |
+| beige                | bisque               | blanchedalmond       | blueviolet           | brown                |
+| burlywood            | cadetblue            | chartreuse           | chocolate            | coral                |
+| cornflowerblue       | cornsilk             | crimson              | darkblue             | darkcyan             |
+| darkgoldenrod        | darkgray             | darkgreen            | darkkhaki            | darkmagenta          |
+| darkolivegreen       | darkorange           | darkorchid           | darkred              | darksalmon           |
+| darkseagreen         | darkslateblue        | darkslategray        | darkturquoise        | darkviolet           |
+| deeppink             | deepskyblue          | dimgray              | dodgerblue           | firebrick            |
+| floralwhite          | forestgreen          | gainsboro            | ghostwhite           | gold                 |
+| goldenrod            | greenyellow          | honeydew             | hotpink              | indianred            |
+| indigo               | ivory                | khaki                | lavender             | lavenderblush        |
+| lawngreen            | lemonchiffon         | lightblue            | lightcoral           | lightcyan            |
+| lightgoldenrodyellow | lightgray            | lightgreen           | lightpink            | lightsalmon          |
+| lightseagreen        | lightskyblue         | lightslategray       | lightsteelblue       | lightyellow          |
+| limegreen            | linen                | mediumaquamarine     | mediumblue           | mediumorchid         |
+| mediumpurple         | mediumseagreen       | mediumslateblue      | mediumspringgreen    | mediumturquoise      |
+| mediumvioletred      | midnightblue         | mintcream            | mistyrose            | moccasin             |
+| navajowhite          | oldlace              | olivedrab            | orange               | orangered            |
+| orchid               | palegoldenrod        | palegreen            | paleturquoise        | palevioletred        |
+| papayawhip           | peachpuff            | peru                 | pink                 | plum                 |
+| powderblue           | rebeccapurple        | rosybrown            | royalblue            | saddlebrown          |
+| salmon               | sandybrown           | seagreen             | seashell             | sienna               |
+| skyblue              | slateblue            | slategray            | snow                 | springgreen          |
+| steelblue            | tan                  | thistle              | tomato               | turquoise            |
+| violet               | wheat                | whitesmoke           | yellowgreen          | grey                 |
+| dimgrey              | darkgrey             | darkslategrey        | lightgrey            | lightslategrey       |
+| slategrey            | | | | |
 
 ---
 


### PR DESCRIPTION
Purely aesthetic, but every time I look at the table of color, it's _really_ long.