### PR TITLE
Fix default value of k9s.logger.sinceSeconds same as readme

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -267,7 +267,7 @@ var expectedConfig = `k9s:
   logger:
     tail: 500
     buffer: 800
-    sinceSeconds: 5
+    sinceSeconds: 300
     fullScreenLogs: false
     textWrap: false
     showTime: false
@@ -347,7 +347,7 @@ var resetConfig = `k9s:
   logger:
     tail: 200
     buffer: 2000
-    sinceSeconds: 5
+    sinceSeconds: 300
     fullScreenLogs: false
     textWrap: false
     showTime: false

--- a/internal/config/logger.go
+++ b/internal/config/logger.go
@@ -10,7 +10,7 @@ const (
 	// MaxLogThreshold sets the max value for log size.
 	MaxLogThreshold = 5000
 	// DefaultSinceSeconds tracks default log age.
-	DefaultSinceSeconds = 5 // all logs
+	DefaultSinceSeconds = 300
 )
 
 // Logger tracks logger options


### PR DESCRIPTION
The default value of "k9s.logger.sinceSeconds" config value was changed to 5 sec in v0.21.8, but it's not same as docs.
https://github.com/derailed/k9s/blob/master/README.md#k9s-configuration
This PR fixes default value of it to remove conflict with the doc.