### PR TITLE
fix HIGH and MED severity gosec warnings

### DIFF
--- a/internal/config/alias.go
+++ b/internal/config/alias.go
@@ -105,6 +105,8 @@ func (a *Aliases) Load() error {
 
 // LoadFileAliases loads alias from a given file.
 func (a *Aliases) LoadFileAliases(path string) error {
+	/* #nosec G304 */
+	// functional only called with K9sAlias variable as arg
 	f, err := ioutil.ReadFile(path)
 	if err == nil {
 		var aa Aliases
@@ -171,5 +173,6 @@ func (a *Aliases) SaveAliases(path string) error {
 	if err != nil {
 		return err
 	}
+	/* #nosec G306 */
 	return ioutil.WriteFile(path, cfg, 0644)
 }

--- a/internal/config/bench.go
+++ b/internal/config/bench.go
@@ -96,6 +96,8 @@ func (s *Bench) Reload(path string) error {
 
 // Load K9s benchmark configs from file.
 func (s *Bench) load(path string) error {
+	/* #nosec G304 */
+	// Currently only loads variables that come from hard-coded configs
 	f, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,6 +212,7 @@ func (c *Config) SetConnection(conn client.Connection) {
 
 // Load K9s configuration from file.
 func (c *Config) Load(path string) error {
+	/* #nosec G304 */
 	f, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err
@@ -246,6 +247,7 @@ func (c *Config) SaveFile(path string) error {
 		log.Error().Msgf("[Config] Unable to save K9s config file: %v", err)
 		return err
 	}
+	/* #nosec G306 */
 	return ioutil.WriteFile(path, cfg, 0644)
 }
 

--- a/internal/config/hotkey.go
+++ b/internal/config/hotkey.go
@@ -36,6 +36,7 @@ func (h HotKeys) Load() error {
 
 // LoadHotKeys loads plugins from a given file.
 func (h HotKeys) LoadHotKeys(path string) error {
+	/* #nosec G304 */
 	f, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -40,6 +40,7 @@ func (p Plugins) Load() error {
 
 // LoadPlugins loads plugins from a given file.
 func (p Plugins) LoadPlugins(path string) error {
+	/* #nosec G304 */
 	f, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err

--- a/internal/config/styles.go
+++ b/internal/config/styles.go
@@ -541,6 +541,7 @@ func (s *Styles) Views() Views {
 
 // Load K9s configuration from file.
 func (s *Styles) Load(path string) error {
+	/* #nosec G304 */
 	f, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err

--- a/internal/config/views.go
+++ b/internal/config/views.go
@@ -56,6 +56,7 @@ func (v *CustomView) Reset() {
 
 // Load loads view configurations.
 func (v *CustomView) Load(path string) error {
+	/* #nosec G304 */
 	raw, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err

--- a/internal/dao/ofaas.go
+++ b/internal/dao/ofaas.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	oFaasGatewayEnv  = "OPENFAAS_GATEWAY"
+	oFaasGatewayEnv = "OPENFAAS_GATEWAY"
+	/* #nosec G101 */
 	oFaasJWTTokenEnv = "OPENFAAS_JWT_TOKEN"
 	oFaasTLSInsecure = "OPENFAAS_TLS_INSECURE"
 )

--- a/internal/render/benchmark.go
+++ b/internal/render/benchmark.go
@@ -97,6 +97,7 @@ func (Benchmark) diagnose(ns string, ff Fields) error {
 // Helpers...
 
 func (Benchmark) readFile(file string) (string, error) {
+	/* #nosec G304 */
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
 		return "", err

--- a/internal/view/benchmark.go
+++ b/internal/view/benchmark.go
@@ -71,6 +71,7 @@ func benchDir(cfg *config.Config) string {
 }
 
 func readBenchFile(cfg *config.Config, n string) (string, error) {
+	/* #nosec G304 */
 	data, err := ioutil.ReadFile(filepath.Join(benchDir(cfg), n))
 	if err != nil {
 		return "", err

--- a/internal/view/dir.go
+++ b/internal/view/dir.go
@@ -89,7 +89,7 @@ func (d *Dir) viewCmd(evt *tcell.EventKey) *tcell.EventKey {
 	if path.Ext(sel) == "" {
 		return nil
 	}
-
+	/* #nosec G304 */
 	yaml, err := ioutil.ReadFile(sel)
 	if err != nil {
 		d.App().Flash().Err(err)

--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -113,6 +113,7 @@ func execute(opts shellOpts) error {
 	}()
 
 	log.Debug().Msgf("Running command> %s %s", opts.binary, strings.Join(opts.args, " "))
+	/* #nosec G204 */
 	cmd := exec.Command(opts.binary, opts.args...)
 
 	var err error
@@ -163,6 +164,7 @@ func oneShoot(opts shellOpts) (string, error) {
 	}
 
 	log.Debug().Msgf("Running command> %s %s", opts.binary, strings.Join(opts.args, " "))
+	/* #nosec G204 */
 	cmd := exec.Command(opts.binary, opts.args...)
 
 	var err error

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -350,6 +350,7 @@ func saveData(cluster, name, data string) (string, error) {
 
 	path := filepath.Join(dir, fName)
 	mod := os.O_CREATE | os.O_WRONLY
+	/* #nosec G304 */
 	file, err := os.OpenFile(path, mod, 0600)
 	if err != nil {
 		log.Error().Err(err).Msgf("LogFile create %s", path)

--- a/internal/view/table_helper.go
+++ b/internal/view/table_helper.go
@@ -52,6 +52,7 @@ func saveTable(cluster, title, path string, data render.TableData) (string, erro
 	log.Debug().Msgf("Saving Table to %s", fPath)
 
 	mod := os.O_CREATE | os.O_WRONLY
+	/* #nosec G304 */
 	out, err := os.OpenFile(fPath, mod, 0600)
 	if err != nil {
 		return "", err

--- a/internal/view/yaml.go
+++ b/internal/view/yaml.go
@@ -72,6 +72,7 @@ func saveYAML(cluster, name, data string) (string, error) {
 
 	path := filepath.Join(dir, fName)
 	mod := os.O_CREATE | os.O_WRONLY
+	/* #nosec G304 */
 	file, err := os.OpenFile(path, mod, 0600)
 	if err != nil {
 		log.Error().Err(err).Msgf("YAML create %s", path)

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func init() {
 
 func main() {
 	mod := os.O_CREATE | os.O_APPEND | os.O_WRONLY
+	/* #nosec G304 */
 	file, err := os.OpenFile(config.K9sLogs, mod, config.DefaultFileMod)
 	defer func() {
 		_ = file.Close()


### PR DESCRIPTION
Summary of findings:

G101 - hardcoded credentials - 1
G204 - command injection - 2
G304 - File Path Injection - 14
G306 - File Creation Permissions - 2

## G101 Errors (hardcoded credentials, cwe-798)

Manual review showed up nothing suspect. It simply setting a variable for an environment variable name.

See: https://github.com/derailed/k9s/blob/a9ede22134ad68e7841b88294fd87328895b4604/internal/dao/ofaas.go#L49

GraphQL Query: https://github.com/github/codeql-go/blob/cd1e14ed09f4b56229b5c4fb7797203193b93897/ql/src/Security/CWE-798/HardcodedCredentials.ql

No results for `derailed/k9s`: https://lgtm.com/query/7538063270548585986/

## G204 Errors (command-injection, cwe-78)

Initial Strategy: manually inspect code and traverse function calls to see if user input is used as a variable for the commands.

G204 Error for view/exec.go#L166: https://github.com/derailed/k9s/blob//a9ede22134ad68e7841b88294fd87328895b4604/internal/view/exec.go#L116

This is defined in function `execute`
function `execute` is called by `run`: https://github.com/derailed/k9s/blob/a9ede22134ad68e7841b88294fd87328895b4604/internal/view/exec.go#L73
function `run` is used in 10 places across 4 files:
- `internal/view/command.go`
- `internal/view/app.go`
- `internal/view/actions.go`
- `internal/view/exec.go`

G204 Error for view/exec.go#L166: https://github.com/derailed/k9s/blob//a9ede22134ad68e7841b88294fd87328895b4604/internal/view/exec.go#L166

function `oneShoot` called by function `runKu`https://github.com/derailed/k9s/blob//a9ede22134ad68e7841b88294fd87328895b4604/internal/view/exec.go#L157
function `runKu` called by applyCMD + delCMD:
- https://github.com/derailed/k9s/blob/a9ede22134ad68e7841b88294fd87328895b4604/internal/view/dir.go#L192
- https://github.com/derailed/k9s/blob/a9ede22134ad68e7841b88294fd87328895b4604/internal/view/dir.go#L228

It does not appear that these are consuming user-provided inputs, although given the usecase of `k9s`, if someone is executing arbitrary code through `k9s`, what else are they able to do?

https://lgtm.com/query/6815845775730416472/

Query Taken from: https://github.com/github/codeql-go/blob/cd1e14ed09f4b56229b5c4fb7797203193b93897/ql/src/Security/CWE-078/CommandInjection.ql

![image](https://user-images.githubusercontent.com/86374684/123867262-f932da00-d8e2-11eb-8598-d59a8fe45755.png)

## G304 Errors (path-injection, cwe-22)

https://lgtm.com/query/9221441576788509510/

Query taken from: https://github.com/github/codeql-go/blob/cd1e14ed09f4b56229b5c4fb7797203193b93897/ql/src/Security/CWE-022/TaintedPath.ql

![image](https://user-images.githubusercontent.com/86374684/123867059-ba048900-d8e2-11eb-896c-5641ec47ab25.png)

## G306 Errors (file permission, cwe-276)

No CodeQL demo query currently exists for this.

The code is uscing `0644` for permissions for a config file.
This does not seem to need the stricter restrictions as there is no private information in these files, unlike, perhaps, `kubeconfig` files or `.aws/credentials`.

Will be excluding this issue.