### PR TITLE
Fix a typo in bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,8 +33,8 @@ If applicable, add screenshots to help explain your problem.
 
 **Versions (please complete the following information):**
  - OS: [e.g. OSX]
- - K9s [e.g. 0.1.0]
- - K8s [e.g. 1.11.0]
+ - K9s: [e.g. 0.1.0]
+ - K8s: [e.g. 1.11.0]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
There was a typo in bug report issue template omitting colons.