### PR TITLE
Support v1beta1 CRDs

### DIFF
--- a/internal/views/registrar.go
+++ b/internal/views/registrar.go
@@ -307,6 +307,10 @@ func extRes(vv viewers) {
 		listFn:  resource.NewCustomResourceDefinitionList,
 		enterFn: showCRD,
 	}
+	vv["apiextensions.k8s.io/v1beta1/customresourcedefinitions"] = viewer{
+		listFn:  resource.NewCustomResourceDefinitionList,
+		enterFn: showCRD,
+	}
 }
 
 func netRes(vv viewers) {


### PR DESCRIPTION
In the last few builds I noticed `:crd` stopped working, this is the fix. In my cluster most of the CRDs are still `apiextensions.k8s.io/v1beta1`


```
kubectl version
Client Version: version.Info{Major:"1", Minor:"14", GitVersion:"v1.14.1", GitCommit:"b7394102d6ef778017f2ca4046abbaa23b88c290", GitTreeState:"clean", BuildDate:"2019-04-08T17:11:31Z", GoVersion:"go1.12.1", Com
piler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.3", GitCommit:"2d3c76f9091b6bec110a5e63777c332469e0cba2", GitTreeState:"clean", BuildDate:"2019-08-19T11:05:50Z", GoVersion:"go1.12.9", Com
piler:"gc", Platform:"linux/amd64"}
```

```
k9s version
 ____  __.________       
|    |/ _/   __   \______
|      < \____    /  ___/
|    |  \   /    /\___ \ 
|____|__ \ /____//____  >
        \/            \/ 

Version:   0.9.1
Commit:    452a8e4fc7d532a043e157db032f1f9ff0626d50
Date:      2019-10-04T14:35:02Z
```