### PR TITLE
Adds installation instructions for OpenSUSE Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ K9s is available on Linux, macOS and Windows platforms.
   pacman -S k9s
   ```
 
+* On OpenSUSE Linux distribution
+
+  ```shell
+  zypper install k9s
+  ```
+
 * Via [Scoop](https://scoop.sh) for Windows
 
   ```shell


### PR DESCRIPTION
This is a small pull request that adds instructions of how to install k9s in OpenSUSE Linux distribution.