### PR TITLE
Handle Empty Port List in PortForward View

### DIFF
--- a/internal/view/pf_dialog.go
+++ b/internal/view/pf_dialog.go
@@ -30,7 +30,12 @@ func ShowPortForwards(v ResourceViewer, path string, ports []string, okFn PortFo
 		SetFieldBackgroundColor(styles.BgColor.Color())
 
 	address := v.App().Config.CurrentCluster().PortForwardAddress
-	p1, p2 := ports[0], extractPort(ports[0])
+
+	p1, p2 := "", ""
+	if len(ports) != 0 {
+		p1, p2 = ports[0], extractPort(ports[0])
+	}
+
 	f.AddInputField("Container Port:", p1, 30, nil, func(p string) {
 		p1 = p
 	})
@@ -80,7 +85,13 @@ func ShowPortForwards(v ResourceViewer, path string, ports []string, okFn PortFo
 	}
 
 	modal := tview.NewModalForm(fmt.Sprintf("<PortForward on %s>", path), f)
-	modal.SetText("Exposed Ports: " + strings.Join(ports, ","))
+
+	if len(ports) != 0 {
+		modal.SetText("Exposed Ports: " + strings.Join(ports, ","))
+	} else {
+		modal.SetText("Exposed Ports: (none)")
+	}
+
 	modal.SetTextColor(styles.FgColor.Color())
 	modal.SetBackgroundColor(styles.BgColor.Color())
 	modal.SetDoneFunc(func(_ int, b string) {

--- a/internal/view/pf_extender.go
+++ b/internal/view/pf_extender.go
@@ -143,9 +143,6 @@ func showFwdDialog(v ResourceViewer, path string, cb PortForwardCB) error {
 			ports = append(ports, client.FQN(co, p.Name)+":"+strconv.Itoa(int(p.ContainerPort)))
 		}
 	}
-	if len(ports) == 0 {
-		return fmt.Errorf("no tcp ports found on %s", path)
-	}
 	ShowPortForwards(v, path, ports, cb)
 
 	return nil


### PR DESCRIPTION
Attempt to fix #959, enabling port forwarding for pods which do not define containerPorts in their manifests.

Example of what would show up when no containerPort is found: 

![capture](https://user-images.githubusercontent.com/8635747/100051790-9af0c680-2dea-11eb-90bf-a19f2f00d8b0.png)
