### PR TITLE
Add instructions to run Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ K9s is available on Linux, macOS and Windows platforms.
         go run main.go
         ```
 
+--- 
+
+## Running with Docker
+ 
+  You can run k9s as a Docker container by mounting your `KUBECONFIG`:
+ 
+  ```shell
+  docker run --rm -it -v $KUBECONFIG:/root/.kube/config derailed/k9s
+  ```
+ 
+  For default path it would be:
+ 
+  ```shell
+  docker run --rm -it -v ~/.kube/config:/root/.kube/config derailed/k9s
+  ```
+
 ---
 
 ## PreFlight Checks


### PR DESCRIPTION
Containers with bridge network mode work fine with this.

For local clusters, the API server DNS should be resolvable by container.
If bridge network doesn't work, host network can be tried.
Unfortunately, I couldnt test host networking.

Closes #661.