### PR TITLE
fix(describe): Dont panic when trying to describe an unknown resource

### DIFF
--- a/internal/k8s/mapper.go
+++ b/internal/k8s/mapper.go
@@ -243,4 +243,16 @@ var resMap = map[string]*meta.RESTMapping{
 		GroupVersionKind: schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"},
 		Scope:            RestMapping,
 	},
+
+	"Events": {
+		Resource:         schema.GroupVersionResource{Group: "events.k8s.io", Version: "v1beta1", Resource: "events"},
+		GroupVersionKind: schema.GroupVersionKind{Group: "events.k8s.io", Version: "v1beta1", Kind: "Event"},
+		Scope:            RestMapping,
+	},
+
+	"PodDisruptionBudgets": {
+		Resource:         schema.GroupVersionResource{Group: "policy", Version: "v1beta1", Resource: "poddisruptionbudgets"},
+		GroupVersionKind: schema.GroupVersionKind{Group: "policy", Version: "v1beta1", Kind: "PodDisruptionBudget"},
+		Scope:            RestMapping,
+	},
 }

--- a/internal/resource/base.go
+++ b/internal/resource/base.go
@@ -131,13 +131,18 @@ func (b *Base) List(ns string) (Columnars, error) {
 func (b *Base) Describe(kind, pa string) (string, error) {
 	mapping, err := k8s.RestMapping.Find(kind)
 	if err != nil {
-		g, v, n := b.Resource.(*k8s.Resource).GetInfo()
-		mapper := k8s.RestMapper{b.Connection}
+		resource, ok := b.Resource.(*k8s.Resource)
+		if !ok {
+			log.Debug().Msgf("resource not a (*k8s.Resource) and %s", err)
+			return "", fmt.Errorf("resource not a (*k8s.Resource) and %s", err)
+		}
+		g, v, n := resource.GetInfo()
+		mapper := k8s.RestMapper{Connection: b.Connection}
 		var e error
 		mapping, e = mapper.ResourceFor(fmt.Sprintf("%s.%s.%s", n, v, g))
 		if e != nil {
-			log.Debug().Err(err).Msgf("Unable to find mapper for %s %s", kind, pa)
-			return "", err
+			log.Debug().Err(e).Msgf("Unable to find mapper for %s %s", kind, pa)
+			return "", e
 		}
 	}
 

--- a/internal/resource/custom.go
+++ b/internal/resource/custom.go
@@ -38,7 +38,7 @@ func NewCustomList(c k8s.Connection, ns, group, version, name string) List {
 func NewCustom(c k8s.Connection, group, version, name string) *Custom {
 	cr := &Custom{Base: &Base{Connection: c, Resource: k8s.NewResource(c, group, version, name)}}
 	cr.Factory = cr
-	cr.group, cr.version, cr.name = cr.Resource.(*k8s.Resource).GetInfo()
+	cr.group, cr.version, cr.name = group, version, name
 
 	return cr
 }

--- a/internal/views/resource.go
+++ b/internal/views/resource.go
@@ -189,7 +189,7 @@ func (v *resourceView) defaultEnter(ns, _, selection string) {
 
 	yaml, err := v.list.Resource().Describe(v.masterPage().baseTitle, selection)
 	if err != nil {
-		v.app.flash().errf("Describe command failed %s", err)
+		v.app.flash().errf("Describe command failed: %s", err)
 		return
 	}
 


### PR DESCRIPTION
When describing Events or PDBs k9s would crash with `Boom!! interface conversion: resource.Cruder is *k8s.Event, not *k8s.Resource.`

This adds `Events` and `PodDisruptionBudgets` to the mapper and handles the error better so it will log a message and not crash for future resources 


Fixes: #246 