### PR TITLE
remove 'object' field when viewing YAML of CRDs

### DIFF
--- a/internal/resource/custom.go
+++ b/internal/resource/custom.go
@@ -7,9 +7,11 @@ import (
 	"path"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/derailed/k9s/internal/k8s"
 	"github.com/rs/zerolog/log"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 )
 
@@ -78,6 +80,10 @@ func (r *Custom) Marshal(path string) (string, error) {
 	i, err := r.Resource.Get(ns, n)
 	if err != nil {
 		return "", err
+	}
+	switch v := i.(type) {
+	case *unstructured.Unstructured:
+		i = v.Object
 	}
 
 	raw, err := yaml.Marshal(i)


### PR DESCRIPTION
Currently when seeing the YAML of a CRD there is a top level field called `Object`, example:

```yaml
object:
  apiVersion: serving.knative.dev/v1alpha1
  kind: Service
  metadata:
    annotations:
  ...
    name: backstage
  spec:
  ...
```

In this PR, we remove the unnecessary `object` field level and keep everything as: 
```yaml
apiVersion: serving.knative.dev/v1alpha1
kind: Service
metadata:
  annotations:
...
  name: backstage
spec:
...
```