### PR TITLE
Use DefaultColorer for aliases rendering

### DIFF
--- a/internal/render/alias.go
+++ b/internal/render/alias.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/derailed/k9s/internal/client"
-	"github.com/gdamore/tcell"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -15,9 +14,7 @@ type Alias struct{}
 
 // ColorerFunc colors a resource row.
 func (Alias) ColorerFunc() ColorerFunc {
-	return func(ns string, _ Header, re RowEvent) tcell.Color {
-		return tcell.ColorAliceBlue
-	}
+	return DefaultColorer
 }
 
 // Header returns a header row.

--- a/internal/render/alias_test.go
+++ b/internal/render/alias_test.go
@@ -25,15 +25,15 @@ func TestAliasColorer(t *testing.T) {
 		"addAll": {
 			ns: client.AllNamespaces,
 			re: render.RowEvent{Kind: render.EventAdd, Row: r},
-			e:  tcell.ColorAliceBlue},
+			e:  tcell.ColorBlack},
 		"deleteAll": {
 			ns: client.AllNamespaces,
 			re: render.RowEvent{Kind: render.EventDelete, Row: r},
-			e:  tcell.ColorAliceBlue},
+			e:  tcell.ColorBlack},
 		"updateAll": {
 			ns: client.AllNamespaces,
 			re: render.RowEvent{Kind: render.EventUpdate, Row: r},
-			e:  tcell.ColorAliceBlue,
+			e:  tcell.ColorBlack,
 		},
 	}
 

--- a/internal/render/alias_test.go
+++ b/internal/render/alias_test.go
@@ -25,11 +25,11 @@ func TestAliasColorer(t *testing.T) {
 		"addAll": {
 			ns: client.AllNamespaces,
 			re: render.RowEvent{Kind: render.EventAdd, Row: r},
-			e:  tcell.ColorBlack},
+			e:  tcell.ColorBlue},
 		"deleteAll": {
 			ns: client.AllNamespaces,
 			re: render.RowEvent{Kind: render.EventDelete, Row: r},
-			e:  tcell.ColorBlack},
+			e:  tcell.ColorGray},
 		"updateAll": {
 			ns: client.AllNamespaces,
 			re: render.RowEvent{Kind: render.EventUpdate, Row: r},


### PR DESCRIPTION
k9s view for Aliases didn't respect any text color modifications and in "black on white" skins (ie. `kiss.yml`) text was barely visible:
![image](https://user-images.githubusercontent.com/261487/94991260-3780b000-0582-11eb-9b63-7e4bd24ef716.png)

After setting DefaultColorer this view renders correctly as:
![image](https://user-images.githubusercontent.com/261487/94991240-115b1000-0582-11eb-8443-2d34285d614a.png)
