### PR TITLE
invalidate cache when switching context

### DIFF
--- a/internal/k8s/api.go
+++ b/internal/k8s/api.go
@@ -332,6 +332,7 @@ func (a *APIClient) SwitchContextOrDie(ctx string) {
 	}
 
 	if currentCtx != ctx {
+		a.cachedDiscovery = nil
 		a.reset()
 		if err := a.config.SwitchContext(ctx); err != nil {
 			panic(err)


### PR DESCRIPTION
Fixes #377, we only needed to clear the cached discovery client guess I missed when adding this cache. 