### PR TITLE
Add pods headers description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,30 @@ K9s is available on Linux, macOS and Windows platforms.
 
 ---
 
+## Headers description
+
+### Pods view
+
+| Header      | Description                     |
+|-------------|---------------------------------|
+| NAME        | Pod name                        |
+| IMAGE       | Image used                      |
+| READY       | Is pod ready ?                  |
+| STATE       | Pod state                       |
+| INIT        | Is an init pod ?                |
+| RS          | Restart count                   |
+| PROBES(L:R) | ?                               |
+| CPU         | CPU used (millicores)           |
+| MEM         | Memory used (Mb)                |
+| %CPU/R      | % ratio of CPU used/requested   |
+| %MEM/R      | % ratio of MEM used/requested   |
+| %CPU/L      | % ratio of CPU used/limit       |
+| %MEM/L      | % ratio of MEM used/limit       |
+| PORTS       | Ports exposed                   |
+| AGE         | Pod age                         |
+
+---
+
 ## Demo Videos/Recordings
 
 * [K9s Pulses](https://asciinema.org/a/UbXKPal6IWpTaVAjBBFmizcGN)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ K9s is available on Linux, macOS and Windows platforms.
 | STATE       | Pod state                       |
 | INIT        | Is an init pod ?                |
 | RS          | Restart count                   |
-| PROBES(L:R) | ?                               |
+| PROBES(L:R) | Liveness and Readiness probes   |
 | CPU         | CPU used (millicores)           |
 | MEM         | Memory used (Mb)                |
 | %CPU/R      | % ratio of CPU used/requested   |


### PR DESCRIPTION
Add a section to describe headers in  `README` 