### PR TITLE
Optionally allow plugin commands to have confirm dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Entering the command mode and typing a resource name or alias, could be cumberso
 K9s allows you to extend your command line and tooling by defining your very own cluster commands via plugins. K9s will look at `$HOME/.k9s/plugin.yml` to locate all available plugins. A plugin is defined as follows:
 
 * Shortcut option represents the key combination a user would type to activate the plugin
+* Confirm option (when enabled) lets you see the command that is going to be executed and gives you an option to confirm or prevent execution
 * Description will be printed next to the shortcut in the k9s menu
 * Scopes defines a collection of resources names/shortnames for the views associated with the plugin. You can specify `all` to provide this shortcut for all views.
 * Command represents adhoc commands the plugin runs upon activation
@@ -346,6 +347,7 @@ plugin:
   # Defines a plugin to provide a `ctrl-l` shorcut to tail the logs while in pod view.
   fred:
     shortCut: Ctrl-L
+    confirm: false
     description: Pod logs
     scopes:
     - pods

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -18,6 +18,7 @@ type Plugins struct {
 // Plugin describes a K9s plugin
 type Plugin struct {
 	ShortCut    string   `yaml:"shortCut"`
+	Confirm     bool     `yaml:"confirm"`
 	Scopes      []string `yaml:"scopes"`
 	Description string   `yaml:"description"`
 	Command     string   `yaml:"command"`

--- a/internal/config/plugin_test.go
+++ b/internal/config/plugin_test.go
@@ -15,8 +15,10 @@ func TestPluginLoad(t *testing.T) {
 	k, ok := p.Plugin["blah"]
 	assert.True(t, ok)
 	assert.Equal(t, "shift-s", k.ShortCut)
+	assert.True(t, k.Confirm)
 	assert.Equal(t, "blee", k.Description)
 	assert.Equal(t, []string{"po", "dp"}, k.Scopes)
 	assert.Equal(t, "duh", k.Command)
+	assert.False(t, k.Background)
 	assert.Equal(t, []string{"-n", "$NAMESPACE", "-boolean"}, k.Args)
 }

--- a/internal/config/testdata/plugin.yml
+++ b/internal/config/testdata/plugin.yml
@@ -1,11 +1,13 @@
 plugin:
   blah:
     shortCut: shift-s
+    confirm: true
     description: blee
     scopes:
       - po
       - dp
     command: duh
+    background: false
     args:
       - -n
       - $NAMESPACE

--- a/plugins/dive.yml
+++ b/plugins/dive.yml
@@ -1,6 +1,7 @@
 plugin:
   dive:
     shortCut: d
+    confirm: false
     description: "Dive image"
     scopes:
       - containers

--- a/plugins/job_suspend.yml
+++ b/plugins/job_suspend.yml
@@ -2,6 +2,7 @@ plugin:
   # Suspends/Resumes a cronjob
   toggleCronjob:
     shortCut: Ctrl-S
+    confirm: true
     scopes:
       - cj
     description: Toggle to suspend or resume a running cronjob

--- a/plugins/log_jq.yml
+++ b/plugins/log_jq.yml
@@ -2,6 +2,7 @@ plugin:
   # Sends logs over to jq for processing. This leverages kubectl plugin kubectl-jq.
   jqlogs:
     shortCut: Ctrl-J
+    confirm: false
     description: "Logs (jq)"
     scopes:
       - po

--- a/plugins/log_stern.yml
+++ b/plugins/log_stern.yml
@@ -2,6 +2,7 @@ plugin:
   # Leverage stern (https://github.com/wercker/stern) to output logs.
   stern:
     shortCut: Ctrl-L
+    confirm: false
     description: "Logs <Stern>"
     scopes:
       - pods


### PR DESCRIPTION
I have some plugin commands that can be potentially dangerous and having option to confirm/deny would be really helpful.