### PR TITLE
Add ability to set skin colors by hex code

### DIFF
--- a/internal/config/style.go
+++ b/internal/config/style.go
@@ -327,12 +327,10 @@ func (s *Styles) Update() {
 
 // AsColor checks color index, if match return color otherwise pink it is.
 func AsColor(c string) tcell.Color {
-	if color, ok := tcell.ColorNames[c]; ok {
-		return color
-	} else {
-		// Use tcell.GetColor to support hex codes.
-		// "Creates a Color from a color name (W3C name). A hex value may be supplied as a string in the format "#ffffff"."
-		color := tcell.GetColor(c)
+	// Use tcell.GetColor to support hex codes.
+	// "Creates a Color from a color name (W3C name). A hex value may be supplied as a string in the format "#ffffff"."
+	if color := tcell.GetColor(c); color != -1 {
 		return color
 	}
+	return tcell.ColorPink
 }

--- a/internal/config/style.go
+++ b/internal/config/style.go
@@ -329,7 +329,10 @@ func (s *Styles) Update() {
 func AsColor(c string) tcell.Color {
 	if color, ok := tcell.ColorNames[c]; ok {
 		return color
+	} else {
+		// Use tcell.GetColor to support hex codes.
+		// "Creates a Color from a color name (W3C name). A hex value may be supplied as a string in the format "#ffffff"."
+		color := tcell.GetColor(c)
+		return color
 	}
-
-	return tcell.ColorPink
 }


### PR DESCRIPTION
I wanted to theme k9s to match my terminal theme, but I noticed I was limited to a small number of colors.

I have never written Go before, but this seems to work and was a fun learning exercise. This simply allows you to use hex codes in skin colors.

(Note: One weird bug is I cannot seem to make the black box around the table title disappear, or change the colors of some of meta-info in logs from purple)

![k9sthemesnazzy](https://user-images.githubusercontent.com/26604994/70884134-07d8cb00-1fa3-11ea-8609-5d76d52b8f75.gif)


