### PR TITLE
Added kubeconfig option to Pod and Container shell commands

### DIFF
--- a/internal/views/container.go
+++ b/internal/views/container.go
@@ -88,6 +88,7 @@ func (v *containerView) shellIn(path, co string) {
 	args = append(args, "exec", "-it")
 	args = append(args, "--context", v.app.config.K9s.CurrentContext)
 	args = append(args, "-n", ns)
+	args = append(args, "--kubeconfig", *v.app.config.GetConnection().Config().Flags().KubeConfig)
 	args = append(args, po)
 	if len(co) != 0 {
 		args = append(args, "-c", co)

--- a/internal/views/pod.go
+++ b/internal/views/pod.go
@@ -181,6 +181,7 @@ func (v *podView) shellIn(path, co string) {
 		args = append(args, "exec", "-it")
 		args = append(args, "--context", v.app.config.K9s.CurrentContext)
 		args = append(args, "-n", ns)
+		args = append(args, "--kubeconfig", *v.app.config.GetConnection().Config().Flags().KubeConfig)
 		args = append(args, po)
 		if len(co) != 0 {
 			args = append(args, "-c", co)


### PR DESCRIPTION
Fixes #195.

Works great in local testing, both with the `--kubeconfig` option and without.

If there are any other places this should be propagated or tests that should be written/revised, let me know!