### PR TITLE
Add gruvbox skins

### DIFF
--- a/skins/gruvbox-dark.yml
+++ b/skins/gruvbox-dark.yml
@@ -38,8 +38,8 @@ k9s:
       numKeyColor: *magenta
     crumbs:
       fgColor: *foreground
-      bgColor: *current_line
-      activeColor: *current_line
+      bgColor: *comment
+      activeColor: *blue
     status:
       newColor: *cyan
       modifyColor: *blue

--- a/skins/gruvbox-dark.yml
+++ b/skins/gruvbox-dark.yml
@@ -1,0 +1,90 @@
+# K9s Gruvbox Dark Skin Contributed by [@indiebrain](https://github.com/indiebrain)
+foreground: &foreground "#ebdbb2"
+background: &background "#272727"
+current_line: &current_line "#ebdbb2"
+selection: &selection "#3c3735"
+comment: &comment "#bdad93"
+cyan: &cyan "#689d69"
+green: &green "#989719"
+orange: &orange "#d79920"
+magenta: &magenta "#b16185"
+blue: &blue "#448488"
+red: &red "#cc231c"
+
+k9s:
+  body:
+    fgColor: *foreground
+    bgColor: *background
+    logoColor: *blue
+  info:
+    fgColor: *magenta
+    sectionColor: *foreground
+  dialog:
+    fgColor: *foreground
+    bgColor: *background
+    buttonFgColor: *foreground
+    buttonBgColor: *magenta
+    buttonFocusFgColor: white
+    buttonFocusBgColor: *cyan
+    labelFgColor: *orange
+    fieldFgColor: *foreground
+  frame:
+    border:
+      fgColor: *selection
+      focusColor: *current_line
+    menu:
+      fgColor: *foreground
+      keyColor: *magenta
+      numKeyColor: *magenta
+    crumbs:
+      fgColor: *foreground
+      bgColor: *current_line
+      activeColor: *current_line
+    status:
+      newColor: *cyan
+      modifyColor: *blue
+      addColor: *green
+      errorColor: *red
+      highlightcolor: *orange
+      killColor: *comment
+      completedColor: *comment
+    title:
+      fgColor: *foreground
+      bgColor: *background
+      highlightColor: *orange
+      counterColor: *blue
+      filterColor: *magenta
+  views:
+    charts:
+      bgColor: background
+      defaultDialColors:
+        - *blue
+        - *red
+      defaultChartColors:
+        - *blue
+        - *red
+    table:
+      fgColor: *foreground
+      bgColor: *background
+      cursorFgColor: *foreground
+      cursorBgColor: *current_line
+      header:
+        fgColor: *foreground
+        bgColor: *background
+        sorterColor: *selection
+    xray:
+      fgColor: *foreground
+      bgColor: *background
+      cursorColor: *current_line
+      graphicColor: *blue
+      showIcons: false
+    yaml:
+      keyColor: *magenta
+      colonColor: *blue
+      valueColor: *foreground
+    logs:
+      fgColor: *foreground
+      bgColor: *background
+      indicator:
+        fgColor: *foreground
+        bgColor: *background

--- a/skins/gruvbox-light.yml
+++ b/skins/gruvbox-light.yml
@@ -38,8 +38,8 @@ k9s:
       numKeyColor: *magenta
     crumbs:
       fgColor: *foreground
-      bgColor: *current_line
-      activeColor: *current_line
+      bgColor: *comment
+      activeColor: *blue
     status:
       newColor: *cyan
       modifyColor: *blue

--- a/skins/gruvbox-light.yml
+++ b/skins/gruvbox-light.yml
@@ -1,0 +1,90 @@
+# K9s Gruvbox Light Skin Contributed by [@indiebrain](https://github.com/indiebrain)
+foreground: &foreground "#3c3735"
+background: &background "#fbf1c7"
+current_line: &current_line "#ebdbb2"
+selection: &selection "#3c3735"
+comment: &comment "#bdad93"
+cyan: &cyan "#689d69"
+green: &green "#989719"
+orange: &orange "#d79920"
+magenta: &magenta "#b16185"
+blue: &blue "#448488"
+red: &red "#cc231c"
+
+k9s:
+  body:
+    fgColor: *foreground
+    bgColor: *background
+    logoColor: *blue
+  info:
+    fgColor: *magenta
+    sectionColor: *foreground
+  dialog:
+    fgColor: *foreground
+    bgColor: *background
+    buttonFgColor: *foreground
+    buttonBgColor: *magenta
+    buttonFocusFgColor: white
+    buttonFocusBgColor: *cyan
+    labelFgColor: *orange
+    fieldFgColor: *foreground
+  frame:
+    border:
+      fgColor: *selection
+      focusColor: *current_line
+    menu:
+      fgColor: *foreground
+      keyColor: *magenta
+      numKeyColor: *magenta
+    crumbs:
+      fgColor: *foreground
+      bgColor: *current_line
+      activeColor: *current_line
+    status:
+      newColor: *cyan
+      modifyColor: *blue
+      addColor: *green
+      errorColor: *red
+      highlightcolor: *orange
+      killColor: *comment
+      completedColor: *comment
+    title:
+      fgColor: *foreground
+      bgColor: *background
+      highlightColor: *orange
+      counterColor: *blue
+      filterColor: *magenta
+  views:
+    charts:
+      bgColor: background
+      defaultDialColors:
+        - *blue
+        - *red
+      defaultChartColors:
+        - *blue
+        - *red
+    table:
+      fgColor: *foreground
+      bgColor: *background
+      cursorFgColor: *foreground
+      cursorBgColor: *current_line
+      header:
+        fgColor: *foreground
+        bgColor: *background
+        sorterColor: *selection
+    xray:
+      fgColor: *foreground
+      bgColor: *background
+      cursorColor: *current_line
+      graphicColor: *blue
+      showIcons: false
+    yaml:
+      keyColor: *magenta
+      colonColor: *blue
+      valueColor: *foreground
+    logs:
+      fgColor: *foreground
+      bgColor: *background
+      indicator:
+        fgColor: *foreground
+        bgColor: *background


### PR DESCRIPTION
Closes #1087

A visual sample of the skins

## gruvbox-light
### Tables
![gruvbox-light-table](https://user-images.githubusercontent.com/59154/114918621-44b20d80-9df5-11eb-9bb4-61bdeddea7a4.png)


### yaml
![gruvbox-light-yaml](https://user-images.githubusercontent.com/59154/114918614-424fb380-9df5-11eb-8ac1-833554055496.png)


### logs
![gruvbox-light-logs](https://user-images.githubusercontent.com/59154/114918489-21875e00-9df5-11eb-8001-8dfa06c2d26c.png)

## gruvbox-dark


### Tables
![gruvbox-dark-table](https://user-images.githubusercontent.com/59154/114918571-395ee200-9df5-11eb-9569-af613abd17e0.png)

### yaml
![gruvbox-dark-yaml](https://user-images.githubusercontent.com/59154/114918533-2f3ce380-9df5-11eb-84f5-a1f7d6b9b96e.png)

### logs
![gruvbox-dark-logs](https://user-images.githubusercontent.com/59154/114918526-2cda8980-9df5-11eb-826d-801a126319be.png)

