### PR TITLE
Fix invalid memory access when loading empty alias.yml

### DIFF
--- a/internal/config/alias.go
+++ b/internal/config/alias.go
@@ -147,7 +147,7 @@ func (a *Aliases) LoadAliases(path string) error {
 		return nil
 	}
 
-	var aa *Aliases
+	var aa Aliases
 	if err := yaml.Unmarshal(f, &aa); err != nil {
 		return err
 	}


### PR DESCRIPTION
If alias.yml is empty file, LoadAliases function fails with invalid memory access.

```
6:36PM ERR Boom! runtime error: invalid memory address or nil pointer dereference
6:36PM ERR goroutine 1 [running]:
runtime/debug.Stack(0x386df80, 0x2764c03, 0x0)
        /usr/local/Cellar/go/1.13.7/libexec/src/runtime/debug/stack.go:24 +0x9d
github.com/derailed/k9s/cmd.run.func1()
        /private/tmp/k9s-20200206-85995-1096d3l/cmd/root.go:73 +0x11d
panic(0x253a720, 0x383d660)
        /usr/local/Cellar/go/1.13.7/libexec/src/runtime/panic.go:679 +0x1b2
github.com/derailed/k9s/internal/config.(*Aliases).LoadAliases(0xc000706180, 0xc0003d7d00, 0x1d, 0x0, 0x0)
        /private/tmp/k9s-20200206-85995-1096d3l/internal/config/alias.go:157 +0x15e
github.com/derailed/k9s/internal/config.(*Aliases).Load(0xc000706180, 0x0, 0x0)
        /private/tmp/k9s-20200206-85995-1096d3l/internal/config/alias.go:90 +0x51
github.com/derailed/k9s/internal/dao.(*Alias).load(0xc000528070, 0x2a44da0, 0xc0006a0ac0)
        /private/tmp/k9s-20200206-85995-1096d3l/internal/dao/alias.go:78 +0x47
github.com/derailed/k9s/internal/dao.(*Alias).Ensure(0xc000528070, 0xc0006a0ac0, 0xc000528070, 0xc000706140)
        /private/tmp/k9s-20200206-85995-1096d3l/internal/dao/alias.go:74 +0x9a
github.com/derailed/k9s/internal/view.(*Command).Init(0xc000706140, 0xc000706140, 0x1)
        /private/tmp/k9s-20200206-85995-1096d3l/internal/view/command.go:40 +0x62
github.com/derailed/k9s/internal/view.(*App).Init(0xc00009f020, 0x29bee28, 0x7, 0x2, 0x13, 0xc00027b180)
        /private/tmp/k9s-20200206-85995-1096d3l/internal/view/app.go:99 +0x536
github.com/derailed/k9s/cmd.run(0x384fb40, 0xc000543ec0, 0x0, 0x3)
        /private/tmp/k9s-20200206-85995-1096d3l/cmd/root.go:85 +0x125
github.com/spf13/cobra.(*Command).execute(0x384fb40, 0xc00003a110, 0x3, 0x3, 0x384fb40, 0xc00003a110)
        /private/tmp/k9s-20200206-85995-1096d3l/.brew_home/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x2aa
github.com/spf13/cobra.(*Command).ExecuteC(0x384fb40, 0x0, 0x0, 0x0)
        /private/tmp/k9s-20200206-85995-1096d3l/.brew_home/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
        /private/tmp/k9s-20200206-85995-1096d3l/.brew_home/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
github.com/derailed/k9s/cmd.Execute()
        /private/tmp/k9s-20200206-85995-1096d3l/cmd/root.go:64 +0x2d
main.main()
        /private/tmp/k9s-20200206-85995-1096d3l/main.go:25 +0x1a6
```
