### PR TITLE
fix race condition when switching ns.

### DIFF
--- a/internal/watch/no_mx.go
+++ b/internal/watch/no_mx.go
@@ -112,6 +112,7 @@ func (n *nodeMxWatcher) Run() {
 	for {
 		select {
 		case <-n.doneChan:
+			close(n.eventChan)
 			return
 		case <-time.After(nodeMXRefresh):
 			list, err := c.MetricsV1beta1().NodeMetricses().List(metav1.ListOptions{})
@@ -127,7 +128,6 @@ func (n *nodeMxWatcher) Run() {
 func (n *nodeMxWatcher) Stop() {
 	log.Debug().Msg("Stopping NodeMetrix informer!")
 	close(n.doneChan)
-	close(n.eventChan)
 }
 
 // ResultChan retrieves event channel.

--- a/internal/watch/pod_mx.go
+++ b/internal/watch/pod_mx.go
@@ -124,6 +124,7 @@ func (p *podMxWatcher) Run() {
 	for {
 		select {
 		case <-p.doneChan:
+			close(p.eventChan)
 			return
 		case <-time.After(podMXRefresh):
 			list, err := c.MetricsV1beta1().PodMetricses(p.ns).List(metav1.ListOptions{})
@@ -173,7 +174,6 @@ func (p *podMxWatcher) update(list *mv1beta1.PodMetricsList, notify bool) {
 func (p *podMxWatcher) Stop() {
 	log.Debug().Msg("Stopping PodMetrix informer!!")
 	close(p.doneChan)
-	close(p.eventChan)
 }
 
 // ResultChan retrieves event channel.


### PR DESCRIPTION
It is a good practice to let writers of a channel to close it. This ensure that we only close the channel if the informer is not writing to it.

Informers was being closed when we switch namespaces but the informer could be in the middle of updating method and cause a panic due writing to a closed chan. This is a really rare case, you can come across it when switching ns in the pods view. 

It is really rare, I could reproduce it adding some sleeps in the code.