### PR TITLE
Fix embedding version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME    := k9s
-PACKAGE := github.com/derailed/$(NAME)/internal
+PACKAGE := github.com/derailed/$(NAME)
 VERSION := dev
 GIT     := $(shell git rev-parse --short HEAD)
 DATE    := $(shell date +%FT%T%Z)


### PR DESCRIPTION
It seems Makefile isn't used for release, but I found version embedding by ldflags is broken in the Makefile.

```
$ ./execs/k9s version
 ____  __.________
|    |/ _/   __   \______
|      < \____    /  ___/
|    |  \   /    /\___ \
|____|__ \ /____//____  >
        \/            \/

Version:  dev
Commit:  dev
Date:  n/a
```

This PR fixes it.
