### PR TITLE
Fix version tag when building from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PACKAGE := github.com/derailed/$(NAME)
 GIT     := $(shell git rev-parse --short HEAD)
 SOURCE_DATE_EPOCH ?= $(shell date +%s)
 DATE    := $(shell date -u -d @${SOURCE_DATE_EPOCH} +%FT%T%Z)
-VERSION  ?= v0.23.9
+VERSION  ?= 0.23.9
 IMG_NAME := derailed/k9s
 IMAGE    := ${IMG_NAME}:${VERSION}
 


### PR DESCRIPTION
Currently when building via Makefile the version gets a double "v" prefix.

This breaks the "K9s rev" info in the top left panel when running k9s.

Solution is to either remove the extra `v` from the `VERSION =?` variable or from the compile command `(...) cmd.version=v${VERSION} (...)`

