### PR TITLE
use the table's filtered data when saving to file

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -195,6 +195,11 @@ func (v *Table) GetData() resource.TableData {
 	return v.data
 }
 
+// GetFilteredData fetch filtered tabular data.
+func (v *Table) GetFilteredData() resource.TableData {
+	return v.filtered()
+}
+
 // SetBaseTitle set the table title.
 func (v *Table) SetBaseTitle(s string) {
 	v.baseTitle = s

--- a/internal/views/table.go
+++ b/internal/views/table.go
@@ -33,7 +33,7 @@ func (v *tableView) BufferActive(state bool, k ui.BufferKind) {
 }
 
 func (v *tableView) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
-	if path, err := saveTable(v.app.Config.K9s.CurrentCluster, v.GetBaseTitle(), v.GetData()); err != nil {
+	if path, err := saveTable(v.app.Config.K9s.CurrentCluster, v.GetBaseTitle(), v.GetFilteredData()); err != nil {
 		v.app.Flash().Err(err)
 	} else {
 		v.app.Flash().Infof("File %s saved successfully!", path)


### PR DESCRIPTION
Closes #387 

Added a method to get the filtered data from the table and use it in the `saveCmd` method.

Another way I thought about tackling this was changing the `GetData` method to do something like the `Update` method and return the filtered data if `cmdBuff` isn't empty and keep `saveCmd` calling it as before.