### PR TITLE
Invert column sort on subsequent "Sort <column>" key presses

### DIFF
--- a/internal/ui/sort.go
+++ b/internal/ui/sort.go
@@ -1,4 +1,4 @@
-package views
+package ui
 
 import "github.com/gdamore/tcell"
 

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -283,7 +283,22 @@ func (v *Table) doUpdate(data resource.TableData) {
 	v.sort(data, row)
 }
 
+func (v *Table) SortColumn(col int, asc bool) {
+	v.sortCol.asc = asc
+	switch col {
+	case -2:
+		v.sortCol.index = 0
+	case -1:
+		v.sortCol.index = v.GetColumnCount() - 1
+	default:
+		v.sortCol.index = v.NameColIndex() + col
+	}
+	v.Refresh()
+}
+
 // SortColCmd designates a sorted column.
+//
+// DEPRECATED: no
 func (v *Table) SortColCmd(col int) func(evt *tcell.EventKey) *tcell.EventKey {
 	return func(evt *tcell.EventKey) *tcell.EventKey {
 		v.sortCol.asc = !v.sortCol.asc

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -261,7 +261,7 @@ func (v *Table) Update(data resource.TableData) {
 func (v *Table) doUpdate(data resource.TableData) {
 	v.activeNS = data.Namespace
 	if v.activeNS == resource.AllNamespaces && v.activeNS != "*" {
-		v.actions[KeyShiftP] = NewKeyAction("Sort Namespace", v.SortColCmd(-2), false)
+		v.actions[KeyShiftP] = NewKeyAction("Sort Namespace", SortColCmd(v, -2, true), false)
 	} else {
 		delete(v.actions, KeyShiftP)
 	}
@@ -294,27 +294,6 @@ func (v *Table) SortColumn(col int, asc bool) {
 		v.sortCol.index = v.NameColIndex() + col
 	}
 	v.Refresh()
-}
-
-// SortColCmd designates a sorted column.
-//
-// DEPRECATED: no
-func (v *Table) SortColCmd(col int) func(evt *tcell.EventKey) *tcell.EventKey {
-	return func(evt *tcell.EventKey) *tcell.EventKey {
-		v.sortCol.asc = !v.sortCol.asc
-		switch col {
-		case -2:
-			v.sortCol.index = 0
-		case -1:
-			v.sortCol.index = v.GetColumnCount() - 1
-		default:
-			v.sortCol.index = v.NameColIndex() + col
-
-		}
-		v.Refresh()
-
-		return nil
-	}
 }
 
 func (v *Table) adjustSorter(data resource.TableData) {

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -286,7 +286,7 @@ func (v *Table) doUpdate(data resource.TableData) {
 // SortColCmd designates a sorted column.
 func (v *Table) SortColCmd(col int) func(evt *tcell.EventKey) *tcell.EventKey {
 	return func(evt *tcell.EventKey) *tcell.EventKey {
-		v.sortCol.asc = true
+		v.sortCol.asc = !v.sortCol.asc
 		switch col {
 		case -2:
 			v.sortCol.index = 0

--- a/internal/views/alias.go
+++ b/internal/views/alias.go
@@ -56,9 +56,9 @@ func (v *aliasView) registerActions() {
 		tcell.KeyEnter:  ui.NewKeyAction("Goto", v.gotoCmd, true),
 		tcell.KeyEscape: ui.NewKeyAction("Reset", v.resetCmd, false),
 		ui.KeySlash:     ui.NewKeyAction("Filter", v.activateCmd, false),
-		ui.KeyShiftR:    ui.NewKeyAction("Sort Resource", v.SortColCmd(0), false),
-		ui.KeyShiftC:    ui.NewKeyAction("Sort Command", v.SortColCmd(1), false),
-		ui.KeyShiftA:    ui.NewKeyAction("Sort ApiGroup", v.SortColCmd(2), false),
+		ui.KeyShiftR:    ui.NewKeyAction("Sort Resource", ui.SortColCmd(v, 0, true), false),
+		ui.KeyShiftC:    ui.NewKeyAction("Sort Command", ui.SortColCmd(v, 1, true), false),
+		ui.KeyShiftA:    ui.NewKeyAction("Sort ApiGroup", ui.SortColCmd(v, 2, true), false),
 	})
 }
 

--- a/internal/views/bench.go
+++ b/internal/views/bench.go
@@ -97,16 +97,6 @@ func (v *benchView) getTitle() string {
 	return benchTitle
 }
 
-func (v *benchView) sortColCmd(col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {
-	return func(evt *tcell.EventKey) *tcell.EventKey {
-		tv := v.masterPage()
-		tv.SetSortCol(tv.NameColIndex()+col, 0, asc)
-		tv.Refresh()
-
-		return nil
-	}
-}
-
 func (v *benchView) enterCmd(evt *tcell.EventKey) *tcell.EventKey {
 	if v.masterPage().SearchBuff().IsActive() {
 		return v.masterPage().filterCmd(evt)

--- a/internal/views/container.go
+++ b/internal/views/container.go
@@ -48,10 +48,10 @@ func (v *containerView) extraActions(aa ui.KeyActions) {
 	aa[ui.KeyS] = ui.NewKeyAction("Shell", v.shellCmd, true)
 	aa[tcell.KeyEscape] = ui.NewKeyAction("Back", v.backCmd, false)
 	aa[ui.KeyP] = ui.NewKeyAction("Previous", v.backCmd, false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", sortColCmd(v, 6, false), false)
-	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", sortColCmd(v, 7, false), false)
-	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", sortColCmd(v, 8, false), false)
-	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", sortColCmd(v, 9, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", SortColCmd(v, 6, false), false)
+	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", SortColCmd(v, 7, false), false)
+	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", SortColCmd(v, 8, false), false)
+	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", SortColCmd(v, 9, false), false)
 }
 
 func (v *containerView) k9sEnv() K9sEnv {

--- a/internal/views/container.go
+++ b/internal/views/container.go
@@ -48,10 +48,10 @@ func (v *containerView) extraActions(aa ui.KeyActions) {
 	aa[ui.KeyS] = ui.NewKeyAction("Shell", v.shellCmd, true)
 	aa[tcell.KeyEscape] = ui.NewKeyAction("Back", v.backCmd, false)
 	aa[ui.KeyP] = ui.NewKeyAction("Previous", v.backCmd, false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", v.sortColCmd(6, false), false)
-	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", v.sortColCmd(7, false), false)
-	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", v.sortColCmd(8, false), false)
-	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", v.sortColCmd(9, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", sortColCmd(v, 6, false), false)
+	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", sortColCmd(v, 7, false), false)
+	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", sortColCmd(v, 8, false), false)
+	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", sortColCmd(v, 9, false), false)
 }
 
 func (v *containerView) k9sEnv() K9sEnv {

--- a/internal/views/container.go
+++ b/internal/views/container.go
@@ -48,10 +48,10 @@ func (v *containerView) extraActions(aa ui.KeyActions) {
 	aa[ui.KeyS] = ui.NewKeyAction("Shell", v.shellCmd, true)
 	aa[tcell.KeyEscape] = ui.NewKeyAction("Back", v.backCmd, false)
 	aa[ui.KeyP] = ui.NewKeyAction("Previous", v.backCmd, false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", SortColCmd(v, 6, false), false)
-	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", SortColCmd(v, 7, false), false)
-	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", SortColCmd(v, 8, false), false)
-	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", SortColCmd(v, 9, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", ui.SortColCmd(v, 6, false), false)
+	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", ui.SortColCmd(v, 7, false), false)
+	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", ui.SortColCmd(v, 8, false), false)
+	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", ui.SortColCmd(v, 9, false), false)
 }
 
 func (v *containerView) k9sEnv() K9sEnv {

--- a/internal/views/dp.go
+++ b/internal/views/dp.go
@@ -33,8 +33,8 @@ func (v *deployView) extraActions(aa ui.KeyActions) {
 	v.logResourceView.extraActions(aa)
 	v.scalableResourceView.extraActions(aa)
 	v.restartableResourceView.extraActions(aa)
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", sortColCmd(v, 1, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", sortColCmd(v, 2, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", SortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", SortColCmd(v, 2, false), false)
 }
 
 func (v *deployView) showPods(app *appView, _, res, sel string) {

--- a/internal/views/dp.go
+++ b/internal/views/dp.go
@@ -33,8 +33,8 @@ func (v *deployView) extraActions(aa ui.KeyActions) {
 	v.logResourceView.extraActions(aa)
 	v.scalableResourceView.extraActions(aa)
 	v.restartableResourceView.extraActions(aa)
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", SortColCmd(v, 1, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", SortColCmd(v, 2, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", ui.SortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", ui.SortColCmd(v, 2, false), false)
 }
 
 func (v *deployView) showPods(app *appView, _, res, sel string) {

--- a/internal/views/dp.go
+++ b/internal/views/dp.go
@@ -33,8 +33,8 @@ func (v *deployView) extraActions(aa ui.KeyActions) {
 	v.logResourceView.extraActions(aa)
 	v.scalableResourceView.extraActions(aa)
 	v.restartableResourceView.extraActions(aa)
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", v.sortColCmd(1, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", v.sortColCmd(2, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", sortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", sortColCmd(v, 2, false), false)
 }
 
 func (v *deployView) showPods(app *appView, _, res, sel string) {

--- a/internal/views/ds.go
+++ b/internal/views/ds.go
@@ -28,8 +28,8 @@ func newDaemonSetView(title, gvr string, app *appView, list resource.List) resou
 func (v *daemonSetView) extraActions(aa ui.KeyActions) {
 	v.logResourceView.extraActions(aa)
 	v.restartableResourceView.extraActions(aa)
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", sortColCmd(v, 1, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", sortColCmd(v, 2, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", SortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", SortColCmd(v, 2, false), false)
 }
 
 func (v *daemonSetView) showPods(app *appView, _, res, sel string) {

--- a/internal/views/ds.go
+++ b/internal/views/ds.go
@@ -28,8 +28,8 @@ func newDaemonSetView(title, gvr string, app *appView, list resource.List) resou
 func (v *daemonSetView) extraActions(aa ui.KeyActions) {
 	v.logResourceView.extraActions(aa)
 	v.restartableResourceView.extraActions(aa)
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", SortColCmd(v, 1, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", SortColCmd(v, 2, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", ui.SortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", ui.SortColCmd(v, 2, false), false)
 }
 
 func (v *daemonSetView) showPods(app *appView, _, res, sel string) {

--- a/internal/views/ds.go
+++ b/internal/views/ds.go
@@ -28,8 +28,8 @@ func newDaemonSetView(title, gvr string, app *appView, list resource.List) resou
 func (v *daemonSetView) extraActions(aa ui.KeyActions) {
 	v.logResourceView.extraActions(aa)
 	v.restartableResourceView.extraActions(aa)
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", v.sortColCmd(1, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", v.sortColCmd(2, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", sortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", sortColCmd(v, 2, false), false)
 }
 
 func (v *daemonSetView) showPods(app *appView, _, res, sel string) {

--- a/internal/views/dump.go
+++ b/internal/views/dump.go
@@ -100,7 +100,7 @@ func (v *dumpView) getTitle() string {
 	return dumpTitle
 }
 
-func (v *dumpView) sortColumn(col int, asc bool) {
+func (v *dumpView) SortColumn(col int, asc bool) {
 	tv := v.getTV()
 	tv.SetSortCol(tv.NameColIndex()+col, 0, asc)
 	tv.Refresh()

--- a/internal/views/dump.go
+++ b/internal/views/dump.go
@@ -100,6 +100,12 @@ func (v *dumpView) getTitle() string {
 	return dumpTitle
 }
 
+func (v *dumpView) sortColumn(col int, asc bool) {
+	tv := v.getTV()
+	tv.SetSortCol(tv.NameColIndex()+col, 0, asc)
+	tv.Refresh()
+}
+
 func (v *dumpView) sortColCmd(col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {
 	return func(evt *tcell.EventKey) *tcell.EventKey {
 		tv := v.getTV()

--- a/internal/views/dump.go
+++ b/internal/views/dump.go
@@ -106,15 +106,6 @@ func (v *dumpView) sortColumn(col int, asc bool) {
 	tv.Refresh()
 }
 
-func (v *dumpView) sortColCmd(col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {
-	return func(evt *tcell.EventKey) *tcell.EventKey {
-		tv := v.getTV()
-		tv.SetSortCol(tv.NameColIndex()+col, 0, asc)
-		tv.Refresh()
-		return nil
-	}
-}
-
 func (v *dumpView) enterCmd(evt *tcell.EventKey) *tcell.EventKey {
 	log.Debug().Msg("Dump enter!")
 	tv := v.getTV()

--- a/internal/views/forward.go
+++ b/internal/views/forward.go
@@ -107,8 +107,8 @@ func (v *forwardView) registerActions() {
 		tcell.KeyCtrlD: ui.NewKeyAction("Delete", v.deleteCmd, true),
 		ui.KeySlash:    ui.NewKeyAction("Filter", tv.activateCmd, false),
 		ui.KeyP:        ui.NewKeyAction("Previous", v.app.prevCmd, false),
-		ui.KeyShiftP:   ui.NewKeyAction("Sort Ports", sortColCmd(v, 2, true), false),
-		ui.KeyShiftU:   ui.NewKeyAction("Sort URL", sortColCmd(v, 4, true), false),
+		ui.KeyShiftP:   ui.NewKeyAction("Sort Ports", SortColCmd(v, 2, true), false),
+		ui.KeyShiftU:   ui.NewKeyAction("Sort URL", SortColCmd(v, 4, true), false),
 	})
 }
 
@@ -116,7 +116,7 @@ func (v *forwardView) getTitle() string {
 	return forwardTitle
 }
 
-func (v *forwardView) sortColumn(col int, asc bool) {
+func (v *forwardView) SortColumn(col int, asc bool) {
 	tv := v.getTV()
 	tv.SetSortCol(tv.NameColIndex()+col, 0, asc)
 	v.refresh()

--- a/internal/views/forward.go
+++ b/internal/views/forward.go
@@ -107,8 +107,8 @@ func (v *forwardView) registerActions() {
 		tcell.KeyCtrlD: ui.NewKeyAction("Delete", v.deleteCmd, true),
 		ui.KeySlash:    ui.NewKeyAction("Filter", tv.activateCmd, false),
 		ui.KeyP:        ui.NewKeyAction("Previous", v.app.prevCmd, false),
-		ui.KeyShiftP:   ui.NewKeyAction("Sort Ports", v.sortColCmd(2, true), false),
-		ui.KeyShiftU:   ui.NewKeyAction("Sort URL", v.sortColCmd(4, true), false),
+		ui.KeyShiftP:   ui.NewKeyAction("Sort Ports", sortColCmd(v, 2, true), false),
+		ui.KeyShiftU:   ui.NewKeyAction("Sort URL", sortColCmd(v, 4, true), false),
 	})
 }
 
@@ -116,14 +116,10 @@ func (v *forwardView) getTitle() string {
 	return forwardTitle
 }
 
-func (v *forwardView) sortColCmd(col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {
-	return func(evt *tcell.EventKey) *tcell.EventKey {
-		tv := v.getTV()
-		tv.SetSortCol(tv.NameColIndex()+col, 0, asc)
-		v.refresh()
-
-		return nil
-	}
+func (v *forwardView) sortColumn(col int, asc bool) {
+	tv := v.getTV()
+	tv.SetSortCol(tv.NameColIndex()+col, 0, asc)
+	v.refresh()
 }
 
 func (v *forwardView) gotoBenchCmd(evt *tcell.EventKey) *tcell.EventKey {

--- a/internal/views/forward.go
+++ b/internal/views/forward.go
@@ -107,8 +107,8 @@ func (v *forwardView) registerActions() {
 		tcell.KeyCtrlD: ui.NewKeyAction("Delete", v.deleteCmd, true),
 		ui.KeySlash:    ui.NewKeyAction("Filter", tv.activateCmd, false),
 		ui.KeyP:        ui.NewKeyAction("Previous", v.app.prevCmd, false),
-		ui.KeyShiftP:   ui.NewKeyAction("Sort Ports", SortColCmd(v, 2, true), false),
-		ui.KeyShiftU:   ui.NewKeyAction("Sort URL", SortColCmd(v, 4, true), false),
+		ui.KeyShiftP:   ui.NewKeyAction("Sort Ports", ui.SortColCmd(v, 2, true), false),
+		ui.KeyShiftU:   ui.NewKeyAction("Sort URL", ui.SortColCmd(v, 4, true), false),
 	})
 }
 

--- a/internal/views/log_resource.go
+++ b/internal/views/log_resource.go
@@ -30,16 +30,6 @@ func (v *logResourceView) extraActions(aa ui.KeyActions) {
 	aa[ui.KeyShiftL] = ui.NewKeyAction("Logs Previous", v.prevLogsCmd, true)
 }
 
-func (v *logResourceView) sortColCmd(col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {
-	return func(evt *tcell.EventKey) *tcell.EventKey {
-		t := v.masterPage()
-		t.SetSortCol(t.NameColIndex()+col, 0, asc)
-		t.Refresh()
-
-		return nil
-	}
-}
-
 // Protocol...
 
 func (v *logResourceView) getList() resource.List {

--- a/internal/views/master_detail.go
+++ b/internal/views/master_detail.go
@@ -73,6 +73,12 @@ func (v *masterDetail) masterPage() *tableView {
 	return v.GetPrimitive("master").(*tableView)
 }
 
+func (v *masterDetail) sortColumn(col int, asc bool) {
+	t := v.masterPage()
+	t.SetSortCol(t.NameColIndex()+col, 0, asc)
+	t.Refresh()
+}
+
 func (v *masterDetail) showDetails() {
 	v.SwitchToPage("details")
 }

--- a/internal/views/master_detail.go
+++ b/internal/views/master_detail.go
@@ -73,7 +73,7 @@ func (v *masterDetail) masterPage() *tableView {
 	return v.GetPrimitive("master").(*tableView)
 }
 
-func (v *masterDetail) sortColumn(col int, asc bool) {
+func (v *masterDetail) SortColumn(col int, asc bool) {
 	t := v.masterPage()
 	t.SetSortCol(t.NameColIndex()+col, 0, asc)
 	t.Refresh()

--- a/internal/views/no.go
+++ b/internal/views/no.go
@@ -19,10 +19,10 @@ func newNodeView(title, gvr string, app *appView, list resource.List) resourceVi
 }
 
 func (v *nodeView) extraActions(aa ui.KeyActions) {
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", sortColCmd(v, 7, false), false)
-	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", sortColCmd(v, 8, false), false)
-	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", sortColCmd(v, 9, false), false)
-	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", sortColCmd(v, 10, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", SortColCmd(v, 7, false), false)
+	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", SortColCmd(v, 8, false), false)
+	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", SortColCmd(v, 9, false), false)
+	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", SortColCmd(v, 10, false), false)
 }
 
 func (v *nodeView) showPods(app *appView, _, _, sel string) {

--- a/internal/views/no.go
+++ b/internal/views/no.go
@@ -19,20 +19,10 @@ func newNodeView(title, gvr string, app *appView, list resource.List) resourceVi
 }
 
 func (v *nodeView) extraActions(aa ui.KeyActions) {
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", v.sortColCmd(7, false), false)
-	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", v.sortColCmd(8, false), false)
-	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", v.sortColCmd(9, false), false)
-	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", v.sortColCmd(10, false), false)
-}
-
-func (v *nodeView) sortColCmd(col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {
-	return func(evt *tcell.EventKey) *tcell.EventKey {
-		t := v.masterPage()
-		t.SetSortCol(t.NameColIndex()+col, 0, asc)
-		t.Refresh()
-
-		return nil
-	}
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", sortColCmd(v, 7, false), false)
+	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", sortColCmd(v, 8, false), false)
+	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", sortColCmd(v, 9, false), false)
+	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", sortColCmd(v, 10, false), false)
 }
 
 func (v *nodeView) showPods(app *appView, _, _, sel string) {

--- a/internal/views/no.go
+++ b/internal/views/no.go
@@ -19,10 +19,10 @@ func newNodeView(title, gvr string, app *appView, list resource.List) resourceVi
 }
 
 func (v *nodeView) extraActions(aa ui.KeyActions) {
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", SortColCmd(v, 7, false), false)
-	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", SortColCmd(v, 8, false), false)
-	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", SortColCmd(v, 9, false), false)
-	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", SortColCmd(v, 10, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", ui.SortColCmd(v, 7, false), false)
+	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", ui.SortColCmd(v, 8, false), false)
+	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", ui.SortColCmd(v, 9, false), false)
+	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", ui.SortColCmd(v, 10, false), false)
 }
 
 func (v *nodeView) showPods(app *appView, _, _, sel string) {

--- a/internal/views/pod.go
+++ b/internal/views/pod.go
@@ -191,20 +191,6 @@ func (v *podView) shellIn(path, co string) {
 	v.restartUpdates()
 }
 
-type columnSortable interface {
-	sortColumn(col int, asc bool)
-}
-
-func sortColCmd(colSortable columnSortable, col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {
-	// TODO: use direction type instead of asc bool, move
-	return func(evt *tcell.EventKey) *tcell.EventKey {
-		colSortable.sortColumn(col, asc)
-		asc = !asc // flip sort direction for next call
-
-		return nil
-	}
-}
-
 // ----------------------------------------------------------------------------
 // Helpers...
 

--- a/internal/views/pod.go
+++ b/internal/views/pod.go
@@ -56,15 +56,15 @@ func (v *podView) extraActions(aa ui.KeyActions) {
 	aa[ui.KeyL] = ui.NewKeyAction("Logs", v.logsCmd, true)
 	aa[ui.KeyShiftL] = ui.NewKeyAction("Logs Previous", v.prevLogsCmd, true)
 
-	aa[ui.KeyShiftR] = ui.NewKeyAction("Sort Ready", SortColCmd(v, 1, false), false)
-	aa[ui.KeyShiftS] = ui.NewKeyAction("Sort Status", SortColCmd(v, 2, true), false)
-	aa[ui.KeyShiftT] = ui.NewKeyAction("Sort Restart", SortColCmd(v, 3, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", SortColCmd(v, 4, false), false)
-	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", SortColCmd(v, 5, false), false)
-	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", SortColCmd(v, 6, false), false)
-	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", SortColCmd(v, 7, false), false)
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort IP", SortColCmd(v, 8, true), false)
-	aa[ui.KeyShiftO] = ui.NewKeyAction("Sort Node", SortColCmd(v, 9, true), false)
+	aa[ui.KeyShiftR] = ui.NewKeyAction("Sort Ready", ui.SortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftS] = ui.NewKeyAction("Sort Status", ui.SortColCmd(v, 2, true), false)
+	aa[ui.KeyShiftT] = ui.NewKeyAction("Sort Restart", ui.SortColCmd(v, 3, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", ui.SortColCmd(v, 4, false), false)
+	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", ui.SortColCmd(v, 5, false), false)
+	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", ui.SortColCmd(v, 6, false), false)
+	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", ui.SortColCmd(v, 7, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort IP", ui.SortColCmd(v, 8, true), false)
+	aa[ui.KeyShiftO] = ui.NewKeyAction("Sort Node", ui.SortColCmd(v, 9, true), false)
 }
 
 func (v *podView) listContainers(app *appView, _, res, sel string) {

--- a/internal/views/pod.go
+++ b/internal/views/pod.go
@@ -56,15 +56,15 @@ func (v *podView) extraActions(aa ui.KeyActions) {
 	aa[ui.KeyL] = ui.NewKeyAction("Logs", v.logsCmd, true)
 	aa[ui.KeyShiftL] = ui.NewKeyAction("Logs Previous", v.prevLogsCmd, true)
 
-	aa[ui.KeyShiftR] = ui.NewKeyAction("Sort Ready", v.sortColCmd(1, false), false)
-	aa[ui.KeyShiftS] = ui.NewKeyAction("Sort Status", v.sortColCmd(2, true), false)
-	aa[ui.KeyShiftT] = ui.NewKeyAction("Sort Restart", v.sortColCmd(3, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", v.sortColCmd(4, false), false)
-	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", v.sortColCmd(5, false), false)
-	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", v.sortColCmd(6, false), false)
-	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", v.sortColCmd(7, false), false)
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort IP", v.sortColCmd(8, true), false)
-	aa[ui.KeyShiftO] = ui.NewKeyAction("Sort Node", v.sortColCmd(9, true), false)
+	aa[ui.KeyShiftR] = ui.NewKeyAction("Sort Ready", sortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftS] = ui.NewKeyAction("Sort Status", sortColCmd(v, 2, true), false)
+	aa[ui.KeyShiftT] = ui.NewKeyAction("Sort Restart", sortColCmd(v, 3, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", sortColCmd(v, 4, false), false)
+	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", sortColCmd(v, 5, false), false)
+	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", sortColCmd(v, 6, false), false)
+	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", sortColCmd(v, 7, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort IP", sortColCmd(v, 8, true), false)
+	aa[ui.KeyShiftO] = ui.NewKeyAction("Sort Node", sortColCmd(v, 9, true), false)
 }
 
 func (v *podView) listContainers(app *appView, _, res, sel string) {
@@ -191,11 +191,15 @@ func (v *podView) shellIn(path, co string) {
 	v.restartUpdates()
 }
 
-func (v *podView) sortColCmd(col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {
+type columnSortable interface {
+	sortColumn(col int, asc bool)
+}
+
+func sortColCmd(colSortable columnSortable, col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {
+	// TODO: use direction type instead of asc bool, move
 	return func(evt *tcell.EventKey) *tcell.EventKey {
-		t := v.masterPage()
-		t.SetSortCol(t.NameColIndex()+col, 0, asc)
-		t.Refresh()
+		colSortable.sortColumn(col, asc)
+		asc = !asc // flip sort direction for next call
 
 		return nil
 	}

--- a/internal/views/pod.go
+++ b/internal/views/pod.go
@@ -56,15 +56,15 @@ func (v *podView) extraActions(aa ui.KeyActions) {
 	aa[ui.KeyL] = ui.NewKeyAction("Logs", v.logsCmd, true)
 	aa[ui.KeyShiftL] = ui.NewKeyAction("Logs Previous", v.prevLogsCmd, true)
 
-	aa[ui.KeyShiftR] = ui.NewKeyAction("Sort Ready", sortColCmd(v, 1, false), false)
-	aa[ui.KeyShiftS] = ui.NewKeyAction("Sort Status", sortColCmd(v, 2, true), false)
-	aa[ui.KeyShiftT] = ui.NewKeyAction("Sort Restart", sortColCmd(v, 3, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", sortColCmd(v, 4, false), false)
-	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", sortColCmd(v, 5, false), false)
-	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", sortColCmd(v, 6, false), false)
-	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", sortColCmd(v, 7, false), false)
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort IP", sortColCmd(v, 8, true), false)
-	aa[ui.KeyShiftO] = ui.NewKeyAction("Sort Node", sortColCmd(v, 9, true), false)
+	aa[ui.KeyShiftR] = ui.NewKeyAction("Sort Ready", SortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftS] = ui.NewKeyAction("Sort Status", SortColCmd(v, 2, true), false)
+	aa[ui.KeyShiftT] = ui.NewKeyAction("Sort Restart", SortColCmd(v, 3, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort CPU", SortColCmd(v, 4, false), false)
+	aa[ui.KeyShiftM] = ui.NewKeyAction("Sort MEM", SortColCmd(v, 5, false), false)
+	aa[ui.KeyShiftX] = ui.NewKeyAction("Sort CPU%", SortColCmd(v, 6, false), false)
+	aa[ui.KeyShiftZ] = ui.NewKeyAction("Sort MEM%", SortColCmd(v, 7, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort IP", SortColCmd(v, 8, true), false)
+	aa[ui.KeyShiftO] = ui.NewKeyAction("Sort Node", SortColCmd(v, 9, true), false)
 }
 
 func (v *podView) listContainers(app *appView, _, res, sel string) {

--- a/internal/views/policy.go
+++ b/internal/views/policy.go
@@ -76,10 +76,10 @@ func (v *policyView) bindKeys() {
 		tcell.KeyEscape: ui.NewKeyAction("Reset", v.resetCmd, false),
 		ui.KeySlash:     ui.NewKeyAction("Filter", v.activateCmd, false),
 		ui.KeyP:         ui.NewKeyAction("Previous", v.app.prevCmd, false),
-		ui.KeyShiftS:    ui.NewKeyAction("Sort Namespace", v.SortColCmd(0), false),
-		ui.KeyShiftN:    ui.NewKeyAction("Sort Name", v.SortColCmd(1), false),
-		ui.KeyShiftO:    ui.NewKeyAction("Sort Group", v.SortColCmd(2), false),
-		ui.KeyShiftB:    ui.NewKeyAction("Sort Binding", v.SortColCmd(3), false),
+		ui.KeyShiftS:    ui.NewKeyAction("Sort Namespace", ui.SortColCmd(v, 0, true), false),
+		ui.KeyShiftN:    ui.NewKeyAction("Sort Name", ui.SortColCmd(v, 1, true), false),
+		ui.KeyShiftO:    ui.NewKeyAction("Sort Group", ui.SortColCmd(v, 2, true), false),
+		ui.KeyShiftB:    ui.NewKeyAction("Sort Binding", ui.SortColCmd(v, 3, true), false),
 	})
 }
 

--- a/internal/views/rbac.go
+++ b/internal/views/rbac.go
@@ -125,7 +125,7 @@ func (v *rbacView) bindKeys() {
 		tcell.KeyEscape: ui.NewKeyAction("Reset", v.resetCmd, false),
 		ui.KeySlash:     ui.NewKeyAction("Filter", v.activateCmd, false),
 		ui.KeyP:         ui.NewKeyAction("Previous", v.app.prevCmd, false),
-		ui.KeyShiftO:    ui.NewKeyAction("Sort APIGroup", v.SortColCmd(1), false),
+		ui.KeyShiftO:    ui.NewKeyAction("Sort APIGroup", ui.SortColCmd(v, 1, true), false),
 	})
 }
 

--- a/internal/views/rs.go
+++ b/internal/views/rs.go
@@ -32,8 +32,8 @@ func newReplicaSetView(title, gvr string, app *appView, list resource.List) reso
 }
 
 func (v *replicaSetView) extraActions(aa ui.KeyActions) {
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", sortColCmd(v, 1, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", sortColCmd(v, 2, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", SortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", SortColCmd(v, 2, false), false)
 	aa[tcell.KeyCtrlB] = ui.NewKeyAction("Rollback", v.rollbackCmd, true)
 }
 

--- a/internal/views/rs.go
+++ b/internal/views/rs.go
@@ -32,8 +32,8 @@ func newReplicaSetView(title, gvr string, app *appView, list resource.List) reso
 }
 
 func (v *replicaSetView) extraActions(aa ui.KeyActions) {
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", SortColCmd(v, 1, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", SortColCmd(v, 2, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", ui.SortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", ui.SortColCmd(v, 2, false), false)
 	aa[tcell.KeyCtrlB] = ui.NewKeyAction("Rollback", v.rollbackCmd, true)
 }
 

--- a/internal/views/rs.go
+++ b/internal/views/rs.go
@@ -32,19 +32,9 @@ func newReplicaSetView(title, gvr string, app *appView, list resource.List) reso
 }
 
 func (v *replicaSetView) extraActions(aa ui.KeyActions) {
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", v.sortColCmd(1, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", v.sortColCmd(2, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", sortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", sortColCmd(v, 2, false), false)
 	aa[tcell.KeyCtrlB] = ui.NewKeyAction("Rollback", v.rollbackCmd, true)
-}
-
-func (v *replicaSetView) sortColCmd(col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {
-	return func(evt *tcell.EventKey) *tcell.EventKey {
-		t := v.masterPage()
-		t.SetSortCol(t.NameColIndex()+col, 0, asc)
-		t.Refresh()
-
-		return nil
-	}
 }
 
 func (v *replicaSetView) showPods(app *appView, ns, res, sel string) {

--- a/internal/views/sort.go
+++ b/internal/views/sort.go
@@ -1,0 +1,16 @@
+package views
+
+import "github.com/gdamore/tcell"
+
+type columnSortable interface {
+	sortColumn(col int, asc bool)
+}
+
+func sortColCmd(v columnSortable, col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {
+	return func(evt *tcell.EventKey) *tcell.EventKey {
+		v.sortColumn(col, asc)
+		asc = !asc // flip sort direction for next call
+
+		return nil
+	}
+}

--- a/internal/views/sort.go
+++ b/internal/views/sort.go
@@ -2,13 +2,13 @@ package views
 
 import "github.com/gdamore/tcell"
 
-type columnSortable interface {
-	sortColumn(col int, asc bool)
+type ColumnSortable interface {
+	SortColumn(col int, asc bool)
 }
 
-func sortColCmd(v columnSortable, col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {
+func SortColCmd(v ColumnSortable, col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {
 	return func(evt *tcell.EventKey) *tcell.EventKey {
-		v.sortColumn(col, asc)
+		v.SortColumn(col, asc)
 		asc = !asc // flip sort direction for next call
 
 		return nil

--- a/internal/views/sts.go
+++ b/internal/views/sts.go
@@ -32,8 +32,8 @@ func (v *statefulSetView) extraActions(aa ui.KeyActions) {
 	v.logResourceView.extraActions(aa)
 	v.scalableResourceView.extraActions(aa)
 	v.restartableResourceView.extraActions(aa)
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", v.sortColCmd(1, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", v.sortColCmd(2, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", sortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", sortColCmd(v, 2, false), false)
 }
 
 func (v *statefulSetView) showPods(app *appView, ns, res, sel string) {

--- a/internal/views/sts.go
+++ b/internal/views/sts.go
@@ -32,8 +32,8 @@ func (v *statefulSetView) extraActions(aa ui.KeyActions) {
 	v.logResourceView.extraActions(aa)
 	v.scalableResourceView.extraActions(aa)
 	v.restartableResourceView.extraActions(aa)
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", SortColCmd(v, 1, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", SortColCmd(v, 2, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", ui.SortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", ui.SortColCmd(v, 2, false), false)
 }
 
 func (v *statefulSetView) showPods(app *appView, ns, res, sel string) {

--- a/internal/views/sts.go
+++ b/internal/views/sts.go
@@ -32,8 +32,8 @@ func (v *statefulSetView) extraActions(aa ui.KeyActions) {
 	v.logResourceView.extraActions(aa)
 	v.scalableResourceView.extraActions(aa)
 	v.restartableResourceView.extraActions(aa)
-	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", sortColCmd(v, 1, false), false)
-	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", sortColCmd(v, 2, false), false)
+	aa[ui.KeyShiftD] = ui.NewKeyAction("Sort Desired", SortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftC] = ui.NewKeyAction("Sort Current", SortColCmd(v, 2, false), false)
 }
 
 func (v *statefulSetView) showPods(app *appView, ns, res, sel string) {

--- a/internal/views/subject.go
+++ b/internal/views/subject.go
@@ -95,7 +95,7 @@ func (v *subjectView) bindKeys() {
 		tcell.KeyEscape: ui.NewKeyAction("Reset", v.resetCmd, false),
 		ui.KeySlash:     ui.NewKeyAction("Filter", v.activateCmd, false),
 		ui.KeyP:         ui.NewKeyAction("Previous", v.app.prevCmd, false),
-		ui.KeyShiftK:    ui.NewKeyAction("Sort Kind", v.SortColCmd(1), false),
+		ui.KeyShiftK:    ui.NewKeyAction("Sort Kind", ui.SortColCmd(v, 1, true), false),
 	})
 }
 

--- a/internal/views/svc.go
+++ b/internal/views/svc.go
@@ -47,17 +47,7 @@ func (v *svcView) extraActions(aa ui.KeyActions) {
 	aa[ui.KeyL] = ui.NewKeyAction("Logs", v.logsCmd, true)
 	aa[tcell.KeyCtrlB] = ui.NewKeyAction("Bench", v.benchCmd, true)
 	aa[tcell.KeyCtrlK] = ui.NewKeyAction("Bench Stop", v.benchStopCmd, true)
-	aa[ui.KeyShiftT] = ui.NewKeyAction("Sort Type", v.sortColCmd(1, false), false)
-}
-
-func (v *svcView) sortColCmd(col int, asc bool) func(evt *tcell.EventKey) *tcell.EventKey {
-	return func(evt *tcell.EventKey) *tcell.EventKey {
-		t := v.masterPage()
-		t.SetSortCol(t.NameColIndex()+col, 0, asc)
-		t.Refresh()
-
-		return nil
-	}
+	aa[ui.KeyShiftT] = ui.NewKeyAction("Sort Type", sortColCmd(v, 1, false), false)
 }
 
 func (v *svcView) showPods(app *appView, ns, res, sel string) {

--- a/internal/views/svc.go
+++ b/internal/views/svc.go
@@ -47,7 +47,7 @@ func (v *svcView) extraActions(aa ui.KeyActions) {
 	aa[ui.KeyL] = ui.NewKeyAction("Logs", v.logsCmd, true)
 	aa[tcell.KeyCtrlB] = ui.NewKeyAction("Bench", v.benchCmd, true)
 	aa[tcell.KeyCtrlK] = ui.NewKeyAction("Bench Stop", v.benchStopCmd, true)
-	aa[ui.KeyShiftT] = ui.NewKeyAction("Sort Type", SortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftT] = ui.NewKeyAction("Sort Type", ui.SortColCmd(v, 1, false), false)
 }
 
 func (v *svcView) showPods(app *appView, ns, res, sel string) {

--- a/internal/views/svc.go
+++ b/internal/views/svc.go
@@ -47,7 +47,7 @@ func (v *svcView) extraActions(aa ui.KeyActions) {
 	aa[ui.KeyL] = ui.NewKeyAction("Logs", v.logsCmd, true)
 	aa[tcell.KeyCtrlB] = ui.NewKeyAction("Bench", v.benchCmd, true)
 	aa[tcell.KeyCtrlK] = ui.NewKeyAction("Bench Stop", v.benchStopCmd, true)
-	aa[ui.KeyShiftT] = ui.NewKeyAction("Sort Type", sortColCmd(v, 1, false), false)
+	aa[ui.KeyShiftT] = ui.NewKeyAction("Sort Type", SortColCmd(v, 1, false), false)
 }
 
 func (v *svcView) showPods(app *appView, ns, res, sel string) {

--- a/internal/views/table.go
+++ b/internal/views/table.go
@@ -61,8 +61,8 @@ func (v *tableView) bindKeys() {
 		tcell.KeyBackspace:  ui.NewKeyAction("Erase", v.eraseCmd, false),
 		tcell.KeyDelete:     ui.NewKeyAction("Erase", v.eraseCmd, false),
 		ui.KeyShiftI:        ui.NewKeyAction("Invert", v.SortInvertCmd, false),
-		ui.KeyShiftN:        ui.NewKeyAction("Sort Name", v.SortColCmd(0), false),
-		ui.KeyShiftA:        ui.NewKeyAction("Sort Age", v.SortColCmd(-1), false),
+		ui.KeyShiftN:        ui.NewKeyAction("Sort Name", ui.SortColCmd(v, 0, true), false),
+		ui.KeyShiftA:        ui.NewKeyAction("Sort Age", ui.SortColCmd(v, -1, true), false),
 	})
 }
 

--- a/internal/views/table_test.go
+++ b/internal/views/table_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/resource"
+	"github.com/derailed/k9s/internal/ui"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/watch"
 )
@@ -103,7 +104,7 @@ func TestTableViewSort(t *testing.T) {
 		Namespace: "",
 	}
 	v.Update(data)
-	v.SortColCmd(1)(nil)
+	ui.SortColCmd(v, 1, true)(nil)
 	assert.Equal(t, 3, v.GetRowCount())
 	assert.Equal(t, "blee ", v.GetCell(1, 1).Text)
 


### PR DESCRIPTION
For issue https://github.com/derailed/k9s/issues/408

e.g. to sort by name descending, previously you had to press `<shift-n>` then `<shift-i>`, now you can press `<shift-n>` multiple times to toggle back and forth between ascending/descending sort

Introduced a `ui.ColumnSortable` interface which various things now implement. The next sort direction is stored in a closure.
