### PR TITLE
Make data dump dir configurable

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -26,7 +26,6 @@ func printInfo() {
 	printLogo(color.Cyan)
 	printTuple(sectionFmt, "Configuration", config.K9sConfigFile)
 	printTuple(sectionFmt, "Logs", config.K9sLogs)
-	printTuple(sectionFmt, "Screen Dumps", config.K9sDumpDir)
 }
 
 func printLogo(c color.Paint) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,8 +25,6 @@ var (
 	K9sConfigFile = filepath.Join(K9sHome, "config.yml")
 	// K9sLogs represents K9s log.
 	K9sLogs = filepath.Join(os.TempDir(), fmt.Sprintf("k9s-%s.log", MustK9sUser()))
-	// K9sDumpDir represents a directory where K9s screen dumps will be persisted.
-	K9sDumpDir = filepath.Join(os.TempDir(), fmt.Sprintf("k9s-screens-%s", MustK9sUser()))
 )
 
 type (

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -100,6 +100,7 @@ func TestConfigLoad(t *testing.T) {
 	assert.Equal(t, "minikube", cfg.K9s.CurrentCluster)
 	assert.NotNil(t, cfg.K9s.Clusters)
 	assert.Equal(t, 2, len(cfg.K9s.Clusters))
+	assert.Equal(t, "/test", cfg.K9s.DumpDir)
 
 	nn := []string{
 		"default",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -209,6 +209,7 @@ func TestConfigSaveFile(t *testing.T) {
 	cfg.K9s.LogRequestSize = 100
 	cfg.K9s.CurrentContext = "blee"
 	cfg.K9s.CurrentCluster = "blee"
+	cfg.K9s.DumpDir = "/test"
 	cfg.Validate()
 	path := filepath.Join("/tmp", "k9s.yml")
 	err := cfg.SaveFile(path)
@@ -262,6 +263,7 @@ var expectedConfig = `k9s:
   headless: false
   logBufferSize: 500
   logRequestSize: 100
+  dumpDir: /test
   currentContext: blee
   currentCluster: blee
   clusters:
@@ -301,6 +303,7 @@ var resetConfig = `k9s:
   headless: false
   logBufferSize: 200
   logRequestSize: 200
+  dumpDir: /test
   currentContext: blee
   currentCluster: blee
   clusters:

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -20,10 +20,10 @@ type K9s struct {
 	Headless          bool                `yaml:"headless"`
 	LogBufferSize     int                 `yaml:"logBufferSize"`
 	LogRequestSize    int                 `yaml:"logRequestSize"`
+	DumpDir           string              `yaml:"dumpDir"`
 	CurrentContext    string              `yaml:"currentContext"`
 	CurrentCluster    string              `yaml:"currentCluster"`
 	Clusters          map[string]*Cluster `yaml:"clusters,omitempty"`
-	DumpDir           string              `yaml:"dumpDir"`
 	manualRefreshRate int
 	manualHeadless    *bool
 	manualCommand     *string
@@ -35,8 +35,8 @@ func NewK9s() *K9s {
 		RefreshRate:    defaultRefreshRate,
 		LogBufferSize:  defaultLogBufferSize,
 		LogRequestSize: defaultLogRequestSize,
-		Clusters:       make(map[string]*Cluster),
 		DumpDir:        os.TempDir(),
+		Clusters:       make(map[string]*Cluster),
 	}
 }
 

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -1,6 +1,10 @@
 package config
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/derailed/k9s/internal/k8s"
 )
 
@@ -19,6 +23,7 @@ type K9s struct {
 	CurrentContext    string              `yaml:"currentContext"`
 	CurrentCluster    string              `yaml:"currentCluster"`
 	Clusters          map[string]*Cluster `yaml:"clusters,omitempty"`
+	DumpDir           string              `yaml:"dumpDir"`
 	manualRefreshRate int
 	manualHeadless    *bool
 	manualCommand     *string
@@ -31,6 +36,7 @@ func NewK9s() *K9s {
 		LogBufferSize:  defaultLogBufferSize,
 		LogRequestSize: defaultLogRequestSize,
 		Clusters:       make(map[string]*Cluster),
+		DumpDir:        os.TempDir(),
 	}
 }
 
@@ -81,6 +87,11 @@ func (k *K9s) ActiveCluster() *Cluster {
 	k.Clusters[k.CurrentCluster] = NewCluster()
 
 	return k.Clusters[k.CurrentCluster]
+}
+
+// GetDumpDir returns the directory where screen dumps are persisted.
+func (k *K9s) GetDumpDir() string {
+	return filepath.Join(k.DumpDir, fmt.Sprintf("k9s-screens-%s", MustK9sUser()))
 }
 
 func (k *K9s) validateDefaults() {

--- a/internal/config/k9s_test.go
+++ b/internal/config/k9s_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/derailed/k9s/internal/config"
@@ -27,6 +28,7 @@ func TestK9sValidate(t *testing.T) {
 	assert.Equal(t, "ctx1", c.CurrentContext)
 	assert.Equal(t, "c1", c.CurrentCluster)
 	assert.Equal(t, 1, len(c.Clusters))
+	assert.Equal(t, os.TempDir(), c.DumpDir)
 	_, ok := c.Clusters[c.CurrentCluster]
 	assert.True(t, ok)
 }

--- a/internal/config/test_assets/k9s.yml
+++ b/internal/config/test_assets/k9s.yml
@@ -4,6 +4,7 @@ k9s:
   logRequestSize: 200
   currentContext: minikube
   currentCluster: minikube
+  dumpDir: /test
   clusters:
     minikube:
       namespace:

--- a/internal/config/test_assets/k9s.yml
+++ b/internal/config/test_assets/k9s.yml
@@ -2,9 +2,9 @@ k9s:
   refreshRate: 2
   logBufferSize: 200
   logRequestSize: 200
+  dumpDir: /test
   currentContext: minikube
   currentCluster: minikube
-  dumpDir: /test
   clusters:
     minikube:
       namespace:

--- a/internal/views/details.go
+++ b/internal/views/details.go
@@ -2,6 +2,7 @@ package views
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -103,7 +104,8 @@ func (v *detailsView) keyboard(evt *tcell.EventKey) *tcell.EventKey {
 }
 
 func (v *detailsView) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
-	if path, err := saveYAML(v.app.Config.K9s.CurrentCluster, v.title, v.GetText(true)); err != nil {
+	dir := filepath.Join(v.app.Config.K9s.GetDumpDir(), v.app.Config.K9s.CurrentCluster)
+	if path, err := saveYAML(dir, v.title, v.GetText(true)); err != nil {
 		v.app.Flash().Err(err)
 	} else {
 		v.app.Flash().Infof("Log %s saved successfully!", path)

--- a/internal/views/dump.go
+++ b/internal/views/dump.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/resource"
 	"github.com/derailed/k9s/internal/ui"
 	"github.com/derailed/tview"
@@ -120,7 +119,7 @@ func (v *dumpView) enterCmd(evt *tcell.EventKey) *tcell.EventKey {
 		return nil
 	}
 
-	dir := filepath.Join(config.K9sDumpDir, v.app.Config.K9s.CurrentCluster)
+	dir := filepath.Join(v.app.Config.K9s.GetDumpDir(), v.app.Config.K9s.CurrentCluster)
 	if !edit(true, v.app, filepath.Join(dir, sel)) {
 		v.app.Flash().Err(errors.New("Failed to launch editor"))
 	}
@@ -134,7 +133,7 @@ func (v *dumpView) deleteCmd(evt *tcell.EventKey) *tcell.EventKey {
 		return nil
 	}
 
-	dir := filepath.Join(config.K9sDumpDir, v.app.Config.K9s.CurrentCluster)
+	dir := filepath.Join(v.app.Config.K9s.GetDumpDir(), v.app.Config.K9s.CurrentCluster)
 	showModal(v.Pages, fmt.Sprintf("Delete screen dump `%s?", sel), "table", func() {
 		if err := os.Remove(filepath.Join(dir, sel)); err != nil {
 			v.app.Flash().Errf("Unable to delete file %s", err)
@@ -166,7 +165,7 @@ func (v *dumpView) hydrate() resource.TableData {
 		Namespace: resource.NotNamespaced,
 	}
 
-	dir := filepath.Join(config.K9sDumpDir, v.app.Config.K9s.CurrentCluster)
+	dir := filepath.Join(v.app.Config.K9s.GetDumpDir(), v.app.Config.K9s.CurrentCluster)
 	ff, err := ioutil.ReadDir(dir)
 	if err != nil {
 		v.app.Flash().Errf("Unable to read dump directory %s", err)
@@ -213,7 +212,7 @@ func (v *dumpView) watchDumpDir(ctx context.Context) error {
 		}
 	}()
 
-	return w.Add(filepath.Join(config.K9sDumpDir, v.app.Config.K9s.CurrentCluster))
+	return w.Add(filepath.Join(v.app.Config.K9s.GetDumpDir(), v.app.Config.K9s.CurrentCluster))
 }
 
 func (v *dumpView) getTV() *tableView {

--- a/internal/views/log.go
+++ b/internal/views/log.go
@@ -151,7 +151,8 @@ func (v *logView) updateIndicator() {
 // Actions...
 
 func (v *logView) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
-	if path, err := saveData(v.app.Config.K9s.CurrentCluster, v.path, v.logs.GetText(true)); err != nil {
+	dir := filepath.Join(v.app.Config.K9s.GetDumpDir(), v.app.Config.K9s.CurrentCluster)
+	if path, err := saveData(dir, v.path, v.logs.GetText(true)); err != nil {
 		v.app.Flash().Err(err)
 	} else {
 		v.app.Flash().Infof("Log %s saved successfully!", path)
@@ -163,8 +164,7 @@ func ensureDir(dir string) error {
 	return os.MkdirAll(dir, 0744)
 }
 
-func saveData(cluster, name, data string) (string, error) {
-	dir := filepath.Join(config.K9sDumpDir, cluster)
+func saveData(dir, name, data string) (string, error) {
 	if err := ensureDir(dir); err != nil {
 		return "", err
 	}

--- a/internal/views/log_test.go
+++ b/internal/views/log_test.go
@@ -41,7 +41,7 @@ func TestLogViewSave(t *testing.T) {
 	v := newLogView("Logs", NewApp(config.NewConfig(ks{})), nil)
 	v.flush(2, []string{"blee", "bozo"})
 	v.path = "k9s-test"
-	dir := filepath.Join(config.K9sDumpDir, v.app.Config.K9s.CurrentCluster)
+	dir := filepath.Join(v.app.Config.K9s.GetDumpDir(), v.app.Config.K9s.CurrentCluster)
 	c1, _ := ioutil.ReadDir(dir)
 	v.saveCmd(nil)
 	c2, _ := ioutil.ReadDir(dir)

--- a/internal/views/table.go
+++ b/internal/views/table.go
@@ -1,6 +1,8 @@
 package views
 
 import (
+	"path/filepath"
+
 	"github.com/derailed/k9s/internal/ui"
 	"github.com/gdamore/tcell"
 )
@@ -34,7 +36,8 @@ func (v *tableView) BufferActive(state bool, k ui.BufferKind) {
 }
 
 func (v *tableView) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
-	if path, err := saveTable(v.app.Config.K9s.CurrentCluster, v.GetBaseTitle(), v.GetData()); err != nil {
+	dir := filepath.Join(v.app.Config.K9s.GetDumpDir(), v.app.Config.K9s.CurrentCluster)
+	if path, err := saveTable(dir, v.GetBaseTitle(), v.GetData()); err != nil {
 		v.app.Flash().Err(err)
 	} else {
 		v.app.Flash().Infof("File %s saved successfully!", path)

--- a/internal/views/table_helper.go
+++ b/internal/views/table_helper.go
@@ -46,8 +46,7 @@ func trimCellRelative(tv *tableView, row, col int) string {
 // 	return strings.TrimSpace(c.Text)
 // }
 
-func saveTable(cluster, name string, data resource.TableData) (string, error) {
-	dir := filepath.Join(config.K9sDumpDir, cluster)
+func saveTable(dir, name string, data resource.TableData) (string, error) {
 	if err := ensureDir(dir); err != nil {
 		return "", err
 	}

--- a/internal/views/table_test.go
+++ b/internal/views/table_test.go
@@ -16,7 +16,7 @@ import (
 func TestTableViewSave(t *testing.T) {
 	v := newTableView(NewApp(config.NewConfig(ks{})), "test")
 	v.SetTitle("k9s-test")
-	dir := filepath.Join(config.K9sDumpDir, v.app.Config.K9s.CurrentCluster)
+	dir := filepath.Join(v.app.Config.K9s.GetDumpDir(), v.app.Config.K9s.CurrentCluster)
 	c1, _ := ioutil.ReadDir(dir)
 	v.saveCmd(nil)
 	c2, _ := ioutil.ReadDir(dir)

--- a/internal/views/yaml.go
+++ b/internal/views/yaml.go
@@ -57,8 +57,7 @@ func colorizeYAML(style config.Yaml, raw string) string {
 	return strings.Join(buff, "\n")
 }
 
-func saveYAML(cluster, name, data string) (string, error) {
-	dir := filepath.Join(config.K9sDumpDir, cluster)
+func saveYAML(dir, name, data string) (string, error) {
 	if err := ensureDir(dir); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Allow changing the screen dump directory in the k9s configuration file. Implements #343 