### PR TITLE
Added sort node by cpu and mem percentage

### DIFF
--- a/internal/views/no.go
+++ b/internal/views/no.go
@@ -20,6 +20,8 @@ func newNodeView(t string, app *appView, list resource.List) resourceViewer {
 func (v *nodeView) extraActions(aa keyActions) {
 	aa[KeyShiftC] = newKeyAction("Sort CPU", v.sortColCmd(7, false), true)
 	aa[KeyShiftM] = newKeyAction("Sort MEM", v.sortColCmd(8, false), true)
+	aa[KeyAltC] = newKeyAction("Sort CPU%", v.sortColCmd(9, false), true)
+	aa[KeyAltM] = newKeyAction("Sort MEM%", v.sortColCmd(10, false), true)
 }
 
 func (v *nodeView) sortColCmd(col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {


### PR DESCRIPTION
In case nodes machines have different size, total CPU/MEM and percentage are not necessarily the same. This would help see the load more easily.
Also, align sort fields with pods and containers views.