### PR TITLE
jq log - handling non json lines as raw with red color 

### DIFF
--- a/plugins/kubectl-plugins/kubectl-jq
+++ b/plugins/kubectl-plugins/kubectl-jq
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/local/bin/kubectl logs -f $1 -n $2 --context $3 | jq -r '.message'
+/usr/local/bin/kubectl logs -f $1 -n $2 --context $3 | jq -rR '. as $raw | try (fromjson | .message) catch ("\u001b[31m" + $raw + "\u001b[0m")'


### PR DESCRIPTION
Input:
```
{"time":"2020-11-28T21:11:15.949Z","severity":"DEBUG","severityLevel":100,"hostname":"update-deployment-58fffbb4dc-2rzvz","message":"NODE_ENV: production","payload":[]}
{"time":"2020-11-28T21:11:16.242Z","severity":"INFO","severityLevel":200,"hostname":"update-deployment-58fffbb4dc-2rzvz","message":"Authentication successfully initialized.","payload":[]}
Sat, 28 Nov 2020 21:11:21 GMT kubernetes-client deprecated require('kubernetes-client').config, use require('kubernetes-client/backends/request').config. at lib/k8s-api/KubeApiClient.js:25:39
Sat, 28 Nov 2020 21:11:21 GMT kubernetes-client deprecated getInCluster see https://github.com/godaddy/kubernetes-client/blob/master/merging-with-kubernetes.md#request-kubeconfig- at lib/k8s-api/KubeApiClient.js:25:46
{"time":"2020-11-28T21:11:21.035Z","severity":"INFO","severityLevel":200,"hostname":"update-deployment-58fffbb4dc-2rzvz","message":"KubeApiClient successfully initialized.","payload":[]}
{"time":"2020-11-28T21:11:21.036Z","severity":"INFO","severityLevel":200,"hostname":"update-deployment-58fffbb4dc-2rzvz","message":"ComputeEngineApiClient successfully initialized.","payload":[]}
{"time":"2020-11-28T21:11:21.081Z","severity":"INFO","severityLevel":200,"hostname":"update-deployment-58fffbb4dc-2rzvz","message":"StorageApi successfully initialized.","payload":[]}
{"time":"2020-11-28T21:11:21.082Z","severity":"INFO","severityLevel":200,"hostname":"update-deployment-58fffbb4dc-2rzvz","message":"BackupHandler successfully initialized.","payload":[]}
{"time":"2020-11-28T21:11:21.082Z","severity":"INFO","severityLevel":200,"hostname":"update-deployment-58fffbb4dc-2rzvz","message":"Worker [update] successfully initialized.","payload":[]}
{"time":"2020-11-28T21:11:21.083Z","severity":"INFO","severityLevel":200,"hostname":"update-deployment-58fffbb4dc-2rzvz","message":"Worker listen.","payload":[]}
```

Original output 
(drop error during parsing)
```
NODE_ENV: production
Authentication successfully initialized.
parse error: Invalid numeric literal at line 3, column
```

New output looks like this
```diff
NODE_ENV: production
Authentication successfully initialized.
- Sat, 28 Nov 2020 21:11:21 GMT kubernetes-client deprecated require('kubernetes-client').config, use require('kubernetes-client/backends/request').config. at lib/k8s-api/KubeApiClient.js:25:39"
- Sat, 28 Nov 2020 21:11:21 GMT kubernetes-client deprecated getInCluster see https://github.com/godaddy/kubernetes-client/blob/master/merging-with-kubernetes.md#request-kubeconfig- at lib/k8s-api/KubeApiClient.js:25:46
KubeApiClient successfully initialized.
ComputeEngineApiClient successfully initialized.
StorageApi successfully initialized.
BackupHandler successfully initialized.
Worker [update] successfully initialized.
Worker listen.
```