### PR TITLE
Use a discarding writer for klog output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"runtime/debug"
 
 	"github.com/derailed/k9s/internal/client"
@@ -46,9 +47,7 @@ func init() {
 
 	// Klogs (of course) want to print stuff to the screen ;(
 	klog.InitFlags(nil)
-	if err := flag.Set("log_file", "/dev/null"); err != nil {
-		log.Error().Err(err)
-	}
+	klog.SetOutput(ioutil.Discard)
 	if err := flag.Set("stderrthreshold", "fatal"); err != nil {
 		log.Error().Err(err)
 	}


### PR DESCRIPTION
Configure klog to write messages to a discarding writer instead of
writing them to /dev/null.

The change does not affect klog behavior for the stderrthreshold flag.

It fixes crashes when runing on a platform without /dev/null device (for
example on Windows). The klog will exit the program if /dev/null file
cannot be open.

Fixes #703