### PR TITLE
updated the executable path when build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ K9s is available on Linux, macOS and Windows platforms.
  2. Build and run the executable
 
       ```shell
-      make build && ./k9s
+      make build && ./execs/k9s
       ```
 
 ---


### PR DESCRIPTION
Just a small update on the readme because the path to the build executable is wrong.