### PR TITLE
Update copyright year in release note

### DIFF
--- a/change_logs/release_v0.24.12.md
+++ b/change_logs/release_v0.24.12.md
@@ -39,4 +39,4 @@ k9s:
 
 ---
 
-<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/imhotep_logo.png" width="32" height="auto"/> © 2020 Imhotep Software LLC. All materials licensed under [Apache v2.0](http://www.apache.org/licenses/LICENSE-2.0)
+<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/imhotep_logo.png" width="32" height="auto"/> © 2021 Imhotep Software LLC. All materials licensed under [Apache v2.0](http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
Probably it should be fixed in release notes template, but I cannot find it