### PR TITLE
Ensure casing is consistent for help table

### DIFF
--- a/internal/view/help.go
+++ b/internal/view/help.go
@@ -35,7 +35,7 @@ type Help struct {
 // NewHelp returns a new help viewer.
 func NewHelp() *Help {
 	return &Help{
-		Table: NewTable(client.NewGVR("help")),
+		Table: NewTable(client.NewGVR(helpTitle)),
 	}
 }
 


### PR DESCRIPTION
This should fix #673 .  It was trying to compare "help" to "Help" and hence adding additional frames to the same screen.