### PR TITLE
Add Q key as back key (same as ESC)

### DIFF
--- a/internal/views/container.go
+++ b/internal/views/container.go
@@ -47,6 +47,7 @@ func (v *containerView) extraActions(aa ui.KeyActions) {
 	aa[ui.KeyShiftL] = ui.NewKeyAction("Logs Previous", v.prevLogsCmd, true)
 	aa[ui.KeyS] = ui.NewKeyAction("Shell", v.shellCmd, true)
 	aa[tcell.KeyEscape] = ui.NewKeyAction("Back", v.backCmd, false)
+	aa[ui.KeyQ] = ui.NewKeyAction("Back", v.backCmd, false)
 	aa[ui.KeyP] = ui.NewKeyAction("Previous", v.backCmd, false)
 	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", v.sortColCmd(6, false), false)
 	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", v.sortColCmd(7, false), false)

--- a/internal/views/details.go
+++ b/internal/views/details.go
@@ -75,6 +75,7 @@ func (v *detailsView) bindKeys() {
 		tcell.KeyBackspace:  ui.NewKeyAction("Erase", v.eraseCmd, false),
 		tcell.KeyDelete:     ui.NewKeyAction("Erase", v.eraseCmd, false),
 		tcell.KeyEscape:     ui.NewKeyAction("Back", v.backCmd, true),
+		ui.KeyQ:             ui.NewKeyAction("Back", v.backCmd, true),
 		tcell.KeyTab:        ui.NewKeyAction("Next Match", v.nextCmd, false),
 		tcell.KeyBacktab:    ui.NewKeyAction("Previous Match", v.prevCmd, false),
 		tcell.KeyCtrlS:      ui.NewKeyAction("Save", v.saveCmd, true),

--- a/internal/views/log.go
+++ b/internal/views/log.go
@@ -81,6 +81,7 @@ func newLogView(_ string, app *appView, backFn ui.ActionHandler) *logView {
 func (v *logView) bindKeys() {
 	v.actions = ui.KeyActions{
 		tcell.KeyEscape: ui.NewKeyAction("Back", v.backCmd, true),
+		ui.KeyQ:         ui.NewKeyAction("Back", v.backCmd, true),
 		ui.KeyC:         ui.NewKeyAction("Clear", v.clearCmd, true),
 		ui.KeyS:         ui.NewKeyAction("Toggle AutoScroll", v.toggleScrollCmd, true),
 		ui.KeyG:         ui.NewKeyAction("Top", v.topCmd, false),

--- a/internal/views/pod.go
+++ b/internal/views/pod.go
@@ -41,6 +41,7 @@ func newPodView(title, gvr string, app *appView, list resource.List) resourceVie
 	{
 		picker.setActions(ui.KeyActions{
 			tcell.KeyEscape: {Description: "Back", Action: v.backCmd, Visible: true},
+			ui.KeyQ:         {Description: "Back", Action: v.backCmd, Visible: true},
 		})
 	}
 	v.AddPage("picker", picker, true, false)


### PR DESCRIPTION
I kept hitting the q-key to get back to the previous view as this is how most stuff works with vim-mappings, but it didn't work with k9s. I didn't add it as a quit key as that might be too easy to hit and accidentally quit k9s. I guess this would require some confirmation if you really want to quit.