### PR TITLE
add back cmd with "-"

### DIFF
--- a/internal/model/nav_history.go
+++ b/internal/model/nav_history.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"strings"
+)
+
+// MaxNavHistory tracks max command NavHistory
+const MaxNavHistory = 20
+
+// NavHistory represents a command NavHistory.
+type NavHistory struct {
+	commands []string
+	limit    int
+}
+
+// NewNavHistory returns a new instance.
+func NewNavHistory(limit int) *NavHistory {
+	return &NavHistory{
+		limit: limit,
+	}
+}
+
+// Push adds a new item.
+func (h *NavHistory) Push(c string) {
+	if c == "" {
+		return
+	}
+	c = strings.ToLower(c)
+	if len(h.commands) < h.limit {
+		h.commands = append([]string{c}, h.commands...)
+		return
+	}
+	h.commands = append([]string{c}, h.commands[:len(h.commands)-1]...)
+}
+
+func (h *NavHistory) Prev() string {
+	if len(h.commands) < 2 {
+		return ""
+	}
+	return h.commands[1]
+}

--- a/internal/model/nav_history_test.go
+++ b/internal/model/nav_history_test.go
@@ -1,0 +1,16 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/derailed/k9s/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNavHistoryPrev(t *testing.T) {
+	h := model.NewNavHistory(3)
+	h.Push("a")
+	h.Push("b")
+
+	assert.Equal(t, "a", h.Prev())
+}

--- a/internal/ui/key.go
+++ b/internal/ui/key.go
@@ -77,6 +77,7 @@ const (
 	KeySlash = 47
 	KeyColon = 58
 	KeySpace = 32
+	KeyHRule = 45
 )
 
 // Define Shift Keys

--- a/internal/view/app_test.go
+++ b/internal/view/app_test.go
@@ -12,5 +12,5 @@ func TestAppNew(t *testing.T) {
 	a := view.NewApp(config.NewConfig(ks{}))
 	a.Init("blee", 10)
 
-	assert.Equal(t, 10, len(a.GetActions()))
+	assert.Equal(t, 11, len(a.GetActions()))
 }

--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -270,6 +270,7 @@ func (c *Command) exec(cmd, gvr string, comp model.Component, clearStack bool) (
 		return err
 	}
 	c.app.cmdHistory.Push(cmd)
+	c.app.navHistory.Push(cmd)
 
 	return
 }


### PR DESCRIPTION
This PR adds a "back" command with "-" key that allows to toggle between current and preview view!

This could be the base for a "recent" panel for navigation

Related to #869 

[![asciicast](https://asciinema.org/a/iXjHH4SoNy6lHV7yk9CBVDoj3.svg)](https://asciinema.org/a/iXjHH4SoNy6lHV7yk9CBVDoj3)

Co-Authored-by: Jaga Santagostino <jagasantagostino@gmail.com>