### PR TITLE
ISSUE-957 - Add a simple pause button to stop auto-refresh on ConfigMap and Secrets

### DIFF
--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -154,7 +154,7 @@ func (v *LiveView) pauseCmd(evt *tcell.EventKey) *tcell.EventKey {
 		v.app.Flash().Info("Auto-refresh is enabled")
 	} else {
 		v.Stop()
-		v.app.Flash().Infof("Auto-refresh is disabled")
+		v.app.Flash().Info("Auto-refresh is disabled")
 	}
 
 	v.paused = !v.paused

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -133,7 +133,7 @@ func (v *LiveView) bindKeys() {
 		tcell.KeyCtrlS:  ui.NewKeyAction("Save", v.saveCmd, false),
 		ui.KeyC:         ui.NewKeyAction("Copy", v.cpCmd, true),
 		ui.KeyF:         ui.NewKeyAction("Toggle FullScreen", v.toggleFullScreenCmd, true),
-		ui.KeyP:         ui.NewKeyAction("Enable/Disable Auto-Refresh", v.pauseCmd, true),
+		ui.KeyP:         ui.NewKeyAction("Toggle Auto-Refresh", v.pauseCmd, true),
 		ui.KeyN:         ui.NewKeyAction("Next Match", v.nextCmd, true),
 		ui.KeyShiftN:    ui.NewKeyAction("Prev Match", v.prevCmd, true),
 		ui.KeySlash:     ui.NewSharedKeyAction("Filter Mode", v.activateCmd, false),

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -33,6 +33,7 @@ type LiveView struct {
 	fullScreen                bool
 	managedField              bool
 	cancel                    context.CancelFunc
+	paused                    bool
 }
 
 // NewLiveView returns a live viewer.
@@ -132,6 +133,7 @@ func (v *LiveView) bindKeys() {
 		tcell.KeyCtrlS:  ui.NewKeyAction("Save", v.saveCmd, false),
 		ui.KeyC:         ui.NewKeyAction("Copy", v.cpCmd, true),
 		ui.KeyF:         ui.NewKeyAction("Toggle FullScreen", v.toggleFullScreenCmd, true),
+		ui.KeyP:         ui.NewKeyAction("Enable/Disable Auto-Refresh", v.pauseCmd, true),
 		ui.KeyN:         ui.NewKeyAction("Next Match", v.nextCmd, true),
 		ui.KeyShiftN:    ui.NewKeyAction("Prev Match", v.prevCmd, true),
 		ui.KeySlash:     ui.NewSharedKeyAction("Filter Mode", v.activateCmd, false),
@@ -143,6 +145,21 @@ func (v *LiveView) bindKeys() {
 			ui.KeyM: ui.NewKeyAction("Toggle ManagedFields", v.toggleManagedCmd, true),
 		})
 	}
+}
+
+// pauseCmd is used for pausing the refreshing of data on config map and secrets
+func (v *LiveView) pauseCmd(evt *tcell.EventKey) *tcell.EventKey {
+	if v.paused {
+		v.Start()
+		v.app.Flash().Info("Auto-refresh is enabled")
+	} else {
+		v.Stop()
+		v.app.Flash().Infof("Auto-refresh is disabled")
+	}
+
+	v.paused = !v.paused
+
+	return evt
 }
 
 func (v *LiveView) keyboard(evt *tcell.EventKey) *tcell.EventKey {


### PR DESCRIPTION
Tries to address this issue/request: https://github.com/derailed/k9s/issues/957

I'm pretty new to the codebase so I have no idea if this is the right way to go about it.

I added a "Enable/Disable Auto-Refresh" button that shows up on `LiveTextView` components.
Which I guess covers secrets and configmaps. (Only tested secrets so far).    
It simply calls the `Stop` or `Start` methods of the `LiveTextView` component.    
I also changed the `Start` method so that the auto-refresh can be off by default, as users recommended in the issue

I made a gif of how it works (You press R), the gif is kind of long because of the low refresh rate, but it gets the point across.

![simplescreenrecorder-2021-03-25_23 59 27](https://user-images.githubusercontent.com/10860860/112730518-3efc9280-8eef-11eb-8afa-e0041ec2627f.gif)
