### PR TITLE
Introduce Resource creation and duplication functionality

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,8 @@ var (
 	DefaultK9sHome = filepath.Join(mustK9sHome(), ".k9s")
 	// K9sConfigFile represents K9s config file location.
 	K9sConfigFile = filepath.Join(K9sHome(), "config.yml")
+	// K9sTempFile represents K9s temp file location used for creation of new kubernetes resources.
+	K9sTempFile = filepath.Join(K9sHome(), "tmp.yml")
 	// K9sLogs represents K9s log.
 	K9sLogs = filepath.Join(os.TempDir(), fmt.Sprintf("k9s-%s.log", MustK9sUser()))
 	// K9sDumpDir represents a directory where K9s screen dumps will be persisted.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,8 +22,6 @@ var (
 	DefaultK9sHome = filepath.Join(mustK9sHome(), ".k9s")
 	// K9sConfigFile represents K9s config file location.
 	K9sConfigFile = filepath.Join(K9sHome(), "config.yml")
-	// K9sTempFile represents K9s temp file location used for creation of new kubernetes resources.
-	K9sTempFile = filepath.Join(K9sHome(), "tmp.yml")
 	// K9sLogs represents K9s log.
 	K9sLogs = filepath.Join(os.TempDir(), fmt.Sprintf("k9s-%s.log", MustK9sUser()))
 	// K9sDumpDir represents a directory where K9s screen dumps will be persisted.

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -141,8 +141,8 @@ func (v *LiveView) bindKeys() {
 
 	if v.title == "YAML" {
 		v.actions.Add(ui.KeyActions{
-			ui.KeyM: ui.NewKeyAction("Toggle ManagedFields", v.toggleManagedCmd, true),
 			ui.KeyD: ui.NewKeyAction("Duplicate", v.duplicateCmd, true),
+			ui.KeyM: ui.NewKeyAction("Toggle ManagedFields", v.toggleManagedCmd, true),
 		})
 	}
 }


### PR DESCRIPTION
# Introduce Resource creation and duplication functionality

I love **k9s** but one thing which always bugged me was having to create new resources - it usually meant that I had to:
1) Open a new terminal window and ditch **k9s**
2) Create a new temporary YAML file somewhere to paste the resource yaml content
3) `kubectl apply -f temp.yaml`
4) Remove `temp.yaml` as it's no longer needed (or actually forget to delete it, which happens often which leads to junk/unused files on my file system)
5) Go back to **k9s**

This is way too much of a hassle and at best it slows down an operator's workflow and at worst it may break his focus while working intensely on some issue as the operator now has to do all this miscellaneous stuff when all he wanted to do was to apply a new Kubernetes resource.

## Proposal

This PR propose the addition of two new keybindings:
- Add **New** keybinding (_n_ key) to allow new resource creation while viewing pods, deployments, services etc... This opens a blank text editor where you can paste the yaml content of a Kubernetes resource (or multiple resources separated by `---`) and upon closing the text editor the content will be applied to your Kubernetes cluster.
- Add **Duplicate** keybinding  (_d_ key) in the YAML view to allow creation of new Kubernetes resources by using the current resource as a starting point. This again opens your text editor but this time it pre-populates it with the yaml content of the resource you were just viewing. This allows you to create similar resources by simply using the current one as your base and changing it as you wish. For example - you may be looking at a Kubernetes service of which you may want to create a copy of but maybe change up the ports, you would simply open up the YAML view for the specific service and press the **Duplicate** keybinding  (_d_ key), an editor would open and you would only need to change up the resource name (so it's unique) and the ports you as you like them to change.

The above two actions are things I often need to do and I'm sure other operators also have faced similar issues of having to switch contexts between **k9s** and another terminal window just to do them.

## Related issues

There seem to be an previous (closed) issues which inquire about functionality about easily creating new resources:
https://github.com/derailed/k9s/issues/191 and https://github.com/derailed/k9s/issues/496

## Closing thoughts

To me **k9s** is an awesome tool which saves a ton of time when operating Kubernetes clusters. The only missing peace for me was creation of new resources with ease and quickness. I believe this PR proposed a solution to this missing peace which would make **k9s** a complete package for anyone who wishes to operate Kubernetes clusters with maximum efficiency.

<img width="1675" alt="newBtn" src="https://user-images.githubusercontent.com/15074116/99865848-3d276900-2bb5-11eb-8619-c2df07469de8.png">

<img width="1671" alt="duplicateBtn" src="https://user-images.githubusercontent.com/15074116/99865854-49132b00-2bb5-11eb-9282-6c119471b31c.png">

<img width="660" alt="editMode" src="https://user-images.githubusercontent.com/15074116/99865889-8b3c6c80-2bb5-11eb-8f7c-9567d87e6d47.png">
