### PR TITLE
wait for refresh to finish before queue another one

### DIFF
--- a/internal/views/resource.go
+++ b/internal/views/resource.go
@@ -118,9 +118,10 @@ func (v *resourceView) update(ctx context.Context) {
 				log.Debug().Msgf("%s updater canceled!", v.list.GetName())
 				return
 			case <-time.After(time.Duration(v.app.Config.K9s.GetRefreshRate()) * time.Second):
-				v.app.QueueUpdateDraw(func() {
+				done := QueueUpdateDraw(v.app.Application, func() {
 					v.refresh()
 				})
+				<-done
 			}
 		}
 	}(ctx)


### PR DESCRIPTION
If the `resource.update()` or `app.clusterUpdater()` (that are queue synchronously to the tview.app) runs slowly it start to queueing up and slowing down k9s.

This wraps the `QueueUpdateDraw` with a channel to send a signal when the update has been finished, making sure the next update will run `refreshTime` seconds _after_  the last one has been finished.