### PR TITLE
add dockerfile for k9s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:alpine AS builder
+
+ADD ./ /k9s
+WORKDIR /k9s
+RUN apk add make git gcc libc-dev curl
+RUN curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator
+RUN make build && go clean
+
+FROM alpine:latest
+
+RUN mkdir /k9s /root/.kube /root/.aws
+COPY --from=builder /k9s/execs/k9s /bin/k9s
+COPY --from=builder /k9s/aws-iam-authenticator /bin/aws-iam-authenticator
+RUN chmod +x /bin/aws-iam-authenticator

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ADD ./ /k9s
 WORKDIR /k9s
 RUN apk add make git gcc libc-dev curl
 RUN curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator
-RUN make build && go clean
+RUN make build
 
 FROM alpine:latest
 


### PR DESCRIPTION
It would be nice to have the ability to have k9s run in a container. 
The final image will include aws-iam-authenticator to be able to run this against eks.
Doing a multistage build in order to keep the final image small. Currently under 100MBs.