### PR TITLE
add an option to make the current filter sticky

### DIFF
--- a/internal/filters/filter.go
+++ b/internal/filters/filter.go
@@ -1,0 +1,50 @@
+package filters
+
+import "strings"
+
+const (
+	labelPrefixLegacy = "-l"
+	labelPrefix       = "l:"
+
+	fuzzyPrefixLegacy = "-f"
+	fuzzyPrefix       = "f:"
+)
+
+type Filter struct {
+	Query           string
+	IsLabelSelector bool
+	IsFuzzy         bool
+	Sticky          bool
+}
+
+// LabelSelector extract the query without the label selector prefix.
+// If the query is not sticky, returns the same query and false.
+func LabelSelector(filter string) (string, bool) {
+	// maintain compatibility with the current `-l` label selector prefix.
+	filter, ok := HasPrefixAndTrim(filter, labelPrefixLegacy)
+	if ok {
+		return filter, ok
+	}
+
+	return HasPrefixAndTrim(filter, labelPrefix)
+}
+
+// FuzzyFilter extract the query without the fuzzy filter prefix.
+// If the query is not sticky, returns the same query and false.
+func FuzzyFilter(filter string) (string, bool) {
+	// maintain compatibility with the current `-f` fuzzy filter prefix.
+	filter, ok := HasPrefixAndTrim(filter, fuzzyPrefix)
+	if ok {
+		return filter, ok
+	}
+
+	return HasPrefixAndTrim(filter, fuzzyPrefixLegacy)
+}
+
+func HasPrefixAndTrim(filter, prefix string) (string, bool) {
+	if strings.HasPrefix(filter, prefix) {
+		return strings.TrimSpace(strings.TrimPrefix(filter, prefix)), true
+	}
+
+	return filter, false
+}

--- a/internal/filters/filter_test.go
+++ b/internal/filters/filter_test.go
@@ -1,0 +1,72 @@
+package filters
+
+import (
+	"testing"
+)
+
+func TestFilter(t *testing.T) {
+	uu := map[string]struct {
+		filter        string
+		parsedFilter  string
+		regex         bool
+		fuzzy         bool
+		labelSelector bool
+	}{
+		"basic filter": {
+			filter:       "my_app",
+			parsedFilter: "my_app",
+			regex:        false,
+		},
+
+		"labelSelector/cool": {
+			filter:        "l: app=my_app,env=prod",
+			parsedFilter:  "app=my_app,env=prod",
+			labelSelector: true,
+		},
+		"labelSelector/noSpace": {
+			filter:        "l:app=my_app,env=prod",
+			parsedFilter:  "app=my_app,env=prod",
+			labelSelector: true,
+		},
+		"labelSelector/legacyLabelSelector": {
+			filter:        "-l app=my_app,env=prod",
+			parsedFilter:  "app=my_app,env=prod",
+			labelSelector: true,
+		},
+
+		"fuzzy/cool": {
+			filter:       "f:my_app",
+			parsedFilter: "my_app",
+			fuzzy:        true,
+		},
+		"fuzzy/noSpace": {
+			filter:       "f: my_app",
+			parsedFilter: "my_app",
+			fuzzy:        true,
+		},
+		"fuzzy/legacyLabelSelector": {
+			filter:       "-fmy_app",
+			parsedFilter: "my_app",
+			fuzzy:        true,
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			parsedFilter, isLabelSelector := LabelSelector(u.filter)
+			parsedFilter, isFuzzyFilter := FuzzyFilter(parsedFilter)
+
+			if isFuzzyFilter != u.fuzzy {
+				t.Fatalf("Wrong fuzzy modifier. Expected '%v' got '%v'", u.fuzzy, isFuzzyFilter)
+			}
+
+			if isLabelSelector != u.labelSelector {
+				t.Fatalf("Wrong label selector modifier. Expected '%v' got '%v'", u.fuzzy, isFuzzyFilter)
+			}
+
+			if parsedFilter != u.parsedFilter {
+				t.Fatalf("Expected parsed filter to be '%s' got '%s'", u.parsedFilter, parsedFilter)
+			}
+		})
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -54,7 +54,7 @@ func NewApp() *App {
 		actions:     make(KeyActions),
 		pages:       tview.NewPages(),
 		content:     tview.NewPages(),
-		cmdBuff:     NewCmdBuff(':', CommandBuff),
+		cmdBuff:     NewCmdBuff(CommandBuff),
 	}
 
 	s.RefreshStyles()

--- a/internal/ui/cmd_buff.go
+++ b/internal/ui/cmd_buff.go
@@ -26,31 +26,18 @@ type (
 	CmdBuff struct {
 		buff      []rune
 		kind      BufferKind
-		sticky    bool
-		hotKey    rune
 		active    bool
 		listeners []BuffWatcher
 	}
 )
 
 // NewCmdBuff returns a new command buffer.
-func NewCmdBuff(key rune, kind BufferKind) *CmdBuff {
+func NewCmdBuff(kind BufferKind) *CmdBuff {
 	return &CmdBuff{
-		hotKey:    key,
 		kind:      kind,
 		buff:      make([]rune, 0, maxBuff),
 		listeners: []BuffWatcher{},
 	}
-}
-
-// IsSticky checks if the cmd is going to perist or not.
-func (c *CmdBuff) IsSticky() bool {
-	return c.sticky
-}
-
-// SetSticky returns cmd stickness.
-func (c *CmdBuff) SetSticky(b bool) {
-	c.sticky = b
 }
 
 // IsActive checks if command buffer is active.

--- a/internal/ui/cmd_buff_test.go
+++ b/internal/ui/cmd_buff_test.go
@@ -25,7 +25,7 @@ func (l *testListener) BufferActive(s bool, _ BufferKind) {
 }
 
 func TestCmdBuffActivate(t *testing.T) {
-	b, l := NewCmdBuff('>', CommandBuff), testListener{}
+	b, l := NewCmdBuff(CommandBuff), testListener{}
 	b.AddListener(&l)
 
 	b.SetActive(true)
@@ -35,7 +35,7 @@ func TestCmdBuffActivate(t *testing.T) {
 }
 
 func TestCmdBuffDeactivate(t *testing.T) {
-	b, l := NewCmdBuff('>', CommandBuff), testListener{}
+	b, l := NewCmdBuff(CommandBuff), testListener{}
 	b.AddListener(&l)
 
 	b.SetActive(false)
@@ -45,7 +45,7 @@ func TestCmdBuffDeactivate(t *testing.T) {
 }
 
 func TestCmdBuffChanged(t *testing.T) {
-	b, l := NewCmdBuff('>', CommandBuff), testListener{}
+	b, l := NewCmdBuff(CommandBuff), testListener{}
 	b.AddListener(&l)
 
 	b.Add('b')
@@ -77,7 +77,7 @@ func TestCmdBuffChanged(t *testing.T) {
 }
 
 func TestCmdBuffAdd(t *testing.T) {
-	b := NewCmdBuff('>', CommandBuff)
+	b := NewCmdBuff(CommandBuff)
 
 	uu := []struct {
 		runes []rune
@@ -98,7 +98,7 @@ func TestCmdBuffAdd(t *testing.T) {
 }
 
 func TestCmdBuffDel(t *testing.T) {
-	b := NewCmdBuff('>', CommandBuff)
+	b := NewCmdBuff(CommandBuff)
 
 	uu := []struct {
 		runes []rune
@@ -120,7 +120,7 @@ func TestCmdBuffDel(t *testing.T) {
 }
 
 func TestCmdBuffEmpty(t *testing.T) {
-	b := NewCmdBuff('>', CommandBuff)
+	b := NewCmdBuff(CommandBuff)
 
 	uu := []struct {
 		runes []rune

--- a/internal/ui/table_helper.go
+++ b/internal/ui/table_helper.go
@@ -12,21 +12,18 @@ import (
 )
 
 const (
-	titleFmt          = "[fg:bg:b] %s[fg:bg:-][[count:bg:b]%d[fg:bg:-]] "
-	searchFmt         = "<[filter:bg:r]/%s[fg:bg:-]> "
-	nsTitleFmt        = "[fg:bg:b] %s([hilite:bg:b]%s[fg:bg:-])[fg:bg:-][[count:bg:b]%d[fg:bg:-]][fg:bg:-] "
-	labelSelIndicator = "-l"
-	descIndicator     = "↓"
-	ascIndicator      = "↑"
-	fullFmat          = "%s-%s-%d.csv"
-	noNSFmat          = "%s-%d.csv"
+	titleFmt      = "[fg:bg:b] %s[fg:bg:-][[count:bg:b]%d[fg:bg:-]] "
+	searchFmt     = "<[filter:bg:r]%s/%s[fg:bg:-]> "
+	nsTitleFmt    = "[fg:bg:b] %s([hilite:bg:b]%s[fg:bg:-])[fg:bg:-][[count:bg:b]%d[fg:bg:-]][fg:bg:-] "
+	descIndicator = "↓"
+	ascIndicator  = "↑"
+	fullFmat      = "%s-%s-%d.csv"
+	noNSFmat      = "%s-%d.csv"
 )
 
 var (
-	cpuRX    = regexp.MustCompile(`\A.{0,1}CPU`)
-	memRX    = regexp.MustCompile(`\A.{0,1}MEM`)
-	labelCmd = regexp.MustCompile(`\A\-l`)
-	fuzzyCmd = regexp.MustCompile(`\A\-f`)
+	cpuRX = regexp.MustCompile(`\A.{0,1}CPU`)
+	memRX = regexp.MustCompile(`\A.{0,1}MEM`)
 )
 
 type cleanseFn func(string) string
@@ -39,24 +36,6 @@ func TrimCell(tv *Table, row, col int) string {
 		return ""
 	}
 	return strings.TrimSpace(c.Text)
-}
-
-func isLabelSelector(s string) bool {
-	if s == "" {
-		return false
-	}
-	return labelCmd.MatchString(s)
-}
-
-func isFuzzySelector(s string) bool {
-	if s == "" {
-		return false
-	}
-	return fuzzyCmd.MatchString(s)
-}
-
-func trimLabelSelector(s string) string {
-	return strings.TrimSpace(s[2:])
 }
 
 func skinTitle(fmat string, style config.Frame) string {

--- a/internal/ui/table_helper.go
+++ b/internal/ui/table_helper.go
@@ -17,8 +17,6 @@ const (
 	nsTitleFmt    = "[fg:bg:b] %s([hilite:bg:b]%s[fg:bg:-])[fg:bg:-][[count:bg:b]%d[fg:bg:-]][fg:bg:-] "
 	descIndicator = "↓"
 	ascIndicator  = "↑"
-	fullFmat      = "%s-%s-%d.csv"
-	noNSFmat      = "%s-%d.csv"
 )
 
 var (

--- a/internal/views/app_test.go
+++ b/internal/views/app_test.go
@@ -11,6 +11,6 @@ func TestNewApp(t *testing.T) {
 	a := NewApp(config.NewConfig(ks{}))
 	a.Init("blee", 10)
 
-	assert.Equal(t, 11, len(a.GetActions()))
+	assert.Equal(t, 12, len(a.GetActions()))
 	assert.Equal(t, false, a.HasSkins)
 }

--- a/internal/views/details.go
+++ b/internal/views/details.go
@@ -56,7 +56,7 @@ func newDetailsView(app *appView, backFn ui.ActionHandler) *detailsView {
 	v.SetTitleColor(tcell.ColorAqua)
 	v.SetInputCapture(v.keyboard)
 
-	v.cmdBuff = ui.NewCmdBuff('/', ui.FilterBuff)
+	v.cmdBuff = ui.NewCmdBuff(ui.FilterBuff)
 	v.cmdBuff.AddListener(app.Cmd())
 	v.cmdBuff.Reset()
 

--- a/internal/views/resource.go
+++ b/internal/views/resource.go
@@ -55,7 +55,7 @@ func newResourceView(title, gvr string, app *appView, list resource.List) resour
 // Init watches all running pods in given namespace
 func (v *resourceView) Init(ctx context.Context, ns string) {
 	v.masterDetail.init(ctx, ns)
-	v.masterPage().setFilterFn(v.filterResource)
+	v.masterPage().setLabelFilterFn(v.filterResource)
 	if v.colorerFn != nil {
 		v.masterPage().SetColorerFn(v.colorerFn)
 	}

--- a/internal/views/table_helper.go
+++ b/internal/views/table_helper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -15,21 +14,11 @@ import (
 )
 
 const (
-	titleFmt      = "[fg:bg:b] %s[fg:bg:-][[count:bg:b]%d[fg:bg:-]] "
-	searchFmt     = "<[filter:bg:r]/%s[fg:bg:-]> "
-	nsTitleFmt    = "[fg:bg:b] %s([hilite:bg:b]%s[fg:bg:-])[fg:bg:-][[count:bg:b]%d[fg:bg:-]][fg:bg:-] "
-	descIndicator = "↓"
-	ascIndicator  = "↑"
-	fullFmat      = "%s-%s-%d.csv"
-	noNSFmat      = "%s-%d.csv"
+	searchFmt  = "<[filter:bg:r]/%s[fg:bg:-]> "
+	nsTitleFmt = "[fg:bg:b] %s([hilite:bg:b]%s[fg:bg:-])[fg:bg:-][[count:bg:b]%d[fg:bg:-]][fg:bg:-] "
+	fullFmat   = "%s-%s-%d.csv"
+	noNSFmat   = "%s-%d.csv"
 )
-
-var (
-	cpuRX = regexp.MustCompile(`\A.{0,1}CPU`)
-	memRX = regexp.MustCompile(`\A.{0,1}MEM`)
-)
-
-type cleanseFn func(string) string
 
 func trimCellRelative(tv *tableView, row, col int) string {
 	return ui.TrimCell(tv.Table, row, tv.NameColIndex()+col)

--- a/internal/views/table_helper.go
+++ b/internal/views/table_helper.go
@@ -15,20 +15,18 @@ import (
 )
 
 const (
-	titleFmt          = "[fg:bg:b] %s[fg:bg:-][[count:bg:b]%d[fg:bg:-]] "
-	searchFmt         = "<[filter:bg:r]/%s[fg:bg:-]> "
-	nsTitleFmt        = "[fg:bg:b] %s([hilite:bg:b]%s[fg:bg:-])[fg:bg:-][[count:bg:b]%d[fg:bg:-]][fg:bg:-] "
-	labelSelIndicator = "-l"
-	descIndicator     = "↓"
-	ascIndicator      = "↑"
-	fullFmat          = "%s-%s-%d.csv"
-	noNSFmat          = "%s-%d.csv"
+	titleFmt      = "[fg:bg:b] %s[fg:bg:-][[count:bg:b]%d[fg:bg:-]] "
+	searchFmt     = "<[filter:bg:r]/%s[fg:bg:-]> "
+	nsTitleFmt    = "[fg:bg:b] %s([hilite:bg:b]%s[fg:bg:-])[fg:bg:-][[count:bg:b]%d[fg:bg:-]][fg:bg:-] "
+	descIndicator = "↓"
+	ascIndicator  = "↑"
+	fullFmat      = "%s-%s-%d.csv"
+	noNSFmat      = "%s-%d.csv"
 )
 
 var (
-	cpuRX    = regexp.MustCompile(`\A.{0,1}CPU`)
-	memRX    = regexp.MustCompile(`\A.{0,1}MEM`)
-	labelCmd = regexp.MustCompile(`\A\-l`)
+	cpuRX = regexp.MustCompile(`\A.{0,1}CPU`)
+	memRX = regexp.MustCompile(`\A.{0,1}MEM`)
 )
 
 type cleanseFn func(string) string
@@ -84,17 +82,6 @@ func saveTable(cluster, name string, data resource.TableData) (string, error) {
 	}
 
 	return path, nil
-}
-
-func isLabelSelector(s string) bool {
-	if s == "" {
-		return false
-	}
-	return labelCmd.MatchString(s)
-}
-
-func trimLabelSelector(s string) string {
-	return strings.TrimSpace(s[2:])
 }
 
 func skinTitle(fmat string, style config.Frame) string {

--- a/internal/views/table_test.go
+++ b/internal/views/table_test.go
@@ -112,39 +112,6 @@ func TestTableViewSort(t *testing.T) {
 	assert.Equal(t, "fred ", v.GetCell(1, 1).Text)
 }
 
-func TestIsSelector(t *testing.T) {
-	uu := map[string]struct {
-		sel string
-		e   bool
-	}{
-		"cool":       {"-l app=fred,env=blee", true},
-		"noMode":     {"app=fred,env=blee", false},
-		"noSpace":    {"-lapp=fred,env=blee", true},
-		"wrongLabel": {"-f app=fred,env=blee", false},
-	}
-
-	for k, u := range uu {
-		t.Run(k, func(t *testing.T) {
-			assert.Equal(t, u.e, isLabelSelector(u.sel))
-		})
-	}
-}
-
-func TestTrimLabelSelector(t *testing.T) {
-	uu := map[string]struct {
-		sel, e string
-	}{
-		"cool":    {"-l app=fred,env=blee", "app=fred,env=blee"},
-		"noSpace": {"-lapp=fred,env=blee", "app=fred,env=blee"},
-	}
-
-	for k, u := range uu {
-		t.Run(k, func(t *testing.T) {
-			assert.Equal(t, u.e, trimLabelSelector(u.sel))
-		})
-	}
-}
-
 func BenchmarkTitleReplace(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()


### PR DESCRIPTION
This is an attempt to fix the sticky filter problem. Closes #336.

**First Attempt** 
At first, I thought about creating a prefix in the same way of the fuzzy search. It would be something along the lines of `s: my_app` and it would be able to chain `s:-fmy_app` for doing a sticky fuzzy search.

But I didn't quite liked the UX, if one forgot to put this it would need to clear the filter and type it adding the `s:` prefix.

**Solution implemented**
In the end, I've create another command (Ctrl+f, this could be discussed) that makes the current filter sticky or not. If you want to make a filter that will sticky you should:
1. filter something out with `/my_app`;
2. make the filter sticky with `ctrl+f`;
3. now you can change resources as many times you want with the same filter;
4. If want to "unsticky" the filter, you can reset the filter with `esc` or pressing `Ctrl+f` again.

**Others things done in this PR:**
1. As this started with a prefix solution, I've refactored a little bit the filter (isLabelSelector, IsFuzzy and so on) methods and changed the LabelSelector filter to the prefix `l:` and fuzzy to `f:`. I thought it looks clearer `f:my_app` than `-fmy_app` for example.

2. fix lint errors on some of the changed files that the golangci bot has complained about :)