### PR TITLE
Improve documentation on sinceSeconds in logging config

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ K9s uses aliases to navigate most K8s resources.
       # Defines the total number of log lines to allow in the view. Default 1000
       buffer: 500
       # Represents how far to go back in the log timeline in seconds. Default is 1min
+      # Set to -1 to disable filter
       sinceSeconds: 60
       # Go full screen while displaying logs. Default false
       fullScreenLogs: false


### PR DESCRIPTION
Improve documentation on sinceSeconds in logging config to include info about value to disable filtering.

I would have also updated code for the hosted documentation (https://k9scli.io/topics/config/), but I couldn't figure out how it's created.