### PR TITLE
feat: add timeout option for nodeShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ K9s uses aliases to navigate most K8s resources.
           limits:
             cpu: 100m
             memory: 100Mi
+          # Timeout to pull the image
+          timeout: 30
         # The IP Address to use when launching a port-forward.
         portForwardAddress: 1.2.3.4
       kind:

--- a/internal/config/shell_pod.go
+++ b/internal/config/shell_pod.go
@@ -39,6 +39,9 @@ func (s *ShellPod) Validate(client.Connection, KubeSettings) {
 	if len(s.Limits) == 0 {
 		s.Limits = defaultLimits()
 	}
+	if s.Timeout <= 0 {
+		s.Timeout = defaultDockerShellTimeout
+	}
 }
 
 func defaultLimits() Limits {

--- a/internal/config/shell_pod.go
+++ b/internal/config/shell_pod.go
@@ -5,7 +5,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-const defaultDockerShellImage = "busybox:1.31"
+const defaultDockerShellImage   = "busybox:1.31"
+const defaultDockerShellTimeout = 30
 
 // Limits represents resource limits.
 type Limits map[v1.ResourceName]string
@@ -24,9 +25,9 @@ type ShellPod struct {
 func NewShellPod() *ShellPod {
 	return &ShellPod{
 		Image:       defaultDockerShellImage,
-		Namespace:   "defaulta",
+		Namespace:   "default",
 		Limits:      defaultLimits(),
-		Timeout:     30,
+		Timeout:     defaultDockerShellTimeout,
 	}
 }
 

--- a/internal/config/shell_pod.go
+++ b/internal/config/shell_pod.go
@@ -12,19 +12,21 @@ type Limits map[v1.ResourceName]string
 
 // ShellPod represents k9s shell configuration.
 type ShellPod struct {
-	Image     string   `json:"image"`
-	Command   []string `json:"command,omitempty"`
-	Args      []string `json:"args,omitempty"`
-	Namespace string   `json:"namespace"`
-	Limits    Limits   `json:"resources,omitempty"`
+	Image       string   `json:"image"`
+	Command     []string `json:"command,omitempty"`
+	Args        []string `json:"args,omitempty"`
+	Namespace   string   `json:"namespace"`
+	Limits      Limits   `json:"resources,omitempty"`
+	Timeout     int      `json:"timeout"`
 }
 
 // NewShellPod returns a new instance.
 func NewShellPod() *ShellPod {
 	return &ShellPod{
-		Image:     defaultDockerShellImage,
-		Namespace: "default",
-		Limits:    defaultLimits(),
+		Image:       defaultDockerShellImage,
+		Namespace:   "defaulta",
+		Limits:      defaultLimits(),
+		Timeout:     30,
 	}
 }
 

--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -180,7 +180,6 @@ func clearScreen() {
 
 const (
 	k9sShell           = "k9s-shell"
-	k9sShellRetryCount = 10
 	k9sShellRetryDelay = 1 * time.Second
 )
 
@@ -255,6 +254,7 @@ func launchShellPod(a *App, node string) error {
 	a.Flash().Infof("Launching node shell on %s...", node)
 	ns := a.Config.K9s.ActiveCluster().ShellPod.Namespace
 	spec := k9sShellPod(node, a.Config.K9s.ActiveCluster().ShellPod)
+	timeout := a.Config.K9s.ActiveCluster().ShellPod.Timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -267,7 +267,7 @@ func launchShellPod(a *App, node string) error {
 		return err
 	}
 
-	for i := 0; i < k9sShellRetryCount; i++ {
+	for i := 0; i < timeout; i++ {
 		o, err := a.factory.Get("v1/pods", client.FQN(ns, k9sShellPodName()), true, labels.Everything())
 		if err != nil {
 			time.Sleep(k9sShellRetryDelay)


### PR DESCRIPTION
Allow to change the timeout to pull nodeShell container.
Change default timeout from 10 to 30s.