### PR TITLE
fix(styling): Properly colorize yaml KVs with '/'

### DIFF
--- a/internal/views/yaml.go
+++ b/internal/views/yaml.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	keyValRX = regexp.MustCompile(`\A(\s*)([\w|\-|\.|\s]+):\s(.+)\z`)
-	keyRX    = regexp.MustCompile(`\A(\s*)([\w|\-|\.|\s]+):\s*\z`)
+	keyValRX = regexp.MustCompile(`\A(\s*)([\w|\-|\.|\/|\s]+):\s(.+)\z`)
+	keyRX    = regexp.MustCompile(`\A(\s*)([\w|\-|\.|\/|\s]+):\s*\z`)
 )
 
 const (

--- a/internal/views/yaml_test.go
+++ b/internal/views/yaml_test.go
@@ -39,6 +39,10 @@ func TestYaml(t *testing.T) {
 			"fred.blee:  <none>",
 			"[steelblue::b]fred.blee[white::-]: [papayawhip::] <none>",
 		},
+		{
+			"certmanager.k8s.io/cluster-issuer: nameOfClusterIssuer",
+			"[steelblue::b]certmanager.k8s.io/cluster-issuer[white::-]: [papayawhip::]nameOfClusterIssuer",
+		},
 	}
 
 	s, _ := config.NewStyles("skins/stock.yml")


### PR DESCRIPTION
This fixes it such that annotations with `/` are properly colorized when viewed in yaml mode. Previously this entry would be improperly colored

```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    certmanager.k8s.io/cluster-issuer: nameOfClusterIssuer
```