### PR TITLE
Avoid crashing when scaling deployments/statefulsets with a custom view used

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -29,11 +29,12 @@ type (
 
 // Table represents tabular data.
 type Table struct {
-	gvr     client.GVR
-	sortCol SortColumn
-	header  render.Header
-	Path    string
-	Extras  string
+	gvr           client.GVR
+	sortCol       SortColumn
+	readyColIndex int
+	header        render.Header
+	Path          string
+	Extras        string
 	*SelectTable
 	actions     KeyActions
 	cmdBuff     *model.FishBuff
@@ -227,6 +228,7 @@ func (t *Table) doUpdate(data render.TableData) {
 		col++
 	}
 	colIndex := custData.Header.IndexOf(t.sortCol.name, false)
+	t.readyColIndex = custData.Header.IndexOf("READY", true)
 	custData.RowEvents.Sort(
 		custData.Namespace,
 		colIndex,
@@ -349,6 +351,14 @@ func (t *Table) NameColIndex() int {
 		col++
 	}
 	return col
+}
+
+// ReadyColIndex returns the index of the ready column, or -1 if not applicable
+func (t *Table) ReadyColIndex() int {
+	if t.GetModel().ClusterWide() {
+		return t.readyColIndex
+	}
+	return t.readyColIndex - 1
 }
 
 // AddHeaderCell configures a table cell header.

--- a/internal/view/scale_extender.go
+++ b/internal/view/scale_extender.go
@@ -60,7 +60,7 @@ func (s *ScaleExtender) showScaleDialog(path string) {
 
 func (s *ScaleExtender) makeScaleForm(sel string) *tview.Form {
 	f := s.makeStyledForm()
-	replicas := strings.TrimSpace(s.GetTable().GetCell(s.GetTable().GetSelectedRowIndex(), s.GetTable().NameColIndex()+1).Text)
+	replicas := strings.TrimSpace(s.GetTable().GetCell(s.GetTable().GetSelectedRowIndex(), s.GetTable().ReadyColIndex()).Text)
 	tokens := strings.Split(replicas, "/")
 	replicas = strings.TrimRight(tokens[1], ui.DeltaSign)
 	f.AddInputField("Replicas:", replicas, 4, func(textToCheck string, lastChar rune) bool {


### PR DESCRIPTION
This calculates the index of the `READY` field in a reliable way instead of assuming it is following the `NAME` field which can change position if a custom view is used. It closes #1153.