### PR TITLE
Option to hide logo

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,6 +108,7 @@ func loadConfiguration() *config.Config {
 	}
 
 	k9sCfg.K9s.OverrideHeadless(*k9sFlags.Headless)
+	k9sCfg.K9s.OverrideLogoless(*k9sFlags.Logoless)
 	k9sCfg.K9s.OverrideCrumbsless(*k9sFlags.Crumbsless)
 	k9sCfg.K9s.OverrideReadOnly(*k9sFlags.ReadOnly)
 	k9sCfg.K9s.OverrideWrite(*k9sFlags.Write)
@@ -179,6 +180,12 @@ func initK9sFlags() {
 		"headless",
 		false,
 		"Turn K9s header off",
+	)
+	rootCmd.Flags().BoolVar(
+		k9sFlags.Logoless,
+		"logoless",
+		false,
+		"Turn K9s logo off",
 	)
 	rootCmd.Flags().BoolVar(
 		k9sFlags.Crumbsless,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -264,6 +264,7 @@ var expectedConfig = `k9s:
   maxConnRetry: 5
   enableMouse: false
   headless: false
+  logoless: false
   crumbsless: false
   readOnly: true
   noIcons: false
@@ -347,6 +348,7 @@ var resetConfig = `k9s:
   maxConnRetry: 5
   enableMouse: false
   headless: false
+  logoless: false
   crumbsless: false
   readOnly: false
   noIcons: false

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -16,6 +16,7 @@ type Flags struct {
 	RefreshRate   *int
 	LogLevel      *string
 	Headless      *bool
+	Logoless      *bool
 	Command       *string
 	AllNamespaces *bool
 	ReadOnly      *bool
@@ -29,6 +30,7 @@ func NewFlags() *Flags {
 		RefreshRate:   intPtr(DefaultRefreshRate),
 		LogLevel:      strPtr(DefaultLogLevel),
 		Headless:      boolPtr(false),
+		Logoless:      boolPtr(false),
 		Command:       strPtr(DefaultCommand),
 		AllNamespaces: boolPtr(false),
 		ReadOnly:      boolPtr(false),

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -15,6 +15,7 @@ type K9s struct {
 	MaxConnRetry      int                 `yaml:"maxConnRetry"`
 	EnableMouse       bool                `yaml:"enableMouse"`
 	Headless          bool                `yaml:"headless"`
+	Logoless          bool                `yaml:"logoless"`
 	Crumbsless        bool                `yaml:"crumbsless"`
 	ReadOnly          bool                `yaml:"readOnly"`
 	NoIcons           bool                `yaml:"noIcons"`
@@ -25,6 +26,7 @@ type K9s struct {
 	Thresholds        Threshold           `yaml:"thresholds"`
 	manualRefreshRate int
 	manualHeadless    *bool
+	manualLogoless    *bool
 	manualCrumbsless  *bool
 	manualReadOnly    *bool
 	manualCommand     *string
@@ -51,7 +53,12 @@ func (k *K9s) OverrideHeadless(b bool) {
 	k.manualHeadless = &b
 }
 
-// OverrideCrumbsless set the headlessness manually.
+// OverrideLogoless set the logolessness manually.
+func (k *K9s) OverrideLogoless(b bool) {
+	k.manualLogoless = &b
+}
+
+// OverrideCrumbsless set the crumbslessness manually.
 func (k *K9s) OverrideCrumbsless(b bool) {
 	k.manualCrumbsless = &b
 }
@@ -81,6 +88,16 @@ func (k *K9s) IsHeadless() bool {
 	h := k.Headless
 	if k.manualHeadless != nil && *k.manualHeadless {
 		h = *k.manualHeadless
+	}
+
+	return h
+}
+
+// IsLogoless returns logoless setting.
+func (k *K9s) IsLogoless() bool {
+	h := k.Logoless
+	if k.manualLogoless != nil && *k.manualLogoless {
+		h = *k.manualLogoless
 	}
 
 	return h

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -48,6 +48,7 @@ type App struct {
 	filterHistory *model.History
 	conRetry      int32
 	showHeader    bool
+	showLogo      bool
 	showCrumbs    bool
 }
 
@@ -135,7 +136,7 @@ func (a *App) layout(ctx context.Context) {
 
 	a.Main.AddPage("main", main, true, false)
 	a.Main.AddPage("splash", ui.NewSplash(a.Styles, a.version), true, true)
-	a.toggleHeader(!a.Config.K9s.IsHeadless())
+	a.toggleHeader(!a.Config.K9s.IsHeadless(), !a.Config.K9s.IsLogoless())
 }
 
 func (a *App) initSignals() {
@@ -197,8 +198,9 @@ func (a *App) ActiveView() model.Component {
 	return a.Content.GetPrimitive("main").(model.Component)
 }
 
-func (a *App) toggleHeader(flag bool) {
-	a.showHeader = flag
+func (a *App) toggleHeader(header, logo bool) {
+	a.showHeader = header
+	a.showLogo = logo
 	flex, ok := a.Main.GetPrimitive("main").(*tview.Flex)
 	if !ok {
 		log.Fatal().Msg("Expecting valid flex view")
@@ -245,7 +247,10 @@ func (a *App) buildHeader() tview.Primitive {
 	}
 	header.AddItem(a.clusterInfo(), clWidth, 1, false)
 	header.AddItem(a.Menu(), 0, 1, false)
-	header.AddItem(a.Logo(), 26, 1, false)
+
+	if a.showLogo {
+		header.AddItem(a.Logo(), 26, 1, false)
+	}
 
 	return header
 }
@@ -524,7 +529,7 @@ func (a *App) toggleHeaderCmd(evt *tcell.EventKey) *tcell.EventKey {
 
 	a.QueueUpdateDraw(func() {
 		a.showHeader = !a.showHeader
-		a.toggleHeader(a.showHeader)
+		a.toggleHeader(a.showHeader, a.showLogo)
 	})
 
 	return nil


### PR DESCRIPTION
Hello, thank you for this great tool.

I tend to run `k9s` in rather small tmux panes and the logo is regularly covering the menu options/shortcuts. This PR
adds an option which lets me hide the logo.

Ideally it would be handled by the UI automatically, the menu options should get preference in 'z-index' when resizing,
but I couldn't find an obvious way to do that with `tview`. Feel free to point me in the right direction.