### PR TITLE
Fix empty autocomplete crash

### DIFF
--- a/internal/ui/command.go
+++ b/internal/ui/command.go
@@ -26,7 +26,12 @@ type Command struct {
 
 // NewCommand returns a new command view.
 func NewCommand(styles *config.Styles, m *model.FishBuff) *Command {
-	c := Command{styles: styles, TextView: tview.NewTextView(), model: m}
+	c := Command{
+		styles:          styles,
+		TextView:        tview.NewTextView(),
+		model:           m,
+		suggestionIndex: -1,
+	}
 	c.SetWordWrap(true)
 	c.SetWrap(true)
 	c.SetDynamicColors(true)


### PR DESCRIPTION
If you try to autocomplete in command mode (0.18.0) with empty string k9s crashes:
`Boom!! runtime error: index out of range [0] with length 0.`

Adding the same check as for others keybinds fixes the issue.