### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 NAME    := k9s
 PACKAGE := github.com/derailed/$(NAME)
 GIT     := $(shell git rev-parse --short HEAD)
-DATE     := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+SOURCE_DATE_EPOCH ?= $(shell date +%s)
+DATE    := $(shell date -u -d @${SOURCE_DATE_EPOCH} +"%Y-%m-%dT%H:%M:%SZ")
 VERSION  ?= v0.24.7
 IMG_NAME := derailed/k9s
 IMAGE    := ${IMG_NAME}:${VERSION}


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Also use UTC to be independent of timezone.

This variant only works with GNU date.

This was originally merged in 23ac2b6c9fee1822d05db61b95580a97ce344f01 / #572
and then accidentally reverted in d31328a576ba5a39e65a9971f356db244632e1f7

Is the `Makefile` autogenerated? Then we could patch the generator in addition.