### PR TITLE
k9s has been added to homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,10 @@ K9s is available on Linux, macOS and Windows platforms.
 
 * Binaries for Linux, Windows and Mac are available as tarballs in the [release](https://github.com/derailed/k9s/releases) page.
 
-* Via Homebrew for macOS
+* Via Homebrew for macOS or LinuxBrew for Linux
 
    ```shell
    brew install k9s
-   ```
-   
-* Via LinuxBrew for Linux
-
-   ```shell
-   brew install derailed/k9s/k9s
    ```
 
 * Via [MacPorts](https://www.macports.org)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,13 @@ K9s is available on Linux, macOS and Windows platforms.
 
 * Binaries for Linux, Windows and Mac are available as tarballs in the [release](https://github.com/derailed/k9s/releases) page.
 
-* Via Homebrew or LinuxBrew for macOS and Linux
+* Via Homebrew for macOS
+
+   ```shell
+   brew install k9s
+   ```
+   
+* Via LinuxBrew for Linux
 
    ```shell
    brew install derailed/k9s/k9s


### PR DESCRIPTION
I added k9s to `homebrew-core` for the added exposure and as a knightly accolade for one of my favourite tools https://github.com/Homebrew/homebrew-core/pull/57432#issuecomment-653924624

I also opened a PR at `linuxbrew-core` but oh boy I have no idea what the CI errors mean and will need some help from a contributor to get their meaning.
https://github.com/Homebrew/linuxbrew-core/pull/20669

