### PR TITLE
Show no pods for an ExternalName Service

### DIFF
--- a/internal/view/svc.go
+++ b/internal/view/svc.go
@@ -60,6 +60,10 @@ func (s *Service) showPods(a *App, _ ui.Tabular, gvr, path string) {
 		return
 	}
 
+	if svc.Spec.Type == v1.ServiceTypeExternalName {
+		a.Flash().Warnf("No pod view available. Service %s is an external service.", path)
+		return
+	}
 	showPodsWithLabels(a, path, svc.Spec.Selector)
 }
 


### PR DESCRIPTION
Previously all pods in the service's namespace were shown.

---

Here are some screenshots of the change. The current behavior of k9s is on the top, and the new behavior is on the bottom.

![ExternalName-Service](https://user-images.githubusercontent.com/20690/125860790-8d7df681-cfb1-4f93-8de4-9cf7114e6ed9.png)
