### PR TITLE
Sanitize filename before saving output

### DIFF
--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -288,8 +288,7 @@ func (l *Log) SaveCmd(evt *tcell.EventKey) *tcell.EventKey {
 	return nil
 }
 
-// SanitizeFilename removes characters not allowed by OS
-func SanitizeFilename(name string) string {
+func sanitizeFilename(name string) string {
 	processedString := invalidPathCharsRX.ReplaceAllString(name, "-")
 
 	return processedString
@@ -300,13 +299,13 @@ func ensureDir(dir string) error {
 }
 
 func saveData(cluster, name, data string) (string, error) {
-	dir := filepath.Join(config.K9sDumpDir, SanitizeFilename(cluster))
+	dir := filepath.Join(config.K9sDumpDir, sanitizeFilename(cluster))
 	if err := ensureDir(dir); err != nil {
 		return "", err
 	}
 
 	now := time.Now().UnixNano()
-	fName := fmt.Sprintf("%s-%d.log", SanitizeFilename(name), now)
+	fName := fmt.Sprintf("%s-%d.log", sanitizeFilename(name), now)
 
 	path := filepath.Join(dir, fName)
 	mod := os.O_CREATE | os.O_WRONLY

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -306,7 +306,7 @@ func saveData(cluster, name, data string) (string, error) {
 	}
 
 	now := time.Now().UnixNano()
-	fName := fmt.Sprintf("%s-%d.log", strings.Replace(name, "/", "-", -1), now)
+	fName := fmt.Sprintf("%s-%d.log", SanitizeFilename(name), now)
 
 	path := filepath.Join(dir, fName)
 	mod := os.O_CREATE | os.O_WRONLY

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -28,6 +29,9 @@ const (
 	logCoFmt     = " Logs([hilite:bg:]%s:[hilite:bg:b]%s[-:bg:-])[[green:bg:b]%s[-:bg:-]] "
 	flushTimeout = 50 * time.Millisecond
 )
+
+// InvalidCharsRX contains invalid filename characters.
+var invalidPathCharsRX = regexp.MustCompile(`[:/\\]+`)
 
 // Log represents a generic log viewer.
 type Log struct {
@@ -284,12 +288,19 @@ func (l *Log) SaveCmd(evt *tcell.EventKey) *tcell.EventKey {
 	return nil
 }
 
+// SanitizeFilename removes characters not allowed by OS
+func SanitizeFilename(name string) string {
+	processedString := invalidPathCharsRX.ReplaceAllString(name, "-")
+
+	return processedString
+}
+
 func ensureDir(dir string) error {
 	return os.MkdirAll(dir, 0744)
 }
 
 func saveData(cluster, name, data string) (string, error) {
-	dir := filepath.Join(config.K9sDumpDir, cluster)
+	dir := filepath.Join(config.K9sDumpDir, SanitizeFilename(cluster))
 	if err := ensureDir(dir); err != nil {
 		return "", err
 	}

--- a/internal/view/log_test.go
+++ b/internal/view/log_test.go
@@ -43,6 +43,23 @@ func TestLogViewSave(t *testing.T) {
 	assert.Equal(t, len(c2), len(c1)+1)
 }
 
+func TestSanitizedFilename(t *testing.T) {
+	uu := []struct {
+		name     string
+		expected string
+	}{
+		{"alpha", "alpha"},
+		{"123", "123"},
+		{"with/slash", "with-slash"},
+		{"with:colon", "with-colon"},
+		{":many:invalid\\characters\\", "-many-invalid-characters-"},
+	}
+
+	for _, u := range uu {
+		assert.Equal(t, u.expected, view.SanitizeFilename(u.name))
+	}
+}
+
 // ----------------------------------------------------------------------------
 // Helpers...
 

--- a/internal/view/log_test.go
+++ b/internal/view/log_test.go
@@ -43,23 +43,6 @@ func TestLogViewSave(t *testing.T) {
 	assert.Equal(t, len(c2), len(c1)+1)
 }
 
-func TestSanitizedFilename(t *testing.T) {
-	uu := []struct {
-		name     string
-		expected string
-	}{
-		{"alpha", "alpha"},
-		{"123", "123"},
-		{"with/slash", "with-slash"},
-		{"with:colon", "with-colon"},
-		{":many:invalid\\characters\\", "-many-invalid-characters-"},
-	}
-
-	for _, u := range uu {
-		assert.Equal(t, u.expected, view.SanitizeFilename(u.name))
-	}
-}
-
 // ----------------------------------------------------------------------------
 // Helpers...
 

--- a/internal/view/table_helper.go
+++ b/internal/view/table_helper.go
@@ -18,12 +18,12 @@ import (
 func computeFilename(cluster, ns, title, path string) (string, error) {
 	now := time.Now().UnixNano()
 
-	dir := filepath.Join(config.K9sDumpDir, SanitizeFilename(cluster))
+	dir := filepath.Join(config.K9sDumpDir, sanitizeFilename(cluster))
 	if err := ensureDir(dir); err != nil {
 		return "", err
 	}
 
-	name := title + "-" + SanitizeFilename(path)
+	name := title + "-" + sanitizeFilename(path)
 	if path == "" {
 		name = title
 	}

--- a/internal/view/table_helper.go
+++ b/internal/view/table_helper.go
@@ -18,12 +18,12 @@ import (
 func computeFilename(cluster, ns, title, path string) (string, error) {
 	now := time.Now().UnixNano()
 
-	dir := filepath.Join(config.K9sDumpDir, cluster)
+	dir := filepath.Join(config.K9sDumpDir, SanitizeFilename(cluster))
 	if err := ensureDir(dir); err != nil {
 		return "", err
 	}
 
-	name := title + "-" + strings.Replace(path, "/", "-", -1)
+	name := title + "-" + SanitizeFilename(path)
 	if path == "" {
 		name = title
 	}

--- a/internal/view/yaml.go
+++ b/internal/view/yaml.go
@@ -61,13 +61,13 @@ func enableRegion(str string) string {
 }
 
 func saveYAML(cluster, name, data string) (string, error) {
-	dir := filepath.Join(config.K9sDumpDir, SanitizeFilename(cluster))
+	dir := filepath.Join(config.K9sDumpDir, sanitizeFilename(cluster))
 	if err := ensureDir(dir); err != nil {
 		return "", err
 	}
 
 	now := time.Now().UnixNano()
-	fName := fmt.Sprintf("%s-%d.yml", SanitizeFilename(name), now)
+	fName := fmt.Sprintf("%s-%d.yml", sanitizeFilename(name), now)
 
 	path := filepath.Join(dir, fName)
 	mod := os.O_CREATE | os.O_WRONLY

--- a/internal/view/yaml.go
+++ b/internal/view/yaml.go
@@ -61,13 +61,13 @@ func enableRegion(str string) string {
 }
 
 func saveYAML(cluster, name, data string) (string, error) {
-	dir := filepath.Join(config.K9sDumpDir, cluster)
+	dir := filepath.Join(config.K9sDumpDir, SanitizeFilename(cluster))
 	if err := ensureDir(dir); err != nil {
 		return "", err
 	}
 
 	now := time.Now().UnixNano()
-	fName := fmt.Sprintf("%s-%d.yml", strings.Replace(name, "/", "-", -1), now)
+	fName := fmt.Sprintf("%s-%d.yml", SanitizeFilename(name), now)
 
 	path := filepath.Join(dir, fName)
 	mod := os.O_CREATE | os.O_WRONLY


### PR DESCRIPTION
The AWS cluster name contains `:` characters that are not allowed in a Windows filename. This prevents the log files from being saved on Windows.

Error:
> mkdir C:\Users\User\AppData\Local\Temp\k9s-screens-domain\user\arn:aws:eks:eu-west-1:123456989:cluster: The filename, directory name, or volume label syntax is incorrect.