### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 NAME    := k9s
 PACKAGE := github.com/derailed/$(NAME)
 GIT     := $(shell git rev-parse --short HEAD)
-DATE    := $(shell date +%FT%T%Z)
+SOURCE_DATE_EPOCH ?= $(shell date +%s)
+DATE    := $(shell date -u -d @${SOURCE_DATE_EPOCH} +%FT%T%Z)
 VERSION  ?= v0.14.0
 IMG_NAME := derailed/k9s
 IMAGE    := ${IMG_NAME}:${VERSION}


### PR DESCRIPTION
Allow to override build date with SOURCE_DATE_EPOCH
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This variant only works with GNU date.