### PR TITLE
[BUGFIX] Remove the trailing delta sign from the default replicas of scale form.

### DIFF
--- a/internal/view/scale_extender.go
+++ b/internal/view/scale_extender.go
@@ -59,7 +59,7 @@ func (s *ScaleExtender) makeScaleForm(sel string) *tview.Form {
 	f := s.makeStyledForm()
 	replicas := strings.TrimSpace(s.GetTable().GetCell(s.GetTable().GetSelectedRowIndex(), s.GetTable().NameColIndex()+1).Text)
 	tokens := strings.Split(replicas, "/")
-	replicas = tokens[1]
+	replicas = strings.TrimRight(tokens[1], ui.DeltaSign)
 	f.AddInputField("Replicas:", replicas, 4, func(textToCheck string, lastChar rune) bool {
 		_, err := strconv.Atoi(textToCheck)
 		return err == nil


### PR DESCRIPTION
When I press `s` while the current replica count is changing (for example press `s` and press `s` again while scaling), the default `replicas` in the poped scale form contains the delta sign:

![image](https://user-images.githubusercontent.com/25447002/96329864-59e6f300-1083-11eb-8f07-79f1c87311f5.png)

This PR fixes this by removing the trailing delta sign of the default value obtained from the cell.
