### PR TITLE
Change the event name to event type

### DIFF
--- a/internal/resource/evt.go
+++ b/internal/resource/evt.go
@@ -76,7 +76,7 @@ func (*Event) Header(ns string) Row {
 		ff = append(ff, "NAMESPACE")
 	}
 
-	return append(ff, "NAME", "REASON", "SOURCE", "COUNT", "MESSAGE", "AGE")
+	return append(ff, "TYPE", "REASON", "SOURCE", "COUNT", "MESSAGE", "AGE")
 }
 
 var rx = regexp.MustCompile(`(.+)\.(.+)`)
@@ -91,7 +91,7 @@ func (r *Event) Fields(ns string) Row {
 	}
 
 	return append(ff,
-		i.Name,
+		i.Type,
 		i.Reason,
 		i.Source.Component,
 		strconv.Itoa(int(i.Count)),

--- a/internal/resource/evt_test.go
+++ b/internal/resource/evt_test.go
@@ -38,7 +38,7 @@ func TestEventAccess(t *testing.T) {
 
 func TestEventFields(t *testing.T) {
 	r := newEvent().Fields("blee")
-	assert.Equal(t, resource.Row{"fred", "blah", "", "1"}, r[:4])
+	assert.Equal(t, resource.Row{"Normal", "blah", "", "1"}, r[:4])
 }
 
 func TestEventMarshal(t *testing.T) {
@@ -74,7 +74,7 @@ func TestEventData(t *testing.T) {
 	for _, d := range row.Deltas {
 		assert.Equal(t, "", d)
 	}
-	assert.Equal(t, resource.Row{"fred"}, row.Fields[:1])
+	assert.Equal(t, resource.Row{"Normal"}, row.Fields[:1])
 }
 
 // Helpers...
@@ -86,6 +86,7 @@ func k8sEvent() *v1.Event {
 			Name:              "fred",
 			CreationTimestamp: metav1.Time{Time: testTime()},
 		},
+		Type:    "Normal",
 		Reason:  "blah",
 		Message: "blee",
 		Count:   1,
@@ -114,5 +115,6 @@ reason: blah
 reportingComponent: ""
 reportingInstance: ""
 source: {}
+type: Normal
 `
 }


### PR DESCRIPTION
The `v1.Event` name is usually a [unique name](https://github.com/kubernetes/client-go/blob/master/tools/record/event.go#L362) not important to display.

I think that The `TYPE` filed is more important, that shows if the is a "Normal" event or "Warning" etc..

The standard `kubectl get events` is:

```
LAST SEEN   TYPE      REASON              OBJECT                                                             MESSAGE
4m25s       Normal    Pulling             pod/alertmanager-wobbling-parrot-prometheus-alertmanager-0         Pulling image "quay.io/prometheus/alertmanager:v0.19.0"
3m13s       Normal    Pulled              pod/alertmanager-wobbling-parrot-prometheus-alertmanager-0         Successfully pulled image "quay.io/prometheus/alertmanager:v0.19.0"
3m13s       Normal    Created             pod/alertmanager-wobbling-parrot-prometheus-alertmanager-0         Created container alertmanager
3m13s       Normal    Started             pod/alertmanager-wobbling-parrot-prometheus-alertmanager-0         Started container alertmanager
3m13s       Normal    Pulling             pod/alertmanager-wobbling-parrot-prometheus-alertmanager-0         Pulling image "quay.io/coreos/configmap-reload:v0.0.1"
2m37s       Normal    Pulled              pod/alertmanager-wobbling-parrot-prometheus-alertmanager-0         Successfully pulled image "quay.io/coreos/configmap-reload:v0.0.1"
2m37s       Normal    Created             pod/alertmanager-wobbling-parrot-prometheus-alertmanager-0         Created container config-reloader
```


With this PR the UI will be:

![after_event](https://user-images.githubusercontent.com/386987/70279680-3e4e6300-17b7-11ea-9233-b92354455bd8.png)

instead of:

![before](https://user-images.githubusercontent.com/386987/70279707-4a3a2500-17b7-11ea-8729-4d5b84db29c6.png)



