### PR TITLE
Show port column for services

### DIFF
--- a/internal/render/svc.go
+++ b/internal/render/svc.go
@@ -29,7 +29,7 @@ func (Service) Header(ns string) Header {
 		HeaderColumn{Name: "CLUSTER-IP"},
 		HeaderColumn{Name: "EXTERNAL-IP"},
 		HeaderColumn{Name: "SELECTOR", Wide: true},
-		HeaderColumn{Name: "PORTS", Wide: true},
+		HeaderColumn{Name: "PORTS", Wide: false},
 		HeaderColumn{Name: "LABELS", Wide: true},
 		HeaderColumn{Name: "VALID", Wide: true},
 		HeaderColumn{Name: "AGE", Time: true, Decorator: AgeDecorator},


### PR DESCRIPTION
The port column is at least as important as the service age, so this shows it by default rather than in the wide mode.

This also mimics the output one can get with:

    kubectl get services
