### PR TITLE
Center log indicator

### DIFF
--- a/internal/view/log_indicator.go
+++ b/internal/view/log_indicator.go
@@ -93,10 +93,10 @@ func (l *LogIndicator) ToggleAutoScroll() {
 // Refresh updates the view.
 func (l *LogIndicator) Refresh() {
 	l.Clear()
-	l.update("Autoscroll: " + l.onOff(l.AutoScroll()))
-	l.update("FullScreen: " + l.onOff(l.fullScreen))
-	l.update("Timestamps: " + l.onOff(l.showTime))
-	l.update("Wrap: " + l.onOff(l.textWrap))
+	l.update("Autoscroll", l.AutoScroll(), true)
+	l.update("FullScreen", l.fullScreen, true)
+	l.update("Timestamps", l.showTime, true)
+	l.update("Wrap", l.textWrap, false)
 }
 
 func (l *LogIndicator) onOff(b bool) string {
@@ -106,6 +106,11 @@ func (l *LogIndicator) onOff(b bool) string {
 	return "Off"
 }
 
-func (l *LogIndicator) update(status string) {
-	fmt.Fprintf(l, "[::b]%-20s", status)
+func (l *LogIndicator) update(title string, state bool, pad bool) {
+	const spacer = "     "
+	var padding string
+	if pad {
+		padding = spacer
+	}
+	fmt.Fprintf(l, "[::b]%s: %s%s", title, l.onOff(state), padding)
 }

--- a/internal/view/log_indicator_test.go
+++ b/internal/view/log_indicator_test.go
@@ -13,5 +13,5 @@ func TestLogIndicatorRefresh(t *testing.T) {
 	v := view.NewLogIndicator(config.NewConfig(nil), defaults)
 	v.Refresh()
 
-	assert.Equal(t, "[::b]Autoscroll: On      [::b]FullScreen: Off     [::b]Timestamps: Off     [::b]Wrap: Off           \n", v.GetText(false))
+	assert.Equal(t, "[::b]Autoscroll: On     [::b]FullScreen: Off     [::b]Timestamps: Off     [::b]Wrap: Off\n", v.GetText(false))
 }

--- a/internal/view/log_int_test.go
+++ b/internal/view/log_int_test.go
@@ -19,7 +19,7 @@ func TestLogAutoScroll(t *testing.T) {
 	assert.Equal(t, 13, len(v.Hints()))
 
 	v.toggleAutoScrollCmd(nil)
-	assert.Equal(t, "Autoscroll: Off     FullScreen: Off     Timestamps: Off     Wrap: Off           ", v.Indicator().GetText(true))
+	assert.Equal(t, "Autoscroll: Off     FullScreen: Off     Timestamps: Off     Wrap: Off", v.Indicator().GetText(true))
 }
 
 func TestLogViewNav(t *testing.T) {


### PR DESCRIPTION
Previously all options were padded with spaces which caused the indicator to be visually uncentered.