### PR TITLE
when k9s --insecure-skip-tls-verify is set, kubectl would set the same

### DIFF
--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -49,7 +49,7 @@ func runK(a *App, opts shellOpts) bool {
 	if g, err := a.Conn().Config().ImpersonateGroups(); err == nil {
 		args = append(args, "--as-group", g)
 	}
-	if isInsecure := a.Conn().Config().Flags().Insecure; *isInsecure {
+	if isInsecure := a.Conn().Config().Flags().Insecure; isInsecure != nil && *isInsecure {
 		args = append(args, "--insecure-skip-tls-verify")
 	}
 	args = append(args, "--context", a.Config.K9s.CurrentContext)

--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -49,6 +49,9 @@ func runK(a *App, opts shellOpts) bool {
 	if g, err := a.Conn().Config().ImpersonateGroups(); err == nil {
 		args = append(args, "--as-group", g)
 	}
+	if isInsecure := a.Conn().Config().Flags().Insecure; *isInsecure {
+		args = append(args, "--insecure-skip-tls-verify")
+	}
 	args = append(args, "--context", a.Config.K9s.CurrentContext)
 	if cfg := a.Conn().Config().Flags().KubeConfig; cfg != nil && *cfg != "" {
 		args = append(args, "--kubeconfig", *cfg)


### PR DESCRIPTION
We have special cases and must skip k8s master's CA verifications. In those cases, we will run 
```
k9s --insecure-skip-tls-verify
```
However, we found a bug that we can't open shell in the insecure mode because kubectl exec would require `--insecure-skip-tls-verify` accordingly.

Here is a fix so when **insecure** option is set at k9s, kubectl will follow use the same option.