### PR TITLE
Add plugin example to list all resources in a namespace

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -2,9 +2,10 @@
 
 K9s plugins extend the tool to provide additonal functionality via actions to further help you observe or administer your Kubernetes clusters.
 
-| Plugin-Name     | Description                    | Available on Views | Shortcut | Kubectl plugin, external dependencies     |
-|-----------------|--------------------------------|--------------------|----------|-------------------------------------------|
-| log_stern.yml   | View resource logs using stern | pods               | Ctrl-l   |                                           |
-| log_jq.yml      | View resource logs using jq    | pods               | Ctrl-j   | kubetcl-plugins/kubectl-jq                |
-| job_suspend.yml | Suspends a running cronjob     | cronjobs           | Ctrl-s   |                                           |
-| dive.yml        | Dive image layers              | containers         | d        | [Dive](https://github.com/wagoodman/dive) |
+| Plugin-Name     | Description                      | Available on Views | Shortcut | Kubectl plugin, external dependencies                                                 |
+|-----------------|----------------------------------|--------------------|----------|---------------------------------------------------------------------------------------|
+| log_stern.yml   | View resource logs using stern   | pods               | Ctrl-l   |                                                                                       |
+| log_jq.yml      | View resource logs using jq      | pods               | Ctrl-j   | kubetcl-plugins/kubectl-jq                                                            |
+| job_suspend.yml | Suspends a running cronjob       | cronjobs           | Ctrl-s   |                                                                                       |
+| dive.yml        | Dive image layers                | containers         | d        | [Dive](https://github.com/wagoodman/dive)                                             |
+| get-all.yml     | get all resources in a namespace | all                | g        | [Krew](https://krew.sigs.k8s.io/), [ketall](https://github.com/corneliusweig/ketall/) |

--- a/plugins/get-all.yml
+++ b/plugins/get-all.yml
@@ -1,0 +1,13 @@
+plugin:
+  #get all resources in a namespace using the krew get-all plugin
+  get-all:
+    shortCut: g
+    confirm: false
+    description: get-all
+    scopes:
+    - all
+    command: sh
+    background: false
+    args:
+    - -c
+    - "kubectl get-all -n $NAMESPACE | less"


### PR DESCRIPTION
Add the output of the krew get-all plugin to k9s
Used to see all resource in a selected namespace