### PR TITLE
feat: Add action to restart rollout of dp, ds, sts

### DIFF
--- a/internal/resource/base.go
+++ b/internal/resource/base.go
@@ -35,6 +35,11 @@ type (
 		Scale(ns string, name string, replicas int32) error
 	}
 
+	// Restartable represents a rollout restartable Kubernetes resource.
+	Restartable interface {
+		Restart(ns string, name string) error
+	}
+
 	// Connection represents a Kubenetes apiserver connection.
 	Connection k8s.Connection
 

--- a/internal/resource/dp.go
+++ b/internal/resource/dp.go
@@ -10,6 +10,10 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
+// Compile time checks to ensure type satisfies interface
+var _ Restartable = (*Deployment)(nil)
+var _ Scalable = (*Deployment)(nil)
+
 // Deployment tracks a kubernetes resource.
 type Deployment struct {
 	*Base
@@ -128,4 +132,9 @@ func (r *Deployment) Fields(ns string) Row {
 // Scale the specified resource.
 func (r *Deployment) Scale(ns, n string, replicas int32) error {
 	return r.Resource.(Scalable).Scale(ns, n, replicas)
+}
+
+// Restart the rollout of the specified resource.
+func (r *Deployment) Restart(ns, n string) error {
+	return r.Resource.(Restartable).Restart(ns, n)
 }

--- a/internal/resource/ds.go
+++ b/internal/resource/ds.go
@@ -10,6 +10,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
+// Compile time checks to ensure type satisfies interface
+var _ Restartable = (*DaemonSet)(nil)
+
 // DaemonSet tracks a kubernetes resource.
 type DaemonSet struct {
 	*Base
@@ -111,4 +114,9 @@ func (r *DaemonSet) Fields(ns string) Row {
 		mapToStr(i.Spec.Template.Spec.NodeSelector),
 		toAge(i.ObjectMeta.CreationTimestamp),
 	)
+}
+
+// Restart the rollout of the specified resource.
+func (r *DaemonSet) Restart(ns, n string) error {
+	return r.Resource.(Restartable).Restart(ns, n)
 }

--- a/internal/resource/sts.go
+++ b/internal/resource/sts.go
@@ -10,6 +10,10 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
+// Compile time checks to ensure type satisfies interface
+var _ Restartable = (*StatefulSet)(nil)
+var _ Scalable = (*StatefulSet)(nil)
+
 // StatefulSet tracks a kubernetes resource.
 type StatefulSet struct {
 	*Base
@@ -117,4 +121,9 @@ func (r *StatefulSet) Fields(ns string) Row {
 // Scale the specified resource.
 func (r *StatefulSet) Scale(ns, n string, replicas int32) error {
 	return r.Resource.(Scalable).Scale(ns, n, replicas)
+}
+
+// Restart the rollout of the specified resource.
+func (r *StatefulSet) Restart(ns, n string) error {
+	return r.Resource.(Restartable).Restart(ns, n)
 }

--- a/internal/views/dp.go
+++ b/internal/views/dp.go
@@ -10,14 +10,19 @@ import (
 
 type deployView struct {
 	*logResourceView
-	scalableResourceView *scalableResourceView
+	scalableResourceView    *scalableResourceView
+	restartableResourceView *restartableResourceView
 }
 
 const scaleDialogKey = "scale"
 
 func newDeployView(title, gvr string, app *appView, list resource.List) resourceViewer {
 	logResourceView := newLogResourceView(title, gvr, app, list)
-	v := deployView{logResourceView, newScalableResourceViewForParent(logResourceView.resourceView)}
+	v := deployView{
+		logResourceView:         logResourceView,
+		scalableResourceView:    newScalableResourceViewForParent(logResourceView.resourceView),
+		restartableResourceView: newRestartableResourceViewForParent(logResourceView.resourceView),
+	}
 	v.extraActionsFn = v.extraActions
 	v.enterFn = v.showPods
 
@@ -27,6 +32,7 @@ func newDeployView(title, gvr string, app *appView, list resource.List) resource
 func (v *deployView) extraActions(aa ui.KeyActions) {
 	v.logResourceView.extraActions(aa)
 	v.scalableResourceView.extraActions(aa)
+	v.restartableResourceView.extraActions(aa)
 	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", v.sortColCmd(2, false), false)
 	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", v.sortColCmd(3, false), false)
 }

--- a/internal/views/ds.go
+++ b/internal/views/ds.go
@@ -10,10 +10,15 @@ import (
 
 type daemonSetView struct {
 	*logResourceView
+	restartableResourceView *restartableResourceView
 }
 
 func newDaemonSetView(title, gvr string, app *appView, list resource.List) resourceViewer {
-	v := daemonSetView{newLogResourceView(title, gvr, app, list)}
+	view := newLogResourceView(title, gvr, app, list)
+	v := daemonSetView{
+		logResourceView:         view,
+		restartableResourceView: newRestartableResourceViewForParent(view.resourceView),
+	}
 	v.extraActionsFn = v.extraActions
 	v.enterFn = v.showPods
 
@@ -22,6 +27,7 @@ func newDaemonSetView(title, gvr string, app *appView, list resource.List) resou
 
 func (v *daemonSetView) extraActions(aa ui.KeyActions) {
 	v.logResourceView.extraActions(aa)
+	v.restartableResourceView.extraActions(aa)
 	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", v.sortColCmd(2, false), false)
 	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", v.sortColCmd(3, false), false)
 }

--- a/internal/views/restartable_resource.go
+++ b/internal/views/restartable_resource.go
@@ -23,7 +23,7 @@ func newRestartableResourceViewForParent(parent *resourceView) *restartableResou
 }
 
 func (v *restartableResourceView) extraActions(aa ui.KeyActions) {
-	aa[tcell.KeyCtrlR] = ui.NewKeyAction("Restart Rollout", v.restartCmd, true)
+	aa[tcell.KeyCtrlT] = ui.NewKeyAction("Restart Rollout", v.restartCmd, true)
 }
 
 func (v *restartableResourceView) restartCmd(evt *tcell.EventKey) *tcell.EventKey {

--- a/internal/views/restartable_resource.go
+++ b/internal/views/restartable_resource.go
@@ -1,0 +1,52 @@
+package views
+
+import (
+	"errors"
+
+	"github.com/derailed/k9s/internal/resource"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/gdamore/tcell"
+)
+
+type (
+	restartableResourceView struct {
+		*resourceView
+	}
+)
+
+func newRestartableResourceViewForParent(parent *resourceView) *restartableResourceView {
+	v := restartableResourceView{
+		parent,
+	}
+	parent.extraActionsFn = v.extraActions
+	return &v
+}
+
+func (v *restartableResourceView) extraActions(aa ui.KeyActions) {
+	aa[tcell.KeyCtrlR] = ui.NewKeyAction("Restart Rollout", v.restartCmd, true)
+}
+
+func (v *restartableResourceView) restartCmd(evt *tcell.EventKey) *tcell.EventKey {
+	if !v.masterPage().RowSelected() {
+		return evt
+	}
+
+	v.restartRollout(v.masterPage().GetSelectedItem())
+	return nil
+}
+
+func (v *restartableResourceView) restartRollout(selection string) {
+	ns, n := namespaced(selection)
+
+	r, ok := v.list.Resource().(resource.Restartable)
+	if !ok {
+		v.app.Flash().Err(errors.New("resource is not of type resource.Restartable"))
+		return
+	}
+
+	err := r.Restart(ns, n)
+	if err != nil {
+		v.app.Flash().Err(err)
+	}
+	v.app.Flash().Info("Restarted Rollout")
+}

--- a/internal/views/sts.go
+++ b/internal/views/sts.go
@@ -11,12 +11,13 @@ import (
 
 type statefulSetView struct {
 	*logResourceView
-	scalableResourceView *scalableResourceView
+	scalableResourceView    *scalableResourceView
+	restartableResourceView *restartableResourceView
 }
 
 func newStatefulSetView(title, gvr string, app *appView, list resource.List) resourceViewer {
 	logResourceView := newLogResourceView(title, gvr, app, list)
-	v := statefulSetView{logResourceView, newScalableResourceViewForParent(logResourceView.resourceView)}
+	v := statefulSetView{logResourceView: logResourceView, scalableResourceView: newScalableResourceViewForParent(logResourceView.resourceView), restartableResourceView: newRestartableResourceViewForParent(logResourceView.resourceView)}
 	v.extraActionsFn = v.extraActions
 	v.enterFn = v.showPods
 
@@ -26,6 +27,7 @@ func newStatefulSetView(title, gvr string, app *appView, list resource.List) res
 func (v *statefulSetView) extraActions(aa ui.KeyActions) {
 	v.logResourceView.extraActions(aa)
 	v.scalableResourceView.extraActions(aa)
+	v.restartableResourceView.extraActions(aa)
 	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", v.sortColCmd(1, false), false)
 	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", v.sortColCmd(2, false), false)
 }

--- a/internal/views/sts.go
+++ b/internal/views/sts.go
@@ -17,7 +17,11 @@ type statefulSetView struct {
 
 func newStatefulSetView(title, gvr string, app *appView, list resource.List) resourceViewer {
 	logResourceView := newLogResourceView(title, gvr, app, list)
-	v := statefulSetView{logResourceView: logResourceView, scalableResourceView: newScalableResourceViewForParent(logResourceView.resourceView), restartableResourceView: newRestartableResourceViewForParent(logResourceView.resourceView)}
+	v := statefulSetView{
+		logResourceView:         logResourceView,
+		scalableResourceView:    newScalableResourceViewForParent(logResourceView.resourceView),
+		restartableResourceView: newRestartableResourceViewForParent(logResourceView.resourceView),
+	}
 	v.extraActionsFn = v.extraActions
 	v.enterFn = v.showPods
 


### PR DESCRIPTION
Newer versions of kubectl support the `rollout restart` subcommand, this implements it for the same types!

`Ctrl-T` should appear as `Restart Rollout` on `Deployment`, `DaemonSet`, and `StatefulSet` types


fixes: #337 