### PR TITLE
Increase MaxLogThreshold

### DIFF
--- a/internal/config/logger.go
+++ b/internal/config/logger.go
@@ -8,7 +8,7 @@ const (
 	// DefaultLoggerTailCount tracks default log tail size.
 	DefaultLoggerTailCount = 100
 	// MaxLogThreshold sets the max value for log size.
-	MaxLogThreshold = 5000
+	MaxLogThreshold = 1000000
 	// DefaultSinceSeconds tracks default log age.
 	DefaultSinceSeconds = 60 // all logs
 )


### PR DESCRIPTION
I regularly have to check some event logs that are formatted in pretty JSON, about 200+ lines per event (I know, I know, nothing I can do about it...), so naturally I changed the config file but it reverts down to the hard limit of 5000 when I do.