### PR TITLE
Use config.CallTimeout() in APIClient

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -231,7 +231,7 @@ func (a *APIClient) CheckConnectivity() bool {
 		a.connOK = false
 		return a.connOK
 	}
-	cfg.Timeout = defaultCallTimeoutDuration
+	cfg.Timeout = a.config.CallTimeout()
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		log.Error().Err(err).Msgf("Unable to connect to api server")
@@ -277,11 +277,7 @@ func (a *APIClient) HasMetrics() bool {
 		return flag
 	}
 
-	timeout, err := time.ParseDuration(*a.config.flags.Timeout)
-	if err != nil {
-		timeout = defaultCallTimeoutDuration
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), a.config.CallTimeout())
 	defer cancel()
 	if _, err := dial.MetricsV1beta1().NodeMetricses().List(ctx, metav1.ListOptions{Limit: 1}); err == nil {
 		flag = true


### PR DESCRIPTION
`CheckConnectivity()` is always using `defaultCallTimeoutDuration`, not the configured request timeout,  leading to errors like:

```
K9s can't connect to cluster error="Get \"https://XXXXXXXX.gr7.us-east-1.eks.
amazonaws.com/version?timeout=5s\": context deadline exceeded (Client.Timeout
exceeded while awa ...
```

`HasMetrics()` seemed to be redoing the work of parsing the configurable timeout instead of using the `CallTimeout()` function.

This PR should fix both issues.

PS: Thanks for creating and maintaining `k9s`. I use it almost every day.