### PR TITLE
WIP: don't lock screen update while fetching data.

### DIFF
--- a/internal/resource/cr_binding_test.go
+++ b/internal/resource/cr_binding_test.go
@@ -50,8 +50,9 @@ func TestCRBListData(t *testing.T) {
 	l := NewClusterRoleBindingListWithArgs("-", NewClusterRoleBindingWithArgs(conn, ca))
 	// Make sure we can get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	ca.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)

--- a/internal/resource/cr_test.go
+++ b/internal/resource/cr_test.go
@@ -70,8 +70,9 @@ func TestCRListData(t *testing.T) {
 	l := NewClusterRoleListWithArgs("-", NewClusterRoleWithArgs(mc, mr))
 	// Make sure we mcn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)

--- a/internal/resource/crd_test.go
+++ b/internal/resource/crd_test.go
@@ -70,8 +70,9 @@ func TestCRDListData(t *testing.T) {
 	l := NewCRDListWithArgs("-", NewCRDWithArgs(mc, cr))
 	// Make sure we can get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	cr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)

--- a/internal/resource/cronjob_test.go
+++ b/internal/resource/cronjob_test.go
@@ -62,8 +62,9 @@ func TestCronJobListData(t *testing.T) {
 	l := NewCronJobListWithArgs("-", NewCronJobWithArgs(mc, mr))
 	// Make sure we can get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)

--- a/internal/resource/custom_test.go
+++ b/internal/resource/custom_test.go
@@ -63,8 +63,9 @@ func TestCustomListData(t *testing.T) {
 	l := NewCustomListWithArgs("blee", "fred", NewCustomWithArgs(mc, mr))
 	// Make sure we can get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/dp_test.go
+++ b/internal/resource/dp_test.go
@@ -62,8 +62,9 @@ func TestDeploymentListData(t *testing.T) {
 	l := NewDeploymentListWithArgs("-", NewDeploymentWithArgs(mc, mr))
 	// Make sure we can get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)

--- a/internal/resource/ds_test.go
+++ b/internal/resource/ds_test.go
@@ -61,8 +61,9 @@ func TestDSListData(t *testing.T) {
 	l := NewDaemonSetListWithArgs("blee", NewDaemonSetWithArgs(mc, mr))
 	// Make sure we can get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/ep_test.go
+++ b/internal/resource/ep_test.go
@@ -59,8 +59,9 @@ func TestEndpointsListData(t *testing.T) {
 	l := NewEndpointsListWithArgs("-", NewEndpointsWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)

--- a/internal/resource/evt_test.go
+++ b/internal/resource/evt_test.go
@@ -61,8 +61,9 @@ func TestEventData(t *testing.T) {
 	l := NewEventListWithArgs("blee", NewEventWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/helpers.go
+++ b/internal/resource/helpers.go
@@ -25,7 +25,7 @@ const (
 	NotNamespaced = "-"
 
 	// New track new resource events.
-	New watch.EventType = "NEW"
+	New watch.EventType = watch.Added
 	// Unchanged provides no change events.
 	Unchanged watch.EventType = "UNCHANGED"
 

--- a/internal/resource/hpa_v1_test.go
+++ b/internal/resource/hpa_v1_test.go
@@ -63,8 +63,9 @@ func TestHPAListData(t *testing.T) {
 	l := NewHPAListWithArgs("blee", NewHPAWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/ing_test.go
+++ b/internal/resource/ing_test.go
@@ -61,8 +61,9 @@ func TestIngressListData(t *testing.T) {
 	l := NewIngressListWithArgs("blee", NewIngressWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/job_test.go
+++ b/internal/resource/job_test.go
@@ -61,8 +61,9 @@ func TestJobListData(t *testing.T) {
 	l := NewJobListWithArgs("blee", NewJobWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/list.go
+++ b/internal/resource/list.go
@@ -2,13 +2,12 @@ package resource
 
 import (
 	"fmt"
-	"reflect"
-
 	wa "github.com/derailed/k9s/internal/watch"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	mv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	"reflect"
 )
 
 const (
@@ -317,9 +316,9 @@ func (l *list) Update(items Columnars) {
 			continue
 		}
 
-		a := computeDeltas(evt, ff[:len(ff)-1], dd)
-		if a != Unchanged || evt.Action == watch.Added {
-			l.cache[i.Name()] = newRowEvent(a, ff, dd)
+		delta := computeDeltas(evt, ff[:len(ff)-1], dd)
+		if evt.Action != delta {
+			l.cache[i.Name()] = newRowEvent(delta, ff, dd)
 		}
 	}
 

--- a/internal/resource/no_test.go
+++ b/internal/resource/no_test.go
@@ -71,8 +71,9 @@ func TestNodeListData(t *testing.T) {
 	l := NewNodeListWithArgs("-", NewNodeWithArgs(mc, mr, mx))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("-")

--- a/internal/resource/ns_test.go
+++ b/internal/resource/ns_test.go
@@ -62,8 +62,9 @@ func TestNamespaceListData(t *testing.T) {
 	l := NewNamespaceListWithArgs("-", NewNamespaceWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)

--- a/internal/resource/pdb_test.go
+++ b/internal/resource/pdb_test.go
@@ -61,8 +61,9 @@ func TestPDBListData(t *testing.T) {
 	l := NewPDBListWithArgs("blee", NewPDBWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/pod_test.go
+++ b/internal/resource/pod_test.go
@@ -70,8 +70,9 @@ func TestPodListData(t *testing.T) {
 	l := NewPodListWithArgs("blee", NewPodWithArgs(mc, mr, mx))
 	// Make sure we mcn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/pv_test.go
+++ b/internal/resource/pv_test.go
@@ -61,8 +61,9 @@ func TestPVListData(t *testing.T) {
 	l := NewPVListWithArgs("-", NewPVWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)

--- a/internal/resource/pvc_test.go
+++ b/internal/resource/pvc_test.go
@@ -62,8 +62,9 @@ func TestPVCListData(t *testing.T) {
 	l := NewPVCListWithArgs("blee", NewPVCWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/rc_test.go
+++ b/internal/resource/rc_test.go
@@ -62,8 +62,9 @@ func TestRCListData(t *testing.T) {
 	l := NewRCListWithArgs("blee", NewRCWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/ro_binding_test.go
+++ b/internal/resource/ro_binding_test.go
@@ -42,8 +42,9 @@ func TestRBListData(t *testing.T) {
 	l := NewRBListWithArgs("blee", NewRBWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/ro_test.go
+++ b/internal/resource/ro_test.go
@@ -41,8 +41,9 @@ func TestRoleListData(t *testing.T) {
 	l := NewRoleListWithArgs("blee", NewRoleWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/rs_test.go
+++ b/internal/resource/rs_test.go
@@ -41,8 +41,9 @@ func TestReplicaSetListData(t *testing.T) {
 	l := NewReplicaSetListWithArgs("blee", NewReplicaSetWithArgs(mc, mr))
 	// Make sure we can get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/sa_test.go
+++ b/internal/resource/sa_test.go
@@ -78,8 +78,9 @@ func TestSAListData(t *testing.T) {
 	l := NewServiceAccountListWithArgs("blee", NewServiceAccountWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/sc_test.go
+++ b/internal/resource/sc_test.go
@@ -61,8 +61,9 @@ func TestSCListData(t *testing.T) {
 	l := NewSCListWithArgs("-", NewSCWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)

--- a/internal/resource/sts_test.go
+++ b/internal/resource/sts_test.go
@@ -79,8 +79,9 @@ func TestSTSListData(t *testing.T) {
 	l := NewStatefulSetListWithArgs("blee", NewStatefulSetWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/resource/svc_test.go
+++ b/internal/resource/svc_test.go
@@ -90,8 +90,9 @@ func TestSVCListData(t *testing.T) {
 	l := NewServiceListWithArgs("blee", NewServiceWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
 	for i := 0; i < 2; i++ {
-		err := l.Reconcile(nil, nil)
+		items, err := l.Reconcile(nil, nil)
 		assert.Nil(t, err)
+		l.Update(items)
 	}
 
 	mr.VerifyWasCalled(m.Times(2)).List("blee")

--- a/internal/ui/colorer.go
+++ b/internal/ui/colorer.go
@@ -27,7 +27,7 @@ var (
 func DefaultColorer(ns string, r *resource.RowEvent) tcell.Color {
 	c := StdColor
 	switch r.Action {
-	case watch.Added, resource.New:
+	case watch.Added:
 		c = AddColor
 	case watch.Modified:
 		c = ModColor

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -93,7 +93,7 @@ func (v *Table) AddSelectedRowListener(f SelectedRowFunc) {
 func (v *Table) selChanged(r, c int) {
 	v.selectedRow = r
 	v.updateSelectedItem(r)
-	if r == 0 {
+	if r <= 0 {
 		return
 	}
 
@@ -125,7 +125,7 @@ func (v *Table) SelectRow(r int, broadcast bool) {
 }
 
 func (v *Table) updateSelectedItem(r int) {
-	if r == 0 || v.GetCell(r, 0) == nil {
+	if r <= 0 || v.GetCell(r, 0) == nil {
 		v.selectedItem = ""
 		return
 	}


### PR DESCRIPTION
@derailed this is an attempt to reduce the amount of freezes that happens on k9s. I suffer *a lot* from bad internet connection. A lot of times I need to close k9s throughout the day.

With this, I have split the part of the `refresh` that fetches data (`reconcile`) from the part that actually redraw the screen. I'm seeing k9s to be more fluid and with less stop-the-world-update when loading something like configmaps (even after the improvements from the last PR) with 6000 objects.

I know this is a very sensitive change but I'm very confident with this. I'll ask some of my coworkers to try this out tomorrow and check if it really improves when using daily and if there is any bug that I didn't catch.