### PR TITLE
Update images in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build...
-FROM golang:1.14.4-alpine3.11 AS build
+FROM golang:1.15.2-alpine3.12 AS build
 
 WORKDIR /k9s
 COPY go.mod go.sum main.go Makefile ./
@@ -10,7 +10,7 @@ RUN apk --no-cache add make git gcc libc-dev curl && make build
 # -----------------------------------------------------------------------------
 # Build Image...
 
-FROM alpine:3.10.0
+FROM alpine:3.12.0
 
 COPY --from=build /k9s/execs/k9s /bin/k9s
 ENV KUBE_LATEST_VERSION="v1.18.1"


### PR DESCRIPTION
With this PR the base image is updated to `alpine:3.12.0` and the build stage image is updated to `golang:1.15.2-alpine3.12`.
This should silence the high severity warning (CVE-2019-14697) from the image scanner, see e.g.https://quay.io/repository/derailed/k9s/manifest/sha256:b90018ab8adb6cbe5794879b16a34d53a1616dc50748e90eaad6cc1e8124bc1b?tab=vulnerabilities

The fixed alpine version is actually 3.10.2, as noted here https://github.com/alpinelinux/docker-alpine/issues/34#issuecomment-523418358.