### PR TITLE
disable header toggle when buffer is active.

### DIFF
--- a/internal/views/app.go
+++ b/internal/views/app.go
@@ -350,6 +350,10 @@ func (a *appView) setIndicator(l ui.FlashLevel, msg string) {
 }
 
 func (a *appView) toggleHeaderCmd(evt *tcell.EventKey) *tcell.EventKey {
+	if a.Cmd().InCmdMode() {
+		return evt
+	}
+
 	a.showHeader = !a.showHeader
 	a.toggleHeader(a.showHeader)
 	a.Draw()


### PR DESCRIPTION
After changing the 'header toggle' key to `H`, it became impossible to type the letter `h` on the command and filter buffer.

I've added a guard when either the command buffer or the filter buffer is active to prevent the toggle.


Out of the scope: @derailed do you want me to create issues for small fixes like this or do you think we can skip it?