### PR TITLE
Add FILTER argument to plugin commands

### DIFF
--- a/internal/views/app.go
+++ b/internal/views/app.go
@@ -427,3 +427,7 @@ func (a *appView) clusterInfo() *clusterInfoView {
 func (a *appView) indicator() *ui.IndicatorView {
 	return a.Views()["indicator"].(*ui.IndicatorView)
 }
+
+func (a *appView) activeFilter() string {
+	return a.filter
+}

--- a/internal/views/resource.go
+++ b/internal/views/resource.go
@@ -472,6 +472,7 @@ func (v *resourceView) defaultK9sEnv() K9sEnv {
 	if kcfg != nil && *kcfg != "" {
 		cfg = *kcfg
 	}
+	f := v.app.activeFilter()
 
 	env := K9sEnv{
 		"NAMESPACE":  ns,
@@ -481,6 +482,7 @@ func (v *resourceView) defaultK9sEnv() K9sEnv {
 		"USER":       user,
 		"GROUPS":     strings.Join(groups, ","),
 		"KUBECONFIG": cfg,
+		"FILTER":     f,
 	}
 
 	row := v.masterPage().GetRow()


### PR DESCRIPTION
I wanted a way to monitor multiple logs, so I added a plugin that call Stern to show the logs:
```
plugin:
  stern:
    shortCut: Ctrl-L
    description: "Logs (Stern)"
    scopes:
    - po
    command: /usr/bin/stern
    background: false
    args:
    - --tail
    - 50
    - $FILTER
    - -n
    - $NAMESPACE
    - --context
    - $CONTEXT
```

But this requires that we can get the currently active filter from k9s so we can show the logs that match that filter. This PR adds $FILTER parameter to plugin args.