### PR TITLE
add canonical full and short names for objects

### DIFF
--- a/internal/k8s/mapper.go
+++ b/internal/k8s/mapper.go
@@ -26,12 +26,12 @@ type RestMapper struct {
 	Connection
 }
 
-// Find a mapping given a resource name.
-func (*RestMapper) Find(res string) (*meta.RESTMapping, error) {
-	if m, ok := resMap[res]; ok {
+// Find a mapping given a resource kind.
+func (*RestMapper) Find(kind string) (*meta.RESTMapping, error) {
+	if m, ok := kindToMapper[kind]; ok {
 		return m, nil
 	}
-	return nil, fmt.Errorf("no mapping for resource %s", res)
+	return nil, fmt.Errorf("no mapping for kind %s", kind)
 }
 
 // ToRESTMapper map resources to kind, and map kind and version to interfaces for manipulating K8s objects.
@@ -116,18 +116,18 @@ func (*RestMapper) Name() meta.RESTScopeName {
 	return meta.RESTScopeNameNamespace
 }
 
-var resMap = map[string]*meta.RESTMapping{
-	"ConfigMaps": {
+var kindToMapper = map[string]*meta.RESTMapping{
+	"ConfigMap": {
 		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmap"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
 		Scope:            RestMapping,
 	},
-	"Pods": {
+	"Pod": {
 		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pod"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
 		Scope:            RestMapping,
 	},
-	"Services": {
+	"Service": {
 		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "service"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"},
 		Scope:            RestMapping,
@@ -137,81 +137,81 @@ var resMap = map[string]*meta.RESTMapping{
 		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Endpoints"},
 		Scope:            RestMapping,
 	},
-	"Namespaces": {
+	"Namespace": {
 		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespace"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"},
 		Scope:            RestMapping,
 	},
-	"Nodes": {
+	"Node": {
 		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "node"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"},
 		Scope:            RestMapping,
 	},
-	"PersistentVolumes": {
+	"PersistentVolume": {
 		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolume"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PersistentVolume"},
 		Scope:            RestMapping,
 	},
-	"PersistentVolumeClaims": {
+	"PersistentVolumeClaim": {
 		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaim"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"},
 		Scope:            RestMapping,
 	},
-	"ReplicationControllers": {
+	"ReplicationController": {
 		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "replicationcontroller"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ReplicationController"},
 		Scope:            RestMapping,
 	},
-	"Secrets": {
+	"Secret": {
 		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secret"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"},
 		Scope:            RestMapping,
 	},
-	"StorageClasses": {
+	"StorageClasse": {
 		Resource:         schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "storageclass"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "storage.k8s.io", Version: "v1", Kind: "StorageClass"},
 		Scope:            RestMapping,
 	},
-	"ServiceAccounts": {
+	"ServiceAccount": {
 		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccount"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"},
 		Scope:            RestMapping,
 	},
 
-	"Deployments": {
+	"Deployment": {
 		Resource:         schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployment"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
 		Scope:            RestMapping,
 	},
-	"ReplicaSets": {
+	"ReplicaSet": {
 		Resource:         schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicaset"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"},
 		Scope:            RestMapping,
 	},
-	"StatefulSets": {
+	"StatefulSet": {
 		Resource:         schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"},
 		Scope:            RestMapping,
 	},
 
-	"HorizontalPodAutoscalers": {
+	"HorizontalPodAutoscaler": {
 		Resource:         schema.GroupVersionResource{Group: "autoscaling", Version: "v1", Resource: "horizontalpodautoscaler"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "HorizontalPodAutoscaler"},
 		Scope:            RestMapping,
 	},
 
-	"Jobs": {
+	"Job": {
 		Resource:         schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "job"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
 		Scope:            RestMapping,
 	},
-	"CronJobs": {
+	"CronJob": {
 		Resource:         schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "cronjob"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"},
 		Scope:            RestMapping,
 	},
 
-	"DaemonSets": {
+	"DaemonSet": {
 		Resource:         schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "daemonset"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "DaemonSet"},
 		Scope:            RestMapping,
@@ -222,45 +222,45 @@ var resMap = map[string]*meta.RESTMapping{
 		Scope:            RestMapping,
 	},
 
-	"ClusterRoles": {
+	"ClusterRole": {
 		Resource:         schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrole"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},
 		Scope:            RestMapping,
 	},
-	"ClusterRoleBindings": {
+	"ClusterRoleBinding": {
 		Resource:         schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebinding"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"},
 		Scope:            RestMapping,
 	},
-	"Roles": {
+	"Role": {
 		Resource:         schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "role"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"},
 		Scope:            RestMapping,
 	},
-	"RoleBindings": {
+	"RoleBinding": {
 		Resource:         schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebinding"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"},
 		Scope:            RestMapping,
 	},
 
-	"CustomResourceDefinitions": {
+	"CustomResourceDefinition": {
 		Resource:         schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1beta1", Resource: "customresourcedefinitions"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"},
 		Scope:            RestMapping,
 	},
-	"NetworkPolicies": {
+	"NetworkPolicy": {
 		Resource:         schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "networkpolicies"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "NetworkPolicy"},
 		Scope:            RestMapping,
 	},
 
-	"Events": {
+	"Event": {
 		Resource:         schema.GroupVersionResource{Group: "events.k8s.io", Version: "v1beta1", Resource: "events"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "events.k8s.io", Version: "v1beta1", Kind: "Event"},
 		Scope:            RestMapping,
 	},
 
-	"PodDisruptionBudgets": {
+	"PodDisruptionBudget": {
 		Resource:         schema.GroupVersionResource{Group: "policy", Version: "v1beta1", Resource: "poddisruptionbudgets"},
 		GroupVersionKind: schema.GroupVersionKind{Group: "policy", Version: "v1beta1", Kind: "PodDisruptionBudget"},
 		Scope:            RestMapping,

--- a/internal/views/alias.go
+++ b/internal/views/alias.go
@@ -107,7 +107,7 @@ func (v *aliasView) runCmd(evt *tcell.EventKey) *tcell.EventKey {
 }
 
 func (v *aliasView) hydrate() resource.TableData {
-	cmds := make(map[string]resCmd, 40)
+	cmds := make(map[string]*resCmd, 40)
 	aliasCmds(v.app.Conn(), cmds)
 
 	data := resource.TableData{
@@ -119,7 +119,7 @@ func (v *aliasView) hydrate() resource.TableData {
 	for k := range cmds {
 		fields := resource.Row{
 			ui.Pad(k, 30),
-			ui.Pad(cmds[k].title, 30),
+			ui.Pad(cmds[k].kind, 30),
 			ui.Pad(cmds[k].api, 30),
 		}
 		data.Rows[k] = &resource.RowEvent{

--- a/internal/views/alias_test.go
+++ b/internal/views/alias_test.go
@@ -13,6 +13,6 @@ func TestAliasView(t *testing.T) {
 	v.Init(nil, "")
 
 	assert.Equal(t, 3, len(td.Header))
-	assert.Equal(t, 33, len(td.Rows))
+	assert.Equal(t, 41, len(td.Rows))
 	assert.Equal(t, "Aliases", v.getTitle())
 }

--- a/internal/views/command.go
+++ b/internal/views/command.go
@@ -71,7 +71,7 @@ func (c *command) isStdCmd(cmd string) bool {
 }
 
 func (c *command) isAliasCmd(cmd string) bool {
-	cmds := make(map[string]resCmd, 30)
+	cmds := make(map[string]*resCmd, 30)
 	resourceViews(c.app.Conn(), cmds)
 	res, ok := cmds[cmd]
 	if !ok {
@@ -83,7 +83,7 @@ func (c *command) isAliasCmd(cmd string) bool {
 		r = res.listFn(c.app.Conn(), resource.DefaultNamespace)
 	}
 
-	v := res.viewFn(res.title, c.app, r)
+	v := res.viewFn(res.kind, c.app, r)
 	if res.colorerFn != nil {
 		v.setColorerFn(res.colorerFn)
 	}
@@ -94,8 +94,7 @@ func (c *command) isAliasCmd(cmd string) bool {
 		v.setDecorateFn(res.decorateFn)
 	}
 
-	const fmat = "Viewing resource %s..."
-	c.app.Flash().Infof(fmat, res.title)
+	c.app.Flash().Infof("Viewing resource %s...", res.kind)
 	log.Debug().Msgf("Running command %s", cmd)
 	c.exec(cmd, v)
 
@@ -103,7 +102,7 @@ func (c *command) isAliasCmd(cmd string) bool {
 }
 
 func (c *command) isCRDCmd(cmd string) bool {
-	crds := map[string]resCmd{}
+	crds := map[string]*resCmd{}
 	allCRDs(c.app.Conn(), crds)
 	res, ok := crds[cmd]
 	if !ok {
@@ -115,7 +114,7 @@ func (c *command) isCRDCmd(cmd string) bool {
 		name = res.singular
 	}
 	v := newResourceView(
-		res.title,
+		res.kind,
 		c.app,
 		resource.NewCustomList(c.app.Conn(), "", res.api, res.version, name),
 	)


### PR DESCRIPTION
With this modifications, we can know use the full name, short name and as well internal naming from k9s, i.e., `deploy`, `deployment`, `deployments` and `dp` are valid commands to view `deployments` in k9s.

fixes #315 