### PR TITLE
feat: add option to pass config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 .idea
+.ide
 k9s.log
 .envrc
 cov.out

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ var (
 	version, commit, date = "dev", "dev", "n/a"
 	refreshRate           int
 	logLevel              string
+	cfgPath               string
 	k8sFlags              *genericclioptions.ConfigFlags
 
 	rootCmd = &cobra.Command{
@@ -86,7 +87,7 @@ func loadConfiguration() *config.Config {
 
 	// Load K9s config file...
 	k8sCfg := k8s.NewConfig(k8sFlags)
-	k9sCfg := config.NewConfig(k8sCfg)
+	k9sCfg := config.NewConfig(k8sCfg, cfgPath)
 	if err := k9sCfg.Load(config.K9sConfigFile); err != nil {
 		log.Warn().Msg("Unable to locate K9s config. Generating new configuration...")
 	}
@@ -131,6 +132,12 @@ func initK9sFlags() {
 		"refresh", "r",
 		defaultRefreshRate,
 		"Specifies the default refresh rate as an integer (sec)",
+	)
+	rootCmd.Flags().StringVarP(
+		&cfgPath,
+		"cfg", "c",
+		"config.yml",
+		"Specify a config file path.",
 	)
 	rootCmd.Flags().StringVarP(
 		&logLevel,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,7 +51,13 @@ type (
 )
 
 // NewConfig creates a new default config.
-func NewConfig(ks KubeSettings) *Config {
+func NewConfig(ks KubeSettings, cfgPath string) *Config {
+	var passedCfg = filepath.Join(K9sHome, cfgPath)
+	if _, err := os.Stat(passedCfg); err == nil {
+		if !os.IsNotExist(err) {
+			K9sConfigFile = passedCfg
+		}
+	}
 	return &Config{K9s: NewK9s(), settings: ks}
 }
 


### PR DESCRIPTION
Hey, i am a go beginner.

I implemented a option to pass a config file, which is also located in the .k9s home directory.
i tested it and its basically running ```k9s -c config1.yml```. 
it even saves back to the choosen config file.

i would really like to see this been merged.
Do you have any hints what i should change/adapt to get this merged?

thx for your great work again. k9s is such a time saver!!!
