### PR TITLE
Add nano text editor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,11 @@ ARG KUBECTL_VERSION="v1.21.2"
 
 COPY --from=build /k9s/execs/k9s /bin/k9s
 RUN apk add --update ca-certificates \
-  && apk add --update -t deps curl vim \
+  && apk add --update -t deps curl \
   && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
   && chmod +x /usr/local/bin/kubectl \
   && apk del --purge deps \
+  && apk add vim nano \
   && rm /var/cache/apk/*
 
 ENTRYPOINT [ "/bin/k9s" ]

--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ K9s is available on Linux, macOS and Windows platforms.
   docker run --rm -it -v ~/.kube/config:/root/.kube/config quay.io/derailed/k9s
   ```
 
+  An altername text editor (nano) would be enabled by passing EDITOR environemnt variable:
+  ```shell
+  docker run --rm -it -v ~/.kube/config:/root/.kube/config -e EDITOR=nano quay.io/derailed/k9s
+  ```
+
 ### Building your own Docker image
 
   You can build your own Docker image of k9s from the [Dockerfile](Dockerfile) with the following:


### PR DESCRIPTION
- Update Dockerfile to install nano (and vim in a proper way).
- Update README with an option how to select alternate text editor inside the docker container.