### PR TITLE
Add new "pendingColor" option for Pending pods

### DIFF
--- a/internal/config/styles.go
+++ b/internal/config/styles.go
@@ -259,7 +259,7 @@ func newStatus() Status {
 		NewColor:       "lightskyblue",
 		ModifyColor:    "greenyellow",
 		AddColor:       "dodgerblue",
-		PendingColor:      "orangered",
+		PendingColor:   "darkorange",
 		ErrorColor:     "orangered",
 		HighlightColor: "aqua",
 		KillColor:      "mediumpurple",

--- a/internal/config/styles.go
+++ b/internal/config/styles.go
@@ -69,6 +69,7 @@ type (
 		NewColor       Color `yaml:"newColor"`
 		ModifyColor    Color `yaml:"modifyColor"`
 		AddColor       Color `yaml:"addColor"`
+		PendingColor   Color `yaml:"pendingColor"`
 		ErrorColor     Color `yaml:"errorColor"`
 		HighlightColor Color `yaml:"highlightColor"`
 		KillColor      Color `yaml:"killColor"`
@@ -258,6 +259,7 @@ func newStatus() Status {
 		NewColor:       "lightskyblue",
 		ModifyColor:    "greenyellow",
 		AddColor:       "dodgerblue",
+		PendingColor:      "orangered",
 		ErrorColor:     "orangered",
 		HighlightColor: "aqua",
 		KillColor:      "mediumpurple",

--- a/internal/render/color.go
+++ b/internal/render/color.go
@@ -11,6 +11,9 @@ var (
 	// AddColor row added color.
 	AddColor tcell.Color
 
+	// PendingColor row added color.
+	PendingColor tcell.Color
+
 	// ErrColor row err color.
 	ErrColor tcell.Color
 

--- a/internal/render/container.go
+++ b/internal/render/container.go
@@ -37,25 +37,6 @@ type ContainerWithMetrics interface {
 // Container renders a K8s Container to screen.
 type Container struct{}
 
-// ColorGet returns a color for a state
-func ColorGet(s string,ns string, h Header, re RowEvent) tcell.Color {
-    switch s {
-    case Pending:
-            return PendingColor
-    case ContainerCreating, PodInitializing:
-            return AddColor
-    case Terminating, Initialized:
-            return HighlightColor
-    case Completed:
-            return CompletedColor
-    case Running:
-            return DefaultColorer(ns, h, re)
-    default:
-            return ErrColor
-    }
-
-}
-
 // ColorerFunc colors a resource row.
 func (c Container) ColorerFunc() ColorerFunc {
 	return func(ns string, h Header, re RowEvent) tcell.Color {
@@ -67,7 +48,20 @@ func (c Container) ColorerFunc() ColorerFunc {
 		if stateCol == -1 {
 			return DefaultColorer(ns, h, re)
 		}
-		return ColorGet(strings.TrimSpace(re.Row.Fields[stateCol]), ns, h, re)
+		switch strings.TrimSpace(re.Row.Fields[stateCol]) {
+		case Pending:
+			return PendingColor
+		case ContainerCreating, PodInitializing:
+			return AddColor
+		case Terminating, Initialized:
+			return HighlightColor
+		case Completed:
+			return CompletedColor
+		case Running:
+			return DefaultColorer(ns, h, re)
+		default:
+			return ErrColor
+		}
 	}
 }
 

--- a/internal/render/container.go
+++ b/internal/render/container.go
@@ -37,6 +37,25 @@ type ContainerWithMetrics interface {
 // Container renders a K8s Container to screen.
 type Container struct{}
 
+// ColorGet returns a color for a state
+func ColorGet(s string,ns string, h Header, re RowEvent) tcell.Color {
+    switch s {
+    case Pending:
+            return PendingColor
+    case ContainerCreating, PodInitializing:
+            return AddColor
+    case Terminating, Initialized:
+            return HighlightColor
+    case Completed:
+            return CompletedColor
+    case Running:
+            return DefaultColorer(ns, h, re)
+    default:
+            return ErrColor
+    }
+
+}
+
 // ColorerFunc colors a resource row.
 func (c Container) ColorerFunc() ColorerFunc {
 	return func(ns string, h Header, re RowEvent) tcell.Color {
@@ -48,18 +67,7 @@ func (c Container) ColorerFunc() ColorerFunc {
 		if stateCol == -1 {
 			return DefaultColorer(ns, h, re)
 		}
-		switch strings.TrimSpace(re.Row.Fields[stateCol]) {
-		case ContainerCreating, PodInitializing:
-			return AddColor
-		case Terminating, Initialized:
-			return HighlightColor
-		case Completed:
-			return CompletedColor
-		case Running:
-			return DefaultColorer(ns, h, re)
-		default:
-			return ErrColor
-		}
+		return ColorGet(strings.TrimSpace(re.Row.Fields[stateCol]), ns, h, re)
 	}
 }
 

--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -30,6 +30,8 @@ func (p Pod) ColorerFunc() ColorerFunc {
 		}
 		status := strings.TrimSpace(re.Row.Fields[statusCol])
 		switch status {
+		case Pending:
+			c = PendingColor
 		case ContainerCreating, PodInitializing:
 			c = AddColor
 		case Initialized:

--- a/internal/render/types.go
+++ b/internal/render/types.go
@@ -23,6 +23,9 @@ const (
 
 	// PodInitializing represents a pod initializing status.
 	PodInitializing = "PodInitializing"
+
+	// Pending represents a pod pending status.
+	Pending = "Pending"
 )
 
 const (

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -156,6 +156,7 @@ func (c *Configurator) updateStyles(f string) {
 	render.AddColor = c.Styles.Frame().Status.AddColor.Color()
 	render.ErrColor = c.Styles.Frame().Status.ErrorColor.Color()
 	render.StdColor = c.Styles.Frame().Status.NewColor.Color()
+	render.PendingColor = c.Styles.Frame().Status.PendingColor.Color()
 	render.HighlightColor = c.Styles.Frame().Status.HighlightColor.Color()
 	render.KillColor = c.Styles.Frame().Status.KillColor.Color()
 	render.CompletedColor = c.Styles.Frame().Status.CompletedColor.Color()

--- a/skins/stock.yml
+++ b/skins/stock.yml
@@ -23,6 +23,7 @@ k9s:
       modifyColor: greenyellow
       addColor: white
       errorColor: orangered
+      pendingColor: orangered
       highlightcolor: aqua
       killColor: mediumpurple
       completedColor: gray


### PR DESCRIPTION
k9s has no explicit color handling for “Pending” pods, so it defaults to `ErrorColor` (a scary red). I added an extra color treatment “pendingColor”, which gives users the option to change that color.