### PR TITLE
Add log shortcut to full-screen mode + no wrap mode

### DIFF
--- a/internal/views/log_test.go
+++ b/internal/views/log_test.go
@@ -32,9 +32,9 @@ func TestLogViewFlush(t *testing.T) {
 
 	v.toggleScrollCmd(nil)
 	assert.Equal(t, "blee\nbozo\n", v.logs.GetText(true))
-	assert.Equal(t, " Autoscroll: Off ", v.status.GetText(true))
+	assert.Equal(t, " Autoscroll: Off  FullScreen: Off  TextWrap: On    ", v.status.GetText(true))
 	v.toggleScrollCmd(nil)
-	assert.Equal(t, " Autoscroll: On  ", v.status.GetText(true))
+	assert.Equal(t, " Autoscroll: On   FullScreen: Off  TextWrap: On    ", v.status.GetText(true))
 }
 
 func TestLogViewSave(t *testing.T) {


### PR DESCRIPTION
Sometimes I want to see the logs full screen or I need to copy and paste some logs.
I found this issue and I knew headless mode. 
I think it is very useful though, but I'm glad if more full-screen.
https://github.com/derailed/k9s/issues/223

I propose the command to view the log in full-screen, and command for no wrap log.
I'd appreciate it if you could comment on this feature addition.

![image](https://user-images.githubusercontent.com/9666625/70807037-f86d4c80-1dff-11ea-9150-adeec1e325b7.png)

![image](https://user-images.githubusercontent.com/9666625/70807049-ff945a80-1dff-11ea-944b-4b0c3ca1777d.png)

![image](https://user-images.githubusercontent.com/9666625/70807221-6ca7f000-1e00-11ea-86fb-af0a1e1eca2d.png)

I use k9s every day useful.
Thank you for the awesome tool!  👍