### PR TITLE
Use goproxy to download dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ sudo: false
 install: true
 
 env:
-  - GO111MODULE=on
-  - GOPROXY=https://goproxy.io
+  - GO111MODULE=on GOPROXY=https://goproxy.io
 
 script:
   - go build

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install: true
 
 env:
   - GO111MODULE=on
+  - GOPROXY=https://goproxy.io
 
 script:
   - go build


### PR DESCRIPTION
The current CI is timing out sometimes, this pr adds the usage of a go proxy (https://goproxy.io/) to improve download time of dependencies. 