### PR TITLE
Add ppc64le target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
       - amd64
       - arm64
       - arm
+      - ppc64le
     goarm:
       - 7
     flags:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go_import_path: github.com/derailed/k9s
 go:
-  - "1.13"
+  - "1.15"
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,14 @@ go_import_path: github.com/derailed/k9s
 go:
   - "1.13"
 
-os:
-  - linux
-  - osx
+jobs:
+  include:
+  - os: linux
+    arch: amd64
+  - os: linux
+    arch: ppc64le
+  - os: osx
+    arch: amd64
 
 dist: trusty
 sudo: false


### PR DESCRIPTION
## Context

I've been using k9s on Raptor Blackbird workstation (running Fedora 32 Linux PowerPC64 LE) for few months. It would be more convenient if the team could provide binary package for ppc64le.

## Changes

* Add ppc64le target

## Notes

TravisCI does support ppc64le

## TODO

* [Fix failed test](https://github.com/derailed/k9s/pull/866)