### PR TITLE
Simplify Cruder Interface

### DIFF
--- a/internal/k8s/api.go
+++ b/internal/k8s/api.go
@@ -97,7 +97,7 @@ func InitConnectionOrDie(config *Config, logger zerolog.Logger) *APIClient {
 // CheckListNSAccess check if current user can list namespaces.
 func (a *APIClient) CheckListNSAccess() error {
 	ns := NewNamespace(a)
-	_, err := ns.List("")
+	_, err := ns.List("", metav1.ListOptions{})
 	return err
 }
 
@@ -105,7 +105,7 @@ func (a *APIClient) CheckListNSAccess() error {
 func (a *APIClient) CheckNSAccess(n string) error {
 	ns := NewNamespace(a)
 	if n == "" {
-		_, err := ns.List(n)
+		_, err := ns.List(n, metav1.ListOptions{})
 		return err
 	}
 

--- a/internal/k8s/base.go
+++ b/internal/k8s/base.go
@@ -1,32 +1,6 @@
 package k8s
 
 type base struct {
-	fieldSelector string
-	labelSelector string
-}
-
-// SetFieldSelector refines query results via selector.
-func (b *base) SetFieldSelector(s string) {
-	b.fieldSelector = s
-}
-
-// SetLabelSelector refines query results via labels.
-func (b *base) SetLabelSelector(s string) {
-	b.labelSelector = s
-}
-
-// GetFieldSelector returns field selector.
-func (b *base) GetFieldSelector() string {
-	return b.fieldSelector
-}
-
-// GetLabelSelector returns label selector.
-func (b *base) GetLabelSelector() string {
-	return b.labelSelector
-}
-
-func (b *base) HasSelectors() bool {
-	return b.labelSelector != "" || b.fieldSelector != ""
 }
 
 func (b *base) Kill(ns, n string) error {

--- a/internal/k8s/cluster_role.go
+++ b/internal/k8s/cluster_role.go
@@ -21,11 +21,7 @@ func (c *ClusterRole) Get(_, n string) (interface{}, error) {
 }
 
 // List all ClusterRoles on a cluster.
-func (c *ClusterRole) List(_ string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: c.labelSelector,
-		FieldSelector: c.fieldSelector,
-	}
+func (c *ClusterRole) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := c.DialOrDie().RbacV1().ClusterRoles().List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/cluster_roleb.go
+++ b/internal/k8s/cluster_roleb.go
@@ -21,11 +21,7 @@ func (c *ClusterRoleBinding) Get(_, n string) (interface{}, error) {
 }
 
 // List all ClusterRoleBindings on a cluster.
-func (c *ClusterRoleBinding) List(_ string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: c.labelSelector,
-		FieldSelector: c.fieldSelector,
-	}
+func (c *ClusterRoleBinding) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := c.DialOrDie().RbacV1().ClusterRoleBindings().List(opts)
 	if err != nil {
 		return Collection{}, err

--- a/internal/k8s/context.go
+++ b/internal/k8s/context.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"fmt"
 
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -53,7 +53,7 @@ func (c *Context) Get(_, n string) (interface{}, error) {
 }
 
 // List all Contexts on the current cluster.
-func (c *Context) List(string, v12.ListOptions) (Collection, error) {
+func (c *Context) List(string, metav1.ListOptions) (Collection, error) {
 	ctxs, err := c.Config().Contexts()
 	if err != nil {
 		return nil, err

--- a/internal/k8s/context.go
+++ b/internal/k8s/context.go
@@ -3,6 +3,8 @@ package k8s
 import (
 	"fmt"
 
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -51,7 +53,7 @@ func (c *Context) Get(_, n string) (interface{}, error) {
 }
 
 // List all Contexts on the current cluster.
-func (c *Context) List(string) (Collection, error) {
+func (c *Context) List(string, v12.ListOptions) (Collection, error) {
 	ctxs, err := c.Config().Contexts()
 	if err != nil {
 		return nil, err

--- a/internal/k8s/crd.go
+++ b/internal/k8s/crd.go
@@ -21,11 +21,7 @@ func (c *CustomResourceDefinition) Get(_, n string) (interface{}, error) {
 }
 
 // List all CustomResourceDefinitions in a given namespace.
-func (c *CustomResourceDefinition) List(string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: c.labelSelector,
-		FieldSelector: c.fieldSelector,
-	}
+func (c *CustomResourceDefinition) List(_ string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := c.NSDialOrDie().List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/cronjob.go
+++ b/internal/k8s/cronjob.go
@@ -26,11 +26,7 @@ func (c *CronJob) Get(ns, n string) (interface{}, error) {
 }
 
 // List all CronJobs in a given namespace.
-func (c *CronJob) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: c.labelSelector,
-		FieldSelector: c.fieldSelector,
-	}
+func (c *CronJob) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := c.DialOrDie().BatchV1beta1().CronJobs(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/dp.go
+++ b/internal/k8s/dp.go
@@ -23,11 +23,7 @@ func (d *Deployment) Get(ns, n string) (interface{}, error) {
 }
 
 // List all Deployments in a given namespace.
-func (d *Deployment) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: d.labelSelector,
-		FieldSelector: d.fieldSelector,
-	}
+func (d *Deployment) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := d.DialOrDie().AppsV1().Deployments(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/ds.go
+++ b/internal/k8s/ds.go
@@ -23,11 +23,7 @@ func (d *DaemonSet) Get(ns, n string) (interface{}, error) {
 }
 
 // List all DaemonSets in a given namespace.
-func (d *DaemonSet) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: d.labelSelector,
-		FieldSelector: d.fieldSelector,
-	}
+func (d *DaemonSet) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := d.DialOrDie().AppsV1().DaemonSets(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/ep.go
+++ b/internal/k8s/ep.go
@@ -21,11 +21,7 @@ func (e *Endpoints) Get(ns, n string) (interface{}, error) {
 }
 
 // List all Endpoints in a given namespace.
-func (e *Endpoints) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: e.labelSelector,
-		FieldSelector: e.fieldSelector,
-	}
+func (e *Endpoints) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := e.DialOrDie().CoreV1().Endpoints(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/evt.go
+++ b/internal/k8s/evt.go
@@ -21,11 +21,7 @@ func (e *Event) Get(ns, n string) (interface{}, error) {
 }
 
 // List all Events in a given namespace.
-func (e *Event) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: e.labelSelector,
-		FieldSelector: e.fieldSelector,
-	}
+func (e *Event) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := e.DialOrDie().CoreV1().Events(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/hpa_v1.go
+++ b/internal/k8s/hpa_v1.go
@@ -21,11 +21,7 @@ func (h *HorizontalPodAutoscalerV1) Get(ns, n string) (interface{}, error) {
 }
 
 // List all HorizontalPodAutoscalers in a given namespace.
-func (h *HorizontalPodAutoscalerV1) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: h.labelSelector,
-		FieldSelector: h.fieldSelector,
-	}
+func (h *HorizontalPodAutoscalerV1) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := h.DialOrDie().AutoscalingV1().HorizontalPodAutoscalers(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/hpa_v2beta1.go
+++ b/internal/k8s/hpa_v2beta1.go
@@ -22,11 +22,7 @@ func (h *HorizontalPodAutoscalerV2Beta1) Get(ns, n string) (interface{}, error) 
 }
 
 // List all HorizontalPodAutoscalers in a given namespace.
-func (h *HorizontalPodAutoscalerV2Beta1) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: h.labelSelector,
-		FieldSelector: h.fieldSelector,
-	}
+func (h *HorizontalPodAutoscalerV2Beta1) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := h.DialOrDie().AutoscalingV2beta1().HorizontalPodAutoscalers(ns).List(opts)
 	if err != nil {
 		log.Error().Err(err).Msg("Beta1 Failed!")

--- a/internal/k8s/hpa_v2beta2.go
+++ b/internal/k8s/hpa_v2beta2.go
@@ -23,11 +23,7 @@ func (h *HorizontalPodAutoscalerV2Beta2) Get(ns, n string) (interface{}, error) 
 }
 
 // List all HorizontalPodAutoscalerV2Beta2s in a given namespace.
-func (h *HorizontalPodAutoscalerV2Beta2) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: h.labelSelector,
-		FieldSelector: h.fieldSelector,
-	}
+func (h *HorizontalPodAutoscalerV2Beta2) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := h.DialOrDie().AutoscalingV2beta2().HorizontalPodAutoscalers(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/ing.go
+++ b/internal/k8s/ing.go
@@ -21,11 +21,7 @@ func (i *Ingress) Get(ns, n string) (interface{}, error) {
 }
 
 // List all Ingresses in a given namespace.
-func (i *Ingress) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: i.labelSelector,
-		FieldSelector: i.fieldSelector,
-	}
+func (i *Ingress) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := i.DialOrDie().ExtensionsV1beta1().Ingresses(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/job.go
+++ b/internal/k8s/job.go
@@ -34,11 +34,7 @@ func (j *Job) Get(ns, n string) (interface{}, error) {
 }
 
 // List all Jobs in a given namespace.
-func (j *Job) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: j.labelSelector,
-		FieldSelector: j.fieldSelector,
-	}
+func (j *Job) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := j.DialOrDie().BatchV1().Jobs(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/no.go
+++ b/internal/k8s/no.go
@@ -21,11 +21,7 @@ func (n *Node) Get(_, name string) (interface{}, error) {
 }
 
 // List all nodes on the cluster.
-func (n *Node) List(_ string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: n.labelSelector,
-		FieldSelector: n.fieldSelector,
-	}
+func (n *Node) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := n.DialOrDie().CoreV1().Nodes().List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/np.go
+++ b/internal/k8s/np.go
@@ -21,11 +21,7 @@ func (d *NetworkPolicy) Get(ns, n string) (interface{}, error) {
 }
 
 // List all NetworkPolicys in a given namespace.
-func (d *NetworkPolicy) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: d.labelSelector,
-		FieldSelector: d.fieldSelector,
-	}
+func (d *NetworkPolicy) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := d.DialOrDie().NetworkingV1().NetworkPolicies(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/ns.go
+++ b/internal/k8s/ns.go
@@ -21,11 +21,7 @@ func (n *Namespace) Get(_, name string) (interface{}, error) {
 }
 
 // List all active namespaces on the cluster.
-func (n *Namespace) List(_ string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: n.labelSelector,
-		FieldSelector: n.fieldSelector,
-	}
+func (n *Namespace) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := n.DialOrDie().CoreV1().Namespaces().List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/pdb.go
+++ b/internal/k8s/pdb.go
@@ -21,11 +21,7 @@ func (p *PodDisruptionBudget) Get(ns, n string) (interface{}, error) {
 }
 
 // List all pdbs in a given namespace.
-func (p *PodDisruptionBudget) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: p.labelSelector,
-		FieldSelector: p.fieldSelector,
-	}
+func (p *PodDisruptionBudget) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := p.DialOrDie().PolicyV1beta1().PodDisruptionBudgets(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -26,12 +26,7 @@ func (p *Pod) Get(ns, name string) (interface{}, error) {
 }
 
 // List all pods in a given namespace.
-func (p *Pod) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: p.labelSelector,
-		FieldSelector: p.fieldSelector,
-	}
-
+func (p *Pod) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := p.DialOrDie().CoreV1().Pods(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/pv.go
+++ b/internal/k8s/pv.go
@@ -21,11 +21,7 @@ func (p *PersistentVolume) Get(_, n string) (interface{}, error) {
 }
 
 // List all PersistentVolumes in a given namespace.
-func (p *PersistentVolume) List(_ string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: p.labelSelector,
-		FieldSelector: p.fieldSelector,
-	}
+func (p *PersistentVolume) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := p.DialOrDie().CoreV1().PersistentVolumes().List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/pvc.go
+++ b/internal/k8s/pvc.go
@@ -21,11 +21,7 @@ func (p *PersistentVolumeClaim) Get(ns, n string) (interface{}, error) {
 }
 
 // List all PersistentVolumeClaims in a given namespace.
-func (p *PersistentVolumeClaim) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: p.labelSelector,
-		FieldSelector: p.fieldSelector,
-	}
+func (p *PersistentVolumeClaim) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := p.DialOrDie().CoreV1().PersistentVolumeClaims(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/rc.go
+++ b/internal/k8s/rc.go
@@ -21,11 +21,7 @@ func (r *ReplicationController) Get(ns, n string) (interface{}, error) {
 }
 
 // List all RCs in a given namespace.
-func (r *ReplicationController) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: r.labelSelector,
-		FieldSelector: r.fieldSelector,
-	}
+func (r *ReplicationController) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := r.DialOrDie().CoreV1().ReplicationControllers(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/resource.go
+++ b/internal/k8s/resource.go
@@ -39,7 +39,7 @@ func (r *Resource) Get(ns, n string) (interface{}, error) {
 }
 
 // List all Resources in a given namespace.
-func (r *Resource) List(ns string) (Collection, error) {
+func (r *Resource) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	obj, err := r.listAll(ns, r.gvr.ToR())
 	if err != nil {
 		return nil, err

--- a/internal/k8s/role.go
+++ b/internal/k8s/role.go
@@ -22,11 +22,7 @@ func (r *Role) Get(ns, n string) (interface{}, error) {
 }
 
 // List all Roles in a given namespace.
-func (r *Role) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: r.labelSelector,
-		FieldSelector: r.fieldSelector,
-	}
+func (r *Role) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := r.DialOrDie().RbacV1().Roles(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/role_binding.go
+++ b/internal/k8s/role_binding.go
@@ -19,11 +19,7 @@ func (r *RoleBinding) Get(ns, n string) (interface{}, error) {
 }
 
 // List all RoleBindings in a given namespace.
-func (r *RoleBinding) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: r.labelSelector,
-		FieldSelector: r.fieldSelector,
-	}
+func (r *RoleBinding) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := r.DialOrDie().RbacV1().RoleBindings(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/rs.go
+++ b/internal/k8s/rs.go
@@ -21,11 +21,7 @@ func (r *ReplicaSet) Get(ns, n string) (interface{}, error) {
 }
 
 // List all ReplicaSets in a given namespace.
-func (r *ReplicaSet) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: r.labelSelector,
-		FieldSelector: r.fieldSelector,
-	}
+func (r *ReplicaSet) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := r.DialOrDie().AppsV1().ReplicaSets(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/sa.go
+++ b/internal/k8s/sa.go
@@ -21,11 +21,7 @@ func (s *ServiceAccount) Get(ns, n string) (interface{}, error) {
 }
 
 // List all ServiceAccounts in a given namespace.
-func (s *ServiceAccount) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: s.labelSelector,
-		FieldSelector: s.fieldSelector,
-	}
+func (s *ServiceAccount) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := s.DialOrDie().CoreV1().ServiceAccounts(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/sc.go
+++ b/internal/k8s/sc.go
@@ -21,11 +21,7 @@ func (p *StorageClass) Get(_, n string) (interface{}, error) {
 }
 
 // List all StorageClasses in a given namespace.
-func (p *StorageClass) List(_ string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: p.labelSelector,
-		FieldSelector: p.fieldSelector,
-	}
+func (p *StorageClass) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := p.DialOrDie().StorageV1().StorageClasses().List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/sts.go
+++ b/internal/k8s/sts.go
@@ -23,11 +23,7 @@ func (s *StatefulSet) Get(ns, n string) (interface{}, error) {
 }
 
 // List all StatefulSets in a given namespace.
-func (s *StatefulSet) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: s.labelSelector,
-		FieldSelector: s.fieldSelector,
-	}
+func (s *StatefulSet) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := s.DialOrDie().AppsV1().StatefulSets(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/k8s/svc.go
+++ b/internal/k8s/svc.go
@@ -21,11 +21,7 @@ func (s *Service) Get(ns, n string) (interface{}, error) {
 }
 
 // List all Services in a given namespace.
-func (s *Service) List(ns string) (Collection, error) {
-	opts := metav1.ListOptions{
-		LabelSelector: s.labelSelector,
-		FieldSelector: s.fieldSelector,
-	}
+func (s *Service) List(ns string, opts metav1.ListOptions) (Collection, error) {
 	rr, err := s.DialOrDie().CoreV1().Services(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/internal/resource/base.go
+++ b/internal/resource/base.go
@@ -22,13 +22,8 @@ type (
 	// Cruder represents a crudable Kubernetes resource.
 	Cruder interface {
 		Get(ns string, name string) (interface{}, error)
-		List(ns string) (k8s.Collection, error)
+		List(ns string, opts metav1.ListOptions) (k8s.Collection, error)
 		Delete(ns string, name string, cascade, force bool) error
-		SetLabelSelector(string)
-		SetFieldSelector(string)
-		GetLabelSelector() string
-		GetFieldSelector() string
-		HasSelectors() bool
 	}
 
 	// Scalable represents a scalable Kubernetes resource.
@@ -64,36 +59,11 @@ func NewBase(c Connection, r Cruder) *Base {
 	return &Base{Connection: c, Resource: r}
 }
 
-// HasSelectors returns true if field or label selectors are set.
-func (b *Base) HasSelectors() bool {
-	return b.Resource.HasSelectors()
-}
-
 // SetPodMetrics attach pod metrics to resource.
 func (b *Base) SetPodMetrics(*mv1beta1.PodMetrics) {}
 
 // SetNodeMetrics attach node metrics to resource.
 func (b *Base) SetNodeMetrics(*mv1beta1.NodeMetrics) {}
-
-// SetFieldSelector refines query results via selector.
-func (b *Base) SetFieldSelector(s string) {
-	b.Resource.SetFieldSelector(s)
-}
-
-// SetLabelSelector refines query results via labels.
-func (b *Base) SetLabelSelector(s string) {
-	b.Resource.SetLabelSelector(s)
-}
-
-// GetFieldSelector returns field selector.
-func (b *Base) GetFieldSelector() string {
-	return b.Resource.GetFieldSelector()
-}
-
-// GetLabelSelector returns label selector.
-func (b *Base) GetLabelSelector() string {
-	return b.Resource.GetLabelSelector()
-}
 
 // Name returns the resource namespaced name.
 func (b *Base) Name() string {
@@ -122,8 +92,8 @@ func (b *Base) Get(path string) (Columnar, error) {
 }
 
 // List all resources
-func (b *Base) List(ns string) (Columnars, error) {
-	ii, err := b.Resource.List(ns)
+func (b *Base) List(ns string, opts metav1.ListOptions) (Columnars, error) {
+	ii, err := b.Resource.List(ns, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resource/container.go
+++ b/internal/resource/container.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/derailed/k9s/internal/k8s"
 	v1 "k8s.io/api/core/v1"
 	mv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
@@ -78,7 +80,7 @@ func (r *Container) Logs(ctx context.Context, c chan<- string, opts LogOptions) 
 }
 
 // List resources for a given namespace.
-func (r *Container) List(ns string) (Columnars, error) {
+func (r *Container) List(ns string, opts metav1.ListOptions) (Columnars, error) {
 	icos := r.pod.Spec.InitContainers
 	cos := r.pod.Spec.Containers
 

--- a/internal/resource/context_test.go
+++ b/internal/resource/context_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/derailed/k9s/internal/resource"
 	m "github.com/petergtz/pegomock"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	api "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -36,14 +37,14 @@ func TestCTXSwitch(t *testing.T) {
 func TestCTXList(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockSwitchableCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sNamedCTX()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sNamedCTX()}, nil)
 
 	ctx := NewContextWithArgs(mc, mr)
-	cc, err := ctx.List("blee")
+	cc, err := ctx.List("blee", metav1.ListOptions{})
 
 	assert.Nil(t, err)
 	assert.Equal(t, resource.Columnars{ctx.New(k8sNamedCTX())}, cc)
-	mr.VerifyWasCalledOnce().List("blee")
+	mr.VerifyWasCalledOnce().List("blee", metav1.ListOptions{})
 }
 
 func TestCTXDelete(t *testing.T) {

--- a/internal/resource/cr_binding_test.go
+++ b/internal/resource/cr_binding_test.go
@@ -45,7 +45,7 @@ func TestCRBMarshal(t *testing.T) {
 func TestCRBListData(t *testing.T) {
 	conn := NewMockConnection()
 	ca := NewMockCruder()
-	m.When(ca.List(resource.NotNamespaced)).ThenReturn(k8s.Collection{*k8sCRB()}, nil)
+	m.When(ca.List(resource.NotNamespaced, metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sCRB()}, nil)
 
 	l := NewClusterRoleBindingListWithArgs("-", NewClusterRoleBindingWithArgs(conn, ca))
 	// Make sure we can get deltas!
@@ -54,7 +54,7 @@ func TestCRBListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	ca.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)
+	ca.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced, metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, resource.NotNamespaced, l.GetNamespace())

--- a/internal/resource/cr_test.go
+++ b/internal/resource/cr_test.go
@@ -65,7 +65,7 @@ func TestCRMarshal(t *testing.T) {
 func TestCRListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List(resource.NotNamespaced)).ThenReturn(k8s.Collection{*k8sCR()}, nil)
+	m.When(mr.List(resource.NotNamespaced, metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sCR()}, nil)
 
 	l := NewClusterRoleListWithArgs("-", NewClusterRoleWithArgs(mc, mr))
 	// Make sure we mcn get deltas!
@@ -74,7 +74,7 @@ func TestCRListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)
+	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced, metav1.ListOptions{})
 
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))

--- a/internal/resource/crd_test.go
+++ b/internal/resource/crd_test.go
@@ -3,6 +3,9 @@ package resource_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/derailed/k9s/internal/k8s"
 	"github.com/derailed/k9s/internal/resource"
 	m "github.com/petergtz/pegomock"
@@ -65,7 +68,7 @@ func TestCRDMarshal(t *testing.T) {
 func TestCRDListData(t *testing.T) {
 	mc := NewMockConnection()
 	cr := NewMockCruder()
-	m.When(cr.List(resource.NotNamespaced)).ThenReturn(k8s.Collection{*k8sCRD()}, nil)
+	m.When(cr.List(resource.NotNamespaced, v1.ListOptions{})).ThenReturn(k8s.Collection{*k8sCRD()}, nil)
 
 	l := NewCRDListWithArgs("-", NewCRDWithArgs(mc, cr))
 	// Make sure we can get deltas!
@@ -74,7 +77,7 @@ func TestCRDListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	cr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)
+	cr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced, metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, resource.NotNamespaced, l.GetNamespace())

--- a/internal/resource/cronjob_test.go
+++ b/internal/resource/cronjob_test.go
@@ -57,7 +57,7 @@ func TestCronJobMarshal(t *testing.T) {
 func TestCronJobListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List(resource.NotNamespaced)).ThenReturn(k8s.Collection{*k8sCronJob()}, nil)
+	m.When(mr.List(resource.NotNamespaced, metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sCronJob()}, nil)
 
 	l := NewCronJobListWithArgs("-", NewCronJobWithArgs(mc, mr))
 	// Make sure we can get deltas!
@@ -66,7 +66,7 @@ func TestCronJobListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)
+	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced, metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, resource.NotNamespaced, l.GetNamespace())

--- a/internal/resource/custom.go
+++ b/internal/resource/custom.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"strings"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/derailed/k9s/internal/k8s"
@@ -95,8 +97,8 @@ func (r *Custom) Marshal(path string) (string, error) {
 }
 
 // List all resources
-func (r *Custom) List(ns string) (Columnars, error) {
-	ii, err := r.Resource.List(ns)
+func (r *Custom) List(ns string, opts v1.ListOptions) (Columnars, error) {
+	ii, err := r.Resource.List(ns, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resource/custom_test.go
+++ b/internal/resource/custom_test.go
@@ -3,6 +3,7 @@ package resource_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/derailed/k9s/internal/k8s"
@@ -73,7 +74,7 @@ func TestCustomMarshalWithUnstructured(t *testing.T) {
 func TestCustomListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{k8sCustomTable()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{k8sCustomTable()}, nil)
 
 	l := NewCustomListWithArgs("blee", "fred", NewCustomWithArgs(mc, mr))
 	// Make sure we can get deltas!
@@ -82,7 +83,7 @@ func TestCustomListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/dp_test.go
+++ b/internal/resource/dp_test.go
@@ -57,7 +57,7 @@ func TestDeploymentMarshal(t *testing.T) {
 func TestDeploymentListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List(resource.NotNamespaced)).ThenReturn(k8s.Collection{*k8sDeployment()}, nil)
+	m.When(mr.List(resource.NotNamespaced, metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sDeployment()}, nil)
 
 	l := NewDeploymentListWithArgs("-", NewDeploymentWithArgs(mc, mr))
 	// Make sure we can get deltas!
@@ -66,7 +66,7 @@ func TestDeploymentListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)
+	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced, metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, resource.NotNamespaced, l.GetNamespace())

--- a/internal/resource/ds_test.go
+++ b/internal/resource/ds_test.go
@@ -56,7 +56,7 @@ func TestDSMarshal(t *testing.T) {
 func TestDSListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sDS()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sDS()}, nil)
 
 	l := NewDaemonSetListWithArgs("blee", NewDaemonSetWithArgs(mc, mr))
 	// Make sure we can get deltas!
@@ -65,7 +65,7 @@ func TestDSListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/ep_test.go
+++ b/internal/resource/ep_test.go
@@ -54,7 +54,7 @@ func TestEndpointsMarshal(t *testing.T) {
 func TestEndpointsListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List(resource.NotNamespaced)).ThenReturn(k8s.Collection{*k8sEndpoints()}, nil)
+	m.When(mr.List(resource.NotNamespaced, metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sEndpoints()}, nil)
 
 	l := NewEndpointsListWithArgs("-", NewEndpointsWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -63,7 +63,7 @@ func TestEndpointsListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)
+	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced, metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, resource.NotNamespaced, l.GetNamespace())

--- a/internal/resource/evt_test.go
+++ b/internal/resource/evt_test.go
@@ -56,7 +56,7 @@ func TestEventMarshal(t *testing.T) {
 func TestEventData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sEvent()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sEvent()}, nil)
 
 	l := NewEventListWithArgs("blee", NewEventWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -65,7 +65,7 @@ func TestEventData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/hpa_v1_test.go
+++ b/internal/resource/hpa_v1_test.go
@@ -58,7 +58,7 @@ func TestHPAMarshal(t *testing.T) {
 func TestHPAListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sHPA()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sHPA()}, nil)
 
 	l := NewHPAListWithArgs("blee", NewHPAWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -67,7 +67,7 @@ func TestHPAListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/ing_test.go
+++ b/internal/resource/ing_test.go
@@ -56,7 +56,7 @@ func TestIngressMarshal(t *testing.T) {
 func TestIngressListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sIngress()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sIngress()}, nil)
 
 	l := NewIngressListWithArgs("blee", NewIngressWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -65,7 +65,7 @@ func TestIngressListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/job_test.go
+++ b/internal/resource/job_test.go
@@ -56,7 +56,7 @@ func TestJobMarshal(t *testing.T) {
 func TestJobListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sJob()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sJob()}, nil)
 
 	l := NewJobListWithArgs("blee", NewJobWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -65,7 +65,7 @@ func TestJobListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/mock_cruder_test.go
+++ b/internal/resource/mock_cruder_test.go
@@ -6,6 +6,7 @@ package resource_test
 import (
 	k8s "github.com/derailed/k9s/internal/k8s"
 	pegomock "github.com/petergtz/pegomock"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"time"
 )
@@ -59,56 +60,11 @@ func (mock *MockCruder) Get(_param0 string, _param1 string) (interface{}, error)
 	return ret0, ret1
 }
 
-func (mock *MockCruder) GetFieldSelector() string {
+func (mock *MockCruder) List(_param0 string, _param1 v1.ListOptions) (k8s.Collection, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockCruder().")
 	}
-	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("GetFieldSelector", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem()})
-	var ret0 string
-	if len(result) != 0 {
-		if result[0] != nil {
-			ret0 = result[0].(string)
-		}
-	}
-	return ret0
-}
-
-func (mock *MockCruder) GetLabelSelector() string {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockCruder().")
-	}
-	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("GetLabelSelector", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem()})
-	var ret0 string
-	if len(result) != 0 {
-		if result[0] != nil {
-			ret0 = result[0].(string)
-		}
-	}
-	return ret0
-}
-
-func (mock *MockCruder) HasSelectors() bool {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockCruder().")
-	}
-	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("HasSelectors", params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
-	var ret0 bool
-	if len(result) != 0 {
-		if result[0] != nil {
-			ret0 = result[0].(bool)
-		}
-	}
-	return ret0
-}
-
-func (mock *MockCruder) List(_param0 string) (k8s.Collection, error) {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockCruder().")
-	}
-	params := []pegomock.Param{_param0}
+	params := []pegomock.Param{_param0, _param1}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("List", params, []reflect.Type{reflect.TypeOf((*k8s.Collection)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 k8s.Collection
 	var ret1 error
@@ -121,22 +77,6 @@ func (mock *MockCruder) List(_param0 string) (k8s.Collection, error) {
 		}
 	}
 	return ret0, ret1
-}
-
-func (mock *MockCruder) SetFieldSelector(_param0 string) {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockCruder().")
-	}
-	params := []pegomock.Param{_param0}
-	pegomock.GetGenericMockFrom(mock).Invoke("SetFieldSelector", params, []reflect.Type{})
-}
-
-func (mock *MockCruder) SetLabelSelector(_param0 string) {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockCruder().")
-	}
-	params := []pegomock.Param{_param0}
-	pegomock.GetGenericMockFrom(mock).Invoke("SetLabelSelector", params, []reflect.Type{})
 }
 
 func (mock *MockCruder) VerifyWasCalledOnce() *VerifierMockCruder {
@@ -195,19 +135,19 @@ func (c *MockCruder_Delete_OngoingVerification) GetCapturedArguments() (string, 
 func (c *MockCruder_Delete_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []bool, _param3 []bool) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
-		_param1 = make([]string, len(params[1]))
+		_param1 = make([]string, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.(string)
 		}
-		_param2 = make([]bool, len(params[2]))
+		_param2 = make([]bool, len(c.methodInvocations))
 		for u, param := range params[2] {
 			_param2[u] = param.(bool)
 		}
-		_param3 = make([]bool, len(params[3]))
+		_param3 = make([]bool, len(c.methodInvocations))
 		for u, param := range params[3] {
 			_param3[u] = param.(bool)
 		}
@@ -234,11 +174,11 @@ func (c *MockCruder_Get_OngoingVerification) GetCapturedArguments() (string, str
 func (c *MockCruder_Get_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
-		_param1 = make([]string, len(params[1]))
+		_param1 = make([]string, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.(string)
 		}
@@ -246,59 +186,8 @@ func (c *MockCruder_Get_OngoingVerification) GetAllCapturedArguments() (_param0 
 	return
 }
 
-func (verifier *VerifierMockCruder) GetFieldSelector() *MockCruder_GetFieldSelector_OngoingVerification {
-	params := []pegomock.Param{}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetFieldSelector", params, verifier.timeout)
-	return &MockCruder_GetFieldSelector_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
-
-type MockCruder_GetFieldSelector_OngoingVerification struct {
-	mock              *MockCruder
-	methodInvocations []pegomock.MethodInvocation
-}
-
-func (c *MockCruder_GetFieldSelector_OngoingVerification) GetCapturedArguments() {
-}
-
-func (c *MockCruder_GetFieldSelector_OngoingVerification) GetAllCapturedArguments() {
-}
-
-func (verifier *VerifierMockCruder) GetLabelSelector() *MockCruder_GetLabelSelector_OngoingVerification {
-	params := []pegomock.Param{}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetLabelSelector", params, verifier.timeout)
-	return &MockCruder_GetLabelSelector_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
-
-type MockCruder_GetLabelSelector_OngoingVerification struct {
-	mock              *MockCruder
-	methodInvocations []pegomock.MethodInvocation
-}
-
-func (c *MockCruder_GetLabelSelector_OngoingVerification) GetCapturedArguments() {
-}
-
-func (c *MockCruder_GetLabelSelector_OngoingVerification) GetAllCapturedArguments() {
-}
-
-func (verifier *VerifierMockCruder) HasSelectors() *MockCruder_HasSelectors_OngoingVerification {
-	params := []pegomock.Param{}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "HasSelectors", params, verifier.timeout)
-	return &MockCruder_HasSelectors_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
-
-type MockCruder_HasSelectors_OngoingVerification struct {
-	mock              *MockCruder
-	methodInvocations []pegomock.MethodInvocation
-}
-
-func (c *MockCruder_HasSelectors_OngoingVerification) GetCapturedArguments() {
-}
-
-func (c *MockCruder_HasSelectors_OngoingVerification) GetAllCapturedArguments() {
-}
-
-func (verifier *VerifierMockCruder) List(_param0 string) *MockCruder_List_OngoingVerification {
-	params := []pegomock.Param{_param0}
+func (verifier *VerifierMockCruder) List(_param0 string, _param1 v1.ListOptions) *MockCruder_List_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "List", params, verifier.timeout)
 	return &MockCruder_List_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -308,71 +197,21 @@ type MockCruder_List_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockCruder_List_OngoingVerification) GetCapturedArguments() string {
-	_param0 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1]
+func (c *MockCruder_List_OngoingVerification) GetCapturedArguments() (string, v1.ListOptions) {
+	_param0, _param1 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1]
 }
 
-func (c *MockCruder_List_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
+func (c *MockCruder_List_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []v1.ListOptions) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
-	}
-	return
-}
-
-func (verifier *VerifierMockCruder) SetFieldSelector(_param0 string) *MockCruder_SetFieldSelector_OngoingVerification {
-	params := []pegomock.Param{_param0}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "SetFieldSelector", params, verifier.timeout)
-	return &MockCruder_SetFieldSelector_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
-
-type MockCruder_SetFieldSelector_OngoingVerification struct {
-	mock              *MockCruder
-	methodInvocations []pegomock.MethodInvocation
-}
-
-func (c *MockCruder_SetFieldSelector_OngoingVerification) GetCapturedArguments() string {
-	_param0 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1]
-}
-
-func (c *MockCruder_SetFieldSelector_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
-	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
-	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
-		for u, param := range params[0] {
-			_param0[u] = param.(string)
-		}
-	}
-	return
-}
-
-func (verifier *VerifierMockCruder) SetLabelSelector(_param0 string) *MockCruder_SetLabelSelector_OngoingVerification {
-	params := []pegomock.Param{_param0}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "SetLabelSelector", params, verifier.timeout)
-	return &MockCruder_SetLabelSelector_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
-
-type MockCruder_SetLabelSelector_OngoingVerification struct {
-	mock              *MockCruder
-	methodInvocations []pegomock.MethodInvocation
-}
-
-func (c *MockCruder_SetLabelSelector_OngoingVerification) GetCapturedArguments() string {
-	_param0 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1]
-}
-
-func (c *MockCruder_SetLabelSelector_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
-	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
-	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
-		for u, param := range params[0] {
-			_param0[u] = param.(string)
+		_param1 = make([]v1.ListOptions, len(c.methodInvocations))
+		for u, param := range params[1] {
+			_param1[u] = param.(v1.ListOptions)
 		}
 	}
 	return

--- a/internal/resource/mock_switchablecruder_test.go
+++ b/internal/resource/mock_switchablecruder_test.go
@@ -6,6 +6,7 @@ package resource_test
 import (
 	k8s "github.com/derailed/k9s/internal/k8s"
 	pegomock "github.com/petergtz/pegomock"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"time"
 )
@@ -59,56 +60,11 @@ func (mock *MockSwitchableCruder) Get(_param0 string, _param1 string) (interface
 	return ret0, ret1
 }
 
-func (mock *MockSwitchableCruder) GetFieldSelector() string {
+func (mock *MockSwitchableCruder) List(_param0 string, _param1 v1.ListOptions) (k8s.Collection, error) {
 	if mock == nil {
 		panic("mock must not be nil. Use myMock := NewMockSwitchableCruder().")
 	}
-	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("GetFieldSelector", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem()})
-	var ret0 string
-	if len(result) != 0 {
-		if result[0] != nil {
-			ret0 = result[0].(string)
-		}
-	}
-	return ret0
-}
-
-func (mock *MockSwitchableCruder) GetLabelSelector() string {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockSwitchableCruder().")
-	}
-	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("GetLabelSelector", params, []reflect.Type{reflect.TypeOf((*string)(nil)).Elem()})
-	var ret0 string
-	if len(result) != 0 {
-		if result[0] != nil {
-			ret0 = result[0].(string)
-		}
-	}
-	return ret0
-}
-
-func (mock *MockSwitchableCruder) HasSelectors() bool {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockSwitchableCruder().")
-	}
-	params := []pegomock.Param{}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("HasSelectors", params, []reflect.Type{reflect.TypeOf((*bool)(nil)).Elem()})
-	var ret0 bool
-	if len(result) != 0 {
-		if result[0] != nil {
-			ret0 = result[0].(bool)
-		}
-	}
-	return ret0
-}
-
-func (mock *MockSwitchableCruder) List(_param0 string) (k8s.Collection, error) {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockSwitchableCruder().")
-	}
-	params := []pegomock.Param{_param0}
+	params := []pegomock.Param{_param0, _param1}
 	result := pegomock.GetGenericMockFrom(mock).Invoke("List", params, []reflect.Type{reflect.TypeOf((*k8s.Collection)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 k8s.Collection
 	var ret1 error
@@ -136,22 +92,6 @@ func (mock *MockSwitchableCruder) MustCurrentContextName() string {
 		}
 	}
 	return ret0
-}
-
-func (mock *MockSwitchableCruder) SetFieldSelector(_param0 string) {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockSwitchableCruder().")
-	}
-	params := []pegomock.Param{_param0}
-	pegomock.GetGenericMockFrom(mock).Invoke("SetFieldSelector", params, []reflect.Type{})
-}
-
-func (mock *MockSwitchableCruder) SetLabelSelector(_param0 string) {
-	if mock == nil {
-		panic("mock must not be nil. Use myMock := NewMockSwitchableCruder().")
-	}
-	params := []pegomock.Param{_param0}
-	pegomock.GetGenericMockFrom(mock).Invoke("SetLabelSelector", params, []reflect.Type{})
 }
 
 func (mock *MockSwitchableCruder) Switch(_param0 string) error {
@@ -225,19 +165,19 @@ func (c *MockSwitchableCruder_Delete_OngoingVerification) GetCapturedArguments()
 func (c *MockSwitchableCruder_Delete_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string, _param2 []bool, _param3 []bool) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
-		_param1 = make([]string, len(params[1]))
+		_param1 = make([]string, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.(string)
 		}
-		_param2 = make([]bool, len(params[2]))
+		_param2 = make([]bool, len(c.methodInvocations))
 		for u, param := range params[2] {
 			_param2[u] = param.(bool)
 		}
-		_param3 = make([]bool, len(params[3]))
+		_param3 = make([]bool, len(c.methodInvocations))
 		for u, param := range params[3] {
 			_param3[u] = param.(bool)
 		}
@@ -264,11 +204,11 @@ func (c *MockSwitchableCruder_Get_OngoingVerification) GetCapturedArguments() (s
 func (c *MockSwitchableCruder_Get_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}
-		_param1 = make([]string, len(params[1]))
+		_param1 = make([]string, len(c.methodInvocations))
 		for u, param := range params[1] {
 			_param1[u] = param.(string)
 		}
@@ -276,59 +216,8 @@ func (c *MockSwitchableCruder_Get_OngoingVerification) GetAllCapturedArguments()
 	return
 }
 
-func (verifier *VerifierMockSwitchableCruder) GetFieldSelector() *MockSwitchableCruder_GetFieldSelector_OngoingVerification {
-	params := []pegomock.Param{}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetFieldSelector", params, verifier.timeout)
-	return &MockSwitchableCruder_GetFieldSelector_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
-
-type MockSwitchableCruder_GetFieldSelector_OngoingVerification struct {
-	mock              *MockSwitchableCruder
-	methodInvocations []pegomock.MethodInvocation
-}
-
-func (c *MockSwitchableCruder_GetFieldSelector_OngoingVerification) GetCapturedArguments() {
-}
-
-func (c *MockSwitchableCruder_GetFieldSelector_OngoingVerification) GetAllCapturedArguments() {
-}
-
-func (verifier *VerifierMockSwitchableCruder) GetLabelSelector() *MockSwitchableCruder_GetLabelSelector_OngoingVerification {
-	params := []pegomock.Param{}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "GetLabelSelector", params, verifier.timeout)
-	return &MockSwitchableCruder_GetLabelSelector_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
-
-type MockSwitchableCruder_GetLabelSelector_OngoingVerification struct {
-	mock              *MockSwitchableCruder
-	methodInvocations []pegomock.MethodInvocation
-}
-
-func (c *MockSwitchableCruder_GetLabelSelector_OngoingVerification) GetCapturedArguments() {
-}
-
-func (c *MockSwitchableCruder_GetLabelSelector_OngoingVerification) GetAllCapturedArguments() {
-}
-
-func (verifier *VerifierMockSwitchableCruder) HasSelectors() *MockSwitchableCruder_HasSelectors_OngoingVerification {
-	params := []pegomock.Param{}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "HasSelectors", params, verifier.timeout)
-	return &MockSwitchableCruder_HasSelectors_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
-
-type MockSwitchableCruder_HasSelectors_OngoingVerification struct {
-	mock              *MockSwitchableCruder
-	methodInvocations []pegomock.MethodInvocation
-}
-
-func (c *MockSwitchableCruder_HasSelectors_OngoingVerification) GetCapturedArguments() {
-}
-
-func (c *MockSwitchableCruder_HasSelectors_OngoingVerification) GetAllCapturedArguments() {
-}
-
-func (verifier *VerifierMockSwitchableCruder) List(_param0 string) *MockSwitchableCruder_List_OngoingVerification {
-	params := []pegomock.Param{_param0}
+func (verifier *VerifierMockSwitchableCruder) List(_param0 string, _param1 v1.ListOptions) *MockSwitchableCruder_List_OngoingVerification {
+	params := []pegomock.Param{_param0, _param1}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "List", params, verifier.timeout)
 	return &MockSwitchableCruder_List_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
@@ -338,17 +227,21 @@ type MockSwitchableCruder_List_OngoingVerification struct {
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *MockSwitchableCruder_List_OngoingVerification) GetCapturedArguments() string {
-	_param0 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1]
+func (c *MockSwitchableCruder_List_OngoingVerification) GetCapturedArguments() (string, v1.ListOptions) {
+	_param0, _param1 := c.GetAllCapturedArguments()
+	return _param0[len(_param0)-1], _param1[len(_param1)-1]
 }
 
-func (c *MockSwitchableCruder_List_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
+func (c *MockSwitchableCruder_List_OngoingVerification) GetAllCapturedArguments() (_param0 []string, _param1 []v1.ListOptions) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
+		}
+		_param1 = make([]v1.ListOptions, len(c.methodInvocations))
+		for u, param := range params[1] {
+			_param1[u] = param.(v1.ListOptions)
 		}
 	}
 	return
@@ -371,60 +264,6 @@ func (c *MockSwitchableCruder_MustCurrentContextName_OngoingVerification) GetCap
 func (c *MockSwitchableCruder_MustCurrentContextName_OngoingVerification) GetAllCapturedArguments() {
 }
 
-func (verifier *VerifierMockSwitchableCruder) SetFieldSelector(_param0 string) *MockSwitchableCruder_SetFieldSelector_OngoingVerification {
-	params := []pegomock.Param{_param0}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "SetFieldSelector", params, verifier.timeout)
-	return &MockSwitchableCruder_SetFieldSelector_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
-
-type MockSwitchableCruder_SetFieldSelector_OngoingVerification struct {
-	mock              *MockSwitchableCruder
-	methodInvocations []pegomock.MethodInvocation
-}
-
-func (c *MockSwitchableCruder_SetFieldSelector_OngoingVerification) GetCapturedArguments() string {
-	_param0 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1]
-}
-
-func (c *MockSwitchableCruder_SetFieldSelector_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
-	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
-	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
-		for u, param := range params[0] {
-			_param0[u] = param.(string)
-		}
-	}
-	return
-}
-
-func (verifier *VerifierMockSwitchableCruder) SetLabelSelector(_param0 string) *MockSwitchableCruder_SetLabelSelector_OngoingVerification {
-	params := []pegomock.Param{_param0}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "SetLabelSelector", params, verifier.timeout)
-	return &MockSwitchableCruder_SetLabelSelector_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
-}
-
-type MockSwitchableCruder_SetLabelSelector_OngoingVerification struct {
-	mock              *MockSwitchableCruder
-	methodInvocations []pegomock.MethodInvocation
-}
-
-func (c *MockSwitchableCruder_SetLabelSelector_OngoingVerification) GetCapturedArguments() string {
-	_param0 := c.GetAllCapturedArguments()
-	return _param0[len(_param0)-1]
-}
-
-func (c *MockSwitchableCruder_SetLabelSelector_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
-	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
-	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
-		for u, param := range params[0] {
-			_param0[u] = param.(string)
-		}
-	}
-	return
-}
-
 func (verifier *VerifierMockSwitchableCruder) Switch(_param0 string) *MockSwitchableCruder_Switch_OngoingVerification {
 	params := []pegomock.Param{_param0}
 	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "Switch", params, verifier.timeout)
@@ -444,7 +283,7 @@ func (c *MockSwitchableCruder_Switch_OngoingVerification) GetCapturedArguments()
 func (c *MockSwitchableCruder_Switch_OngoingVerification) GetAllCapturedArguments() (_param0 []string) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
-		_param0 = make([]string, len(params[0]))
+		_param0 = make([]string, len(c.methodInvocations))
 		for u, param := range params[0] {
 			_param0[u] = param.(string)
 		}

--- a/internal/resource/no.go
+++ b/internal/resource/no.go
@@ -8,6 +8,7 @@ import (
 	"github.com/derailed/k9s/internal/k8s"
 	"github.com/rs/zerolog/log"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	mv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
 
@@ -68,8 +69,8 @@ func (r *Node) SetNodeMetrics(m *mv1beta1.NodeMetrics) {
 }
 
 // List all resources for a given namespace.
-func (r *Node) List(ns string) (Columnars, error) {
-	nn, err := r.Resource.List(ns)
+func (r *Node) List(ns string, opts metav1.ListOptions) (Columnars, error) {
+	nn, err := r.Resource.List(ns, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resource/no_test.go
+++ b/internal/resource/no_test.go
@@ -62,7 +62,7 @@ func TestNodeMarshal(t *testing.T) {
 func TestNodeListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("-")).ThenReturn(k8s.Collection{*k8sNode()}, nil)
+	m.When(mr.List("-", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sNode()}, nil)
 	mx := NewMockMetricsServer()
 	m.When(mx.HasMetrics()).ThenReturn(true)
 	m.When(mx.FetchNodesMetrics()).
@@ -75,7 +75,7 @@ func TestNodeListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("-")
+	mr.VerifyWasCalled(m.Times(2)).List("-", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, resource.NotNamespaced, l.GetNamespace())

--- a/internal/resource/ns_test.go
+++ b/internal/resource/ns_test.go
@@ -57,7 +57,7 @@ func TestNamespaceMarshal(t *testing.T) {
 func TestNamespaceListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List(resource.NotNamespaced)).ThenReturn(k8s.Collection{*k8sNamespace()}, nil)
+	m.When(mr.List(resource.NotNamespaced, metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sNamespace()}, nil)
 
 	l := NewNamespaceListWithArgs("-", NewNamespaceWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -66,7 +66,7 @@ func TestNamespaceListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)
+	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced, metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, resource.NotNamespaced, l.GetNamespace())

--- a/internal/resource/pdb_test.go
+++ b/internal/resource/pdb_test.go
@@ -56,7 +56,7 @@ func TestPDBMarshal(t *testing.T) {
 func TestPDBListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sPDB()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sPDB()}, nil)
 
 	l := NewPDBListWithArgs("blee", NewPDBWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -65,7 +65,7 @@ func TestPDBListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/pod.go
+++ b/internal/resource/pod.go
@@ -219,8 +219,8 @@ func readLogs(ctx context.Context, stream io.ReadCloser, c chan<- string, opts L
 }
 
 // List resources for a given namespace.
-func (r *Pod) List(ns string) (Columnars, error) {
-	pods, err := r.Resource.List(ns)
+func (r *Pod) List(ns string, opts metav1.ListOptions) (Columnars, error) {
+	pods, err := r.Resource.List(ns, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resource/pod_test.go
+++ b/internal/resource/pod_test.go
@@ -105,7 +105,7 @@ func TestPodMarshal(t *testing.T) {
 func TestPodListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*makePod()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*makePod()}, nil)
 	mx := NewMockMetricsServer()
 	m.When(mx.HasMetrics()).ThenReturn(true)
 	m.When(mx.FetchPodsMetrics("blee")).
@@ -118,7 +118,7 @@ func TestPodListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/pv_test.go
+++ b/internal/resource/pv_test.go
@@ -56,7 +56,7 @@ func TestPVMarshal(t *testing.T) {
 func TestPVListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List(resource.NotNamespaced)).ThenReturn(k8s.Collection{*k8sPV()}, nil)
+	m.When(mr.List(resource.NotNamespaced, metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sPV()}, nil)
 
 	l := NewPVListWithArgs("-", NewPVWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -65,7 +65,7 @@ func TestPVListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)
+	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced, metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, resource.NotNamespaced, l.GetNamespace())

--- a/internal/resource/pvc_test.go
+++ b/internal/resource/pvc_test.go
@@ -57,7 +57,7 @@ func TestPVCMarshal(t *testing.T) {
 func TestPVCListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sPVC()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sPVC()}, nil)
 
 	l := NewPVCListWithArgs("blee", NewPVCWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -66,7 +66,7 @@ func TestPVCListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/rc_test.go
+++ b/internal/resource/rc_test.go
@@ -57,7 +57,7 @@ func TestRCMarshal(t *testing.T) {
 func TestRCListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sRC()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sRC()}, nil)
 
 	l := NewRCListWithArgs("blee", NewRCWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -66,7 +66,7 @@ func TestRCListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/ro_binding_test.go
+++ b/internal/resource/ro_binding_test.go
@@ -37,7 +37,7 @@ func TestRBMarshal(t *testing.T) {
 func TestRBListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sRB()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sRB()}, nil)
 
 	l := NewRBListWithArgs("blee", NewRBWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -46,7 +46,7 @@ func TestRBListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/ro_test.go
+++ b/internal/resource/ro_test.go
@@ -36,7 +36,7 @@ func TestRoleMarshal(t *testing.T) {
 func TestRoleListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sRole()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sRole()}, nil)
 
 	l := NewRoleListWithArgs("blee", NewRoleWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -45,7 +45,7 @@ func TestRoleListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/rs_test.go
+++ b/internal/resource/rs_test.go
@@ -36,7 +36,7 @@ func TestReplicaSetMarshal(t *testing.T) {
 func TestReplicaSetListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sReplicaSet()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sReplicaSet()}, nil)
 
 	l := NewReplicaSetListWithArgs("blee", NewReplicaSetWithArgs(mc, mr))
 	// Make sure we can get deltas!
@@ -45,7 +45,7 @@ func TestReplicaSetListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/sa_test.go
+++ b/internal/resource/sa_test.go
@@ -73,7 +73,7 @@ func TestSAMarshal(t *testing.T) {
 func TestSAListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sSA()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sSA()}, nil)
 
 	l := NewServiceAccountListWithArgs("blee", NewServiceAccountWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -82,7 +82,7 @@ func TestSAListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/sc_test.go
+++ b/internal/resource/sc_test.go
@@ -56,7 +56,7 @@ func TestSCMarshal(t *testing.T) {
 func TestSCListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List(resource.NotNamespaced)).ThenReturn(k8s.Collection{*k8sSC()}, nil)
+	m.When(mr.List(resource.NotNamespaced, metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sSC()}, nil)
 
 	l := NewSCListWithArgs("-", NewSCWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -65,7 +65,7 @@ func TestSCListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced)
+	mr.VerifyWasCalled(m.Times(2)).List(resource.NotNamespaced, metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, resource.NotNamespaced, l.GetNamespace())

--- a/internal/resource/sts_test.go
+++ b/internal/resource/sts_test.go
@@ -74,7 +74,7 @@ func TestSTSMarshal(t *testing.T) {
 func TestSTSListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sSTS()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sSTS()}, nil)
 
 	l := NewStatefulSetListWithArgs("blee", NewStatefulSetWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -83,7 +83,7 @@ func TestSTSListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/resource/svc_test.go
+++ b/internal/resource/svc_test.go
@@ -85,7 +85,7 @@ func TestSVCMarshal(t *testing.T) {
 func TestSVCListData(t *testing.T) {
 	mc := NewMockConnection()
 	mr := NewMockCruder()
-	m.When(mr.List("blee")).ThenReturn(k8s.Collection{*k8sSVC()}, nil)
+	m.When(mr.List("blee", metav1.ListOptions{})).ThenReturn(k8s.Collection{*k8sSVC()}, nil)
 
 	l := NewServiceListWithArgs("blee", NewServiceWithArgs(mc, mr))
 	// Make sure we mrn get deltas!
@@ -94,7 +94,7 @@ func TestSVCListData(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	mr.VerifyWasCalled(m.Times(2)).List("blee")
+	mr.VerifyWasCalled(m.Times(2)).List("blee", metav1.ListOptions{})
 	td := l.Data()
 	assert.Equal(t, 1, len(td.Rows))
 	assert.Equal(t, "blee", l.GetNamespace())

--- a/internal/views/registrar.go
+++ b/internal/views/registrar.go
@@ -44,7 +44,7 @@ var aliases = config.NewAliases()
 func allCRDs(c k8s.Connection, vv viewers) {
 	crds, err := resource.NewCustomResourceDefinitionList(c, resource.AllNamespaces).
 		Resource().
-		List(resource.AllNamespaces)
+		List(resource.AllNamespaces, metav1.ListOptions{})
 	if err != nil {
 		log.Error().Err(err).Msg("CRDs load fail")
 		return


### PR DESCRIPTION
This greatly simplifies the `Cruder` Interface. Moving the allocation of the `metav1.ListOptions` to the calleer of the `List` method. 

Now the  `list` struct is responsible to holding the label and filter selector.

This is the start for us having a simpler way to configure our filter and tackle down the #336 