### PR TITLE
Update VERSION value in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PACKAGE := github.com/derailed/$(NAME)
 GIT     := $(shell git rev-parse --short HEAD)
 SOURCE_DATE_EPOCH ?= $(shell date +%s)
 DATE    := $(shell date -u -d @${SOURCE_DATE_EPOCH} +%FT%T%Z)
-VERSION  ?= v0.19.7
+VERSION  ?= v0.20.2
 IMG_NAME := derailed/k9s
 IMAGE    := ${IMG_NAME}:${VERSION}
 


### PR DESCRIPTION
This hasn't been updated since `0.19.7`; I was wondering why it kept stating I was running `0.19.7` after I updated to what I believed to be `0.20.2` :sweat_smile: 