### PR TITLE
Disable filtering on the Help screen

### DIFF
--- a/internal/view/help.go
+++ b/internal/view/help.go
@@ -56,7 +56,7 @@ func (h *Help) Init(ctx context.Context) error {
 }
 
 func (h *Help) bindKeys() {
-	h.Actions().Delete(ui.KeySpace, tcell.KeyCtrlSpace, tcell.KeyCtrlS)
+	h.Actions().Delete(ui.KeySpace, tcell.KeyCtrlSpace, tcell.KeyCtrlS), ui.KeySlash)
 	h.Actions().Set(ui.KeyActions{
 		tcell.KeyEscape: ui.NewKeyAction("Back", h.app.PrevCmd, true),
 		ui.KeyHelp:      ui.NewKeyAction("Back", h.app.PrevCmd, false),


### PR DESCRIPTION
Do not allow filtering on the Help screen since it doesn't work and causes a crash.

Fixes #967 