### PR TITLE
use the crd renderer as the default renderer

### DIFF
--- a/internal/model/table.go
+++ b/internal/model/table.go
@@ -249,7 +249,7 @@ func (t *Table) resourceMeta() ResourceMeta {
 		log.Debug().Msgf("Resource %s not found in registry. Going generic!", t.gvr)
 		meta = ResourceMeta{
 			DAO:      &dao.Generic{},
-			Renderer: &render.Generic{},
+			Renderer: &render.CustomResourceDefinition{},
 		}
 	}
 	if meta.DAO == nil {


### PR DESCRIPTION
Default renderer should be the CRD one since the generic DAO uses the k8s dynamic client to fetches `unstructured.Unstructured` and not `TableRow`.

Closes #466 