### PR TITLE
add common commands example

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ K9s uses aliases to navigate most K8s resources.
 
 | Command                     | Result                                             | Example                    |
 |-----------------------------|----------------------------------------------------|----------------------------|
+| `:dp`, `:deploy`            | View deployments                                   |                            |
+| `:no`, `:nodes`             | View nodes                                         |                            |
+| `:svc`, `:service`          | View services                                      |                            |
 | `:`alias`<ENTER>`           | View a Kubernetes resource aliases                 | `:po<ENTER>`               |
 | `?`                         | Show keyboard shortcuts and help                   |                            |
 | `Ctrl-a`                    | Show all available resource alias                  | select+`<ENTER>` to view   |


### PR DESCRIPTION
I added a couple of very common commands to allow easier discoverability of the command feature.

At first, it can be hard to understand how to show different resources without a clear example, the first thing I tried was searching for "deploy" or "nodes" into the readme but I had to most of it to realize that the command feature has to be used for that.


Thanks a lot for the tools, it's amazing! 🙌

[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/)