### PR TITLE
use cached discovery client in more places.

### DIFF
--- a/internal/config/mock_connection_test.go
+++ b/internal/config/mock_connection_test.go
@@ -8,6 +8,7 @@ import (
 	pegomock "github.com/petergtz/pegomock"
 	v1 "k8s.io/api/core/v1"
 	version "k8s.io/apimachinery/pkg/version"
+	disk "k8s.io/client-go/discovery/cached/disk"
 	dynamic "k8s.io/client-go/dynamic"
 	kubernetes "k8s.io/client-go/kubernetes"
 	rest "k8s.io/client-go/rest"
@@ -30,6 +31,25 @@ func NewMockConnection(options ...pegomock.Option) *MockConnection {
 
 func (mock *MockConnection) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockConnection) FailHandler() pegomock.FailHandler      { return mock.fail }
+
+func (mock *MockConnection) CachedDiscovery() (*disk.CachedDiscoveryClient, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockConnection().")
+	}
+	params := []pegomock.Param{}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CachedDiscovery", params, []reflect.Type{reflect.TypeOf((**disk.CachedDiscoveryClient)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 *disk.CachedDiscoveryClient
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(*disk.CachedDiscoveryClient)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
 
 func (mock *MockConnection) CanIAccess(_param0 string, _param1 string, _param2 []string) (bool, error) {
 	if mock == nil {
@@ -380,6 +400,23 @@ type VerifierMockConnection struct {
 	invocationCountMatcher pegomock.Matcher
 	inOrderContext         *pegomock.InOrderContext
 	timeout                time.Duration
+}
+
+func (verifier *VerifierMockConnection) CachedDiscovery() *MockConnection_CachedDiscovery_OngoingVerification {
+	params := []pegomock.Param{}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "CachedDiscovery", params, verifier.timeout)
+	return &MockConnection_CachedDiscovery_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockConnection_CachedDiscovery_OngoingVerification struct {
+	mock              *MockConnection
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockConnection_CachedDiscovery_OngoingVerification) GetCapturedArguments() {
+}
+
+func (c *MockConnection_CachedDiscovery_OngoingVerification) GetAllCapturedArguments() {
 }
 
 func (verifier *VerifierMockConnection) CanIAccess(_param0 string, _param1 string, _param2 []string) *MockConnection_CanIAccess_OngoingVerification {

--- a/internal/k8s/mapper.go
+++ b/internal/k8s/mapper.go
@@ -3,14 +3,11 @@ package k8s
 import (
 	"fmt"
 	"os/user"
-	"path/filepath"
 	"regexp"
 	"strings"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery/cached/disk"
 	"k8s.io/client-go/restmapper"
 )
 
@@ -27,12 +24,7 @@ type RestMapper struct {
 
 // ToRESTMapper map resources to kind, and map kind and version to interfaces for manipulating K8s objects.
 func (r *RestMapper) ToRESTMapper() (meta.RESTMapper, error) {
-	rc := r.RestConfigOrDie()
-
-	httpCacheDir := filepath.Join(mustHomeDir(), ".kube", "http-cache")
-	discCacheDir := filepath.Join(mustHomeDir(), ".kube", "cache", "discovery", toHostDir(rc.Host))
-
-	disc, err := disk.NewCachedDiscoveryClientForConfig(rc, discCacheDir, httpCacheDir, 10*time.Minute)
+	disc, err := r.CachedDiscovery()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resource/mock_clustermeta_test.go
+++ b/internal/resource/mock_clustermeta_test.go
@@ -8,6 +8,7 @@ import (
 	pegomock "github.com/petergtz/pegomock"
 	v1 "k8s.io/api/core/v1"
 	version "k8s.io/apimachinery/pkg/version"
+	disk "k8s.io/client-go/discovery/cached/disk"
 	dynamic "k8s.io/client-go/dynamic"
 	kubernetes "k8s.io/client-go/kubernetes"
 	rest "k8s.io/client-go/rest"
@@ -30,6 +31,25 @@ func NewMockClusterMeta(options ...pegomock.Option) *MockClusterMeta {
 
 func (mock *MockClusterMeta) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockClusterMeta) FailHandler() pegomock.FailHandler      { return mock.fail }
+
+func (mock *MockClusterMeta) CachedDiscovery() (*disk.CachedDiscoveryClient, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockClusterMeta().")
+	}
+	params := []pegomock.Param{}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CachedDiscovery", params, []reflect.Type{reflect.TypeOf((**disk.CachedDiscoveryClient)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 *disk.CachedDiscoveryClient
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(*disk.CachedDiscoveryClient)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
 
 func (mock *MockClusterMeta) CanIAccess(_param0 string, _param1 string, _param2 []string) (bool, error) {
 	if mock == nil {
@@ -465,6 +485,23 @@ type VerifierMockClusterMeta struct {
 	timeout                time.Duration
 }
 
+func (verifier *VerifierMockClusterMeta) CachedDiscovery() *MockClusterMeta_CachedDiscovery_OngoingVerification {
+	params := []pegomock.Param{}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "CachedDiscovery", params, verifier.timeout)
+	return &MockClusterMeta_CachedDiscovery_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockClusterMeta_CachedDiscovery_OngoingVerification struct {
+	mock              *MockClusterMeta
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockClusterMeta_CachedDiscovery_OngoingVerification) GetCapturedArguments() {
+}
+
+func (c *MockClusterMeta_CachedDiscovery_OngoingVerification) GetAllCapturedArguments() {
+}
+
 func (verifier *VerifierMockClusterMeta) CanIAccess(_param0 string, _param1 string, _param2 []string) *MockClusterMeta_CanIAccess_OngoingVerification {
 	params := []pegomock.Param{_param0, _param1, _param2}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "CanIAccess", params, verifier.timeout)
@@ -484,15 +521,15 @@ func (c *MockClusterMeta_CanIAccess_OngoingVerification) GetCapturedArguments() 
 func (c *MockClusterMeta_CanIAccess_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 [][]string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
-		_param1 = make([]string, len(params[1]))
+		_param1 = make([]string, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.(string)
 		}
-		_param2 = make([][]string, len(params[2]))
+		_param2 = make([][]string, len(c.methodInvocations))
 		for u, param := range params[2] {
 			_param2[u] = param.([]string)
 		}
@@ -536,7 +573,7 @@ func (c *MockClusterMeta_CheckNSAccess_OngoingVerification) GetCapturedArguments
 func (c *MockClusterMeta_CheckNSAccess_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
@@ -716,7 +753,7 @@ func (c *MockClusterMeta_IsNamespaced_OngoingVerification) GetCapturedArguments(
 func (c *MockClusterMeta_IsNamespaced_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
@@ -777,7 +814,7 @@ func (c *MockClusterMeta_NodePods_OngoingVerification) GetCapturedArguments() st
 func (c *MockClusterMeta_NodePods_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
@@ -838,11 +875,11 @@ func (c *MockClusterMeta_SupportsRes_OngoingVerification) GetCapturedArguments()
 func (c *MockClusterMeta_SupportsRes_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 [][]string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
-		_param1 = make([][]string, len(params[1]))
+		_param1 = make([][]string, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.([]string)
 		}
@@ -869,7 +906,7 @@ func (c *MockClusterMeta_SupportsResource_OngoingVerification) GetCapturedArgume
 func (c *MockClusterMeta_SupportsResource_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
@@ -896,7 +933,7 @@ func (c *MockClusterMeta_SwitchContextOrDie_OngoingVerification) GetCapturedArgu
 func (c *MockClusterMeta_SwitchContextOrDie_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}

--- a/internal/resource/mock_connection_test.go
+++ b/internal/resource/mock_connection_test.go
@@ -8,6 +8,7 @@ import (
 	pegomock "github.com/petergtz/pegomock"
 	v1 "k8s.io/api/core/v1"
 	version "k8s.io/apimachinery/pkg/version"
+	disk "k8s.io/client-go/discovery/cached/disk"
 	dynamic "k8s.io/client-go/dynamic"
 	kubernetes "k8s.io/client-go/kubernetes"
 	rest "k8s.io/client-go/rest"
@@ -30,6 +31,25 @@ func NewMockConnection(options ...pegomock.Option) *MockConnection {
 
 func (mock *MockConnection) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockConnection) FailHandler() pegomock.FailHandler      { return mock.fail }
+
+func (mock *MockConnection) CachedDiscovery() (*disk.CachedDiscoveryClient, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockConnection().")
+	}
+	params := []pegomock.Param{}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CachedDiscovery", params, []reflect.Type{reflect.TypeOf((**disk.CachedDiscoveryClient)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 *disk.CachedDiscoveryClient
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(*disk.CachedDiscoveryClient)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
 
 func (mock *MockConnection) CanIAccess(_param0 string, _param1 string, _param2 []string) (bool, error) {
 	if mock == nil {
@@ -382,6 +402,23 @@ type VerifierMockConnection struct {
 	timeout                time.Duration
 }
 
+func (verifier *VerifierMockConnection) CachedDiscovery() *MockConnection_CachedDiscovery_OngoingVerification {
+	params := []pegomock.Param{}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "CachedDiscovery", params, verifier.timeout)
+	return &MockConnection_CachedDiscovery_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockConnection_CachedDiscovery_OngoingVerification struct {
+	mock              *MockConnection
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockConnection_CachedDiscovery_OngoingVerification) GetCapturedArguments() {
+}
+
+func (c *MockConnection_CachedDiscovery_OngoingVerification) GetAllCapturedArguments() {
+}
+
 func (verifier *VerifierMockConnection) CanIAccess(_param0 string, _param1 string, _param2 []string) *MockConnection_CanIAccess_OngoingVerification {
 	params := []pegomock.Param{_param0, _param1, _param2}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "CanIAccess", params, verifier.timeout)
@@ -401,15 +438,15 @@ func (c *MockConnection_CanIAccess_OngoingVerification) GetCapturedArguments() (
 func (c *MockConnection_CanIAccess_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 [][]string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
-		_param1 = make([]string, len(params[1]))
+		_param1 = make([]string, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.(string)
 		}
-		_param2 = make([][]string, len(params[2]))
+		_param2 = make([][]string, len(c.methodInvocations))
 		for u, param := range params[2] {
 			_param2[u] = param.([]string)
 		}
@@ -453,7 +490,7 @@ func (c *MockConnection_CheckNSAccess_OngoingVerification) GetCapturedArguments(
 func (c *MockConnection_CheckNSAccess_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
@@ -582,7 +619,7 @@ func (c *MockConnection_IsNamespaced_OngoingVerification) GetCapturedArguments()
 func (c *MockConnection_IsNamespaced_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
@@ -643,7 +680,7 @@ func (c *MockConnection_NodePods_OngoingVerification) GetCapturedArguments() str
 func (c *MockConnection_NodePods_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
@@ -704,11 +741,11 @@ func (c *MockConnection_SupportsRes_OngoingVerification) GetCapturedArguments() 
 func (c *MockConnection_SupportsRes_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 [][]string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
-		_param1 = make([][]string, len(params[1]))
+		_param1 = make([][]string, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.([]string)
 		}
@@ -735,7 +772,7 @@ func (c *MockConnection_SupportsResource_OngoingVerification) GetCapturedArgumen
 func (c *MockConnection_SupportsResource_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
@@ -762,7 +799,7 @@ func (c *MockConnection_SwitchContextOrDie_OngoingVerification) GetCapturedArgum
 func (c *MockConnection_SwitchContextOrDie_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}

--- a/internal/watch/mock_connection_test.go
+++ b/internal/watch/mock_connection_test.go
@@ -4,30 +4,52 @@
 package watch
 
 import (
+	"github.com/derailed/k9s/internal/k8s"
+	"github.com/petergtz/pegomock"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery/cached/disk"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/metrics/pkg/client/clientset/versioned"
 	"reflect"
 	"time"
-
-	k8s "github.com/derailed/k9s/internal/k8s"
-	pegomock "github.com/petergtz/pegomock"
-	v1 "k8s.io/api/core/v1"
-	version "k8s.io/apimachinery/pkg/version"
-	dynamic "k8s.io/client-go/dynamic"
-	kubernetes "k8s.io/client-go/kubernetes"
-	rest "k8s.io/client-go/rest"
-	versioned "k8s.io/metrics/pkg/client/clientset/versioned"
 )
 
 type MockConnection struct {
 	fail func(message string, callerSkip ...int)
 }
 
-func NewMockConnection() *MockConnection {
+func NewMockConnection(options ...pegomock.Option) *MockConnection {
 	mock := &MockConnection{}
+	for _, option := range options {
+		option.Apply(mock)
+	}
 	return mock
 }
 
 func (mock *MockConnection) SetFailHandler(fh pegomock.FailHandler) { mock.fail = fh }
 func (mock *MockConnection) FailHandler() pegomock.FailHandler      { return mock.fail }
+
+func (mock *MockConnection) CachedDiscovery() (*disk.CachedDiscoveryClient, error) {
+	if mock == nil {
+		panic("mock must not be nil. Use myMock := NewMockConnection().")
+	}
+	params := []pegomock.Param{}
+	result := pegomock.GetGenericMockFrom(mock).Invoke("CachedDiscovery", params, []reflect.Type{reflect.TypeOf((**disk.CachedDiscoveryClient)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	var ret0 *disk.CachedDiscoveryClient
+	var ret1 error
+	if len(result) != 0 {
+		if result[0] != nil {
+			ret0 = result[0].(*disk.CachedDiscoveryClient)
+		}
+		if result[1] != nil {
+			ret1 = result[1].(error)
+		}
+	}
+	return ret0, ret1
+}
 
 func (mock *MockConnection) CanIAccess(_param0 string, _param1 string, _param2 []string) (bool, error) {
 	if mock == nil {
@@ -378,6 +400,23 @@ type VerifierMockConnection struct {
 	invocationCountMatcher pegomock.Matcher
 	inOrderContext         *pegomock.InOrderContext
 	timeout                time.Duration
+}
+
+func (verifier *VerifierMockConnection) CachedDiscovery() *MockConnection_CachedDiscovery_OngoingVerification {
+	params := []pegomock.Param{}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "CachedDiscovery", params, verifier.timeout)
+	return &MockConnection_CachedDiscovery_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+}
+
+type MockConnection_CachedDiscovery_OngoingVerification struct {
+	mock              *MockConnection
+	methodInvocations []pegomock.MethodInvocation
+}
+
+func (c *MockConnection_CachedDiscovery_OngoingVerification) GetCapturedArguments() {
+}
+
+func (c *MockConnection_CachedDiscovery_OngoingVerification) GetAllCapturedArguments() {
 }
 
 func (verifier *VerifierMockConnection) CanIAccess(_param0 string, _param1 string, _param2 []string) *MockConnection_CanIAccess_OngoingVerification {


### PR DESCRIPTION
This is some of the obvious part we could add cache, initially discussed on #323 

Things that are being cached:
- Kubernetes server version (this rarely changes);
- If a resource is namespaced or not (this shouldn't change);
- If a Kubernetes server support a groupversion (this rarely change);
- Which group version a resource is supported by (this rarely change);

I've followed what we already use for caching the RestMapper, which caches the discovery client for 10 minutes.

It is not a huge performance boost but should improve the UX when user a changing commands, loading k9s and the biggest improvement here is the CRD (Ctrl+a) view.