### PR TITLE
[BUGFIX] Correction of CronJob APIVersion

### DIFF
--- a/internal/dao/cronjob.go
+++ b/internal/dao/cronjob.go
@@ -60,7 +60,7 @@ func (c *CronJob) Run(path string) error {
 			Labels:    cj.Spec.JobTemplate.Labels,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         "batch/v1beta",
+					APIVersion:         "batch/v1beta1",
 					Kind:               "CronJob",
 					BlockOwnerDeletion: &true,
 					Name:               cj.Name,


### PR DESCRIPTION
Hi,

Great job on the tool, I love what you got so far and can't wait to see what is yet to come.

I noticed that CronJobs couldn't be triggered in the latest version `v0.24.2` since the APIVersion of the `OwnerReference` was missing a '1'. I fixed it for you, tested it with my clusters and submitting it as PullRequest for your review. Hope it helps.

Again, thanks for the awesome tool, keep up the great work.

--Kimba