### PR TITLE
Fix environement variable substitution bug at plugin argument

### DIFF
--- a/internal/view/env.go
+++ b/internal/view/env.go
@@ -3,6 +3,7 @@ package view
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -19,6 +20,12 @@ func (e Env) Substitute(arg string) (string, error) {
 	if len(kk) == 0 {
 		return arg, nil
 	}
+
+	// To prevent the substitution starts with the shorter environment variable,
+	// sort with the length of the found environment variables.
+	sort.Slice(kk, func (i, j int) bool {
+		return len(kk[i]) > len(kk[j])
+	})
 
 	for _, k := range kk {
 		key, inverse := k[1:], false

--- a/internal/view/env_test.go
+++ b/internal/view/env_test.go
@@ -15,6 +15,7 @@ func TestEnvReplace(t *testing.T) {
 	}{
 		"no-args":   {arg: "blee blah", e: "blee blah"},
 		"simple":    {arg: "$A", e: "10"},
+		"substring": {arg: "$A and $AA", e: "10 and 20"},
 		"with-text": {arg: "Something $A", e: "Something 10"},
 		"noMatch":   {arg: "blah blah and $BLEE", err: errors.New(`no environment matching key "$BLEE":"BLEE"`), e: ""},
 		"lower":     {arg: "And then $b happened", e: "And then blee happened"},
@@ -27,6 +28,7 @@ func TestEnvReplace(t *testing.T) {
 
 	e := Env{
 		"A":        "10",
+		"AA":       "20",
 		"B":        "blee",
 		"COL0":     "fred",
 		"FRED":     "fred",


### PR DESCRIPTION
Fix https://github.com/derailed/k9s/issues/1197

The problem is the substitution is executed with the founded order.

To prevent the substitution starts with the shorter environment variable,
sort with the length of the found environment variables.