### PR TITLE
replacing [h,H]ealess with [h,H]eaderless

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ K9s uses aliases to navigate most K8s resources.
     # Enable mouse support. Default false
     enableMouse: true
     # Set to true to hide K9s header. Default false
-    headless: false
+    headerless: false
     # Set to true to hide K9s crumbs. Default false
     crumbsless: false
     # Indicates whether modification commands like delete/kill/edit are disabled. Default is false

--- a/change_logs/release_0.12.0.md
+++ b/change_logs/release_0.12.0.md
@@ -29,7 +29,7 @@ Here is a snippet:
 # .k9s/config.yml
 k9s:
   refreshRate: 2
-  headless: false
+  headerless: false
   currentContext: crashandburn666
   currentCluster: slowassnot
   fullScreenLogs: true

--- a/change_logs/release_0.8.1.md
+++ b/change_logs/release_0.8.1.md
@@ -18,22 +18,22 @@ So it looks like going all fuzzy was a mistake as we've lost some nice searchabi
 
 ### Location, Location, Location!
 
-There was a few issues related to screen `real estate` with K9s or more specifically the lack of it! Some folks flat out decided not to use K9s just because of the ASCII Logo ;( WTF! In this drop, I'd like to introduce a new presentation mode aka `Headless`.
+There was a few issues related to screen `real estate` with K9s or more specifically the lack of it! Some folks flat out decided not to use K9s just because of the ASCII Logo ;( WTF! In this drop, I'd like to introduce a new presentation mode aka `Headerless`.
 
-Using the following command you can now run K9s headless:
+Using the following command you can now run K9s headerless:
 
 ```shell
-k9s --headless # => Launch K9s without the header rows
+k9s --headerless # => Launch K9s without the header rows
 ```
 
 NOTE! If you forgot your K9s shortcuts already, fear not! I've also updated the help menu so `?` will remind you of all the available options.
 
-Lastly if you really dig the headless mode, you can sneak an extra `headless: true` in your ./k9s/config.yml like so:
+Lastly if you really dig the headerless mode, you can sneak an extra `headerless: true` in your ./k9s/config.yml like so:
 
 ```yaml
 k9s:
   refreshRate: 2
-  headless: false
+  headerless: false
   ...
 ```
 

--- a/change_logs/release_v0.17.4.md
+++ b/change_logs/release_v0.17.4.md
@@ -24,7 +24,7 @@ In order to override the default thresholds (cpu/mem: 80% ), you will need to mo
 # $HOME/.k9s/config.yml
 k9s:
   refreshRate: 2
-  headless: false
+  headerless: false
   ...
   # Specify resources thresholds percentages
   thresholds:

--- a/change_logs/release_v0.17.5.md
+++ b/change_logs/release_v0.17.5.md
@@ -22,7 +22,7 @@ In the previous k9s release, we've introduced the notion of thresholds to provid
 # $HOME/.k9s/config.yml
 k9s:
   refreshRate: 2
-  headless: false
+  headerless: false
   ...
   # Specify resources thresholds in percent - defaults: critical=90, warn=70
   thresholds:

--- a/change_logs/release_v0.19.0.md
+++ b/change_logs/release_v0.19.0.md
@@ -48,7 +48,7 @@ Some terminals often don't offer icon support. In this release there is a new op
 # $HOME/.k9s/config.yml
 k9s:
   refreshRate: 2
-  headless: false
+  headerless: false
   readOnly: false
   noIcons: true  # Enable/Disable K9s icons display.
 ```

--- a/change_logs/release_v0.21.10.md
+++ b/change_logs/release_v0.21.10.md
@@ -31,7 +31,7 @@ Seems like I've broken the golden rule ie never add a feature without providing 
 k9s:
   refreshRate: 2
   enableMouse: true # Defaults to false if not set
-  headless: false
+  headerless: false
   ...
 ```
 

--- a/change_logs/release_v0.22.0.md
+++ b/change_logs/release_v0.22.0.md
@@ -31,7 +31,7 @@ Seems like I've broken the golden rule ie never add a feature without providing 
 k9s:
   refreshRate: 2
   enableMouse: true # Defaults to false if not set
-  headless: false
+  headerless: false
   ...
 ```
 

--- a/change_logs/release_v0.23.0.md
+++ b/change_logs/release_v0.23.0.md
@@ -73,7 +73,7 @@ We've added a new configuCCration to turn off the crumbs via `crumbsLess` config
 ```yaml
 k9s:
   refreshRate: 2
-  headless: false
+  headerless: false
   crumbsless: false
   readOnly: true
   ...

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -107,7 +107,7 @@ func loadConfiguration() *config.Config {
 		k9sCfg.K9s.OverrideRefreshRate(*k9sFlags.RefreshRate)
 	}
 
-	k9sCfg.K9s.OverrideHeadless(*k9sFlags.Headless)
+	k9sCfg.K9s.OverrideHeaderless(*k9sFlags.Headerless)
 	k9sCfg.K9s.OverrideCrumbsless(*k9sFlags.Crumbsless)
 	k9sCfg.K9s.OverrideReadOnly(*k9sFlags.ReadOnly)
 	k9sCfg.K9s.OverrideWrite(*k9sFlags.Write)
@@ -175,8 +175,8 @@ func initK9sFlags() {
 		"Specify a log level (info, warn, debug, error, fatal, panic, trace)",
 	)
 	rootCmd.Flags().BoolVar(
-		k9sFlags.Headless,
-		"headless",
+		k9sFlags.Headerless,
+		"headerless",
 		false,
 		"Turn K9s header off",
 	)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -263,7 +263,7 @@ var expectedConfig = `k9s:
   refreshRate: 100
   maxConnRetry: 5
   enableMouse: false
-  headless: false
+  headerless: false
   crumbsless: false
   readOnly: true
   noIcons: false
@@ -346,7 +346,7 @@ var resetConfig = `k9s:
   refreshRate: 2
   maxConnRetry: 5
   enableMouse: false
-  headless: false
+  headerless: false
   crumbsless: false
   readOnly: false
   noIcons: false

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -15,7 +15,7 @@ const (
 type Flags struct {
 	RefreshRate   *int
 	LogLevel      *string
-	Headless      *bool
+	Headerless      *bool
 	Command       *string
 	AllNamespaces *bool
 	ReadOnly      *bool
@@ -28,7 +28,7 @@ func NewFlags() *Flags {
 	return &Flags{
 		RefreshRate:   intPtr(DefaultRefreshRate),
 		LogLevel:      strPtr(DefaultLogLevel),
-		Headless:      boolPtr(false),
+		Headerless:      boolPtr(false),
 		Command:       strPtr(DefaultCommand),
 		AllNamespaces: boolPtr(false),
 		ReadOnly:      boolPtr(false),

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -14,7 +14,7 @@ type K9s struct {
 	RefreshRate       int                 `yaml:"refreshRate"`
 	MaxConnRetry      int                 `yaml:"maxConnRetry"`
 	EnableMouse       bool                `yaml:"enableMouse"`
-	Headless          bool                `yaml:"headless"`
+	Headerless          bool                `yaml:"headerless"`
 	Crumbsless        bool                `yaml:"crumbsless"`
 	ReadOnly          bool                `yaml:"readOnly"`
 	NoIcons           bool                `yaml:"noIcons"`
@@ -24,7 +24,7 @@ type K9s struct {
 	Clusters          map[string]*Cluster `yaml:"clusters,omitempty"`
 	Thresholds        Threshold           `yaml:"thresholds"`
 	manualRefreshRate int
-	manualHeadless    *bool
+	manualHeaderless    *bool
 	manualCrumbsless  *bool
 	manualReadOnly    *bool
 	manualCommand     *string
@@ -46,12 +46,12 @@ func (k *K9s) OverrideRefreshRate(r int) {
 	k.manualRefreshRate = r
 }
 
-// OverrideHeadless set the headlessness manually.
-func (k *K9s) OverrideHeadless(b bool) {
-	k.manualHeadless = &b
+// OverrideHeaderless set the headerlessness manually.
+func (k *K9s) OverrideHeaderless(b bool) {
+	k.manualHeaderless = &b
 }
 
-// OverrideCrumbsless set the headlessness manually.
+// OverrideCrumbsless set the headerlessness manually.
 func (k *K9s) OverrideCrumbsless(b bool) {
 	k.manualCrumbsless = &b
 }
@@ -76,11 +76,11 @@ func (k *K9s) OverrideCommand(cmd string) {
 	k.manualCommand = &cmd
 }
 
-// IsHeadless returns headless setting.
-func (k *K9s) IsHeadless() bool {
-	h := k.Headless
-	if k.manualHeadless != nil && *k.manualHeadless {
-		h = *k.manualHeadless
+// IsHeaderless returns headerless setting.
+func (k *K9s) IsHeaderless() bool {
+	h := k.Headerless
+	if k.manualHeaderless != nil && *k.manualHeaderless {
+		h = *k.manualHeaderless
 	}
 
 	return h

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -135,7 +135,7 @@ func (a *App) layout(ctx context.Context) {
 
 	a.Main.AddPage("main", main, true, false)
 	a.Main.AddPage("splash", ui.NewSplash(a.Styles, a.version), true, true)
-	a.toggleHeader(!a.Config.K9s.IsHeadless())
+	a.toggleHeader(!a.Config.K9s.IsHeaderless())
 }
 
 func (a *App) initSignals() {


### PR DESCRIPTION
According to 
https://www.oxfordlearnersdictionaries.com/us/definition/english/headless?q=headless and 
https://www.oxfordlearnersdictionaries.com/definition/english/header?q=header 

replacing with the correct word. 