### PR TITLE
Support bash's process substitution on kubeconfig flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -192,7 +192,7 @@ func initK9sFlags() {
 }
 
 func initK8sFlags() {
-	k8sFlags = genericclioptions.NewConfigFlags(false)
+	k8sFlags = genericclioptions.NewConfigFlags(true)
 
 	rootCmd.Flags().StringVar(
 		k8sFlags.KubeConfig,


### PR DESCRIPTION
Fix https://github.com/derailed/k9s/issues/1210

To support process substitution, load config as persistent config.
This feature prevent to load kubeconfig multiple times.

If you don't like this feature,
I would like to suggest to add another flag to control this feature.
How do you think?

> 	// If set to true, will use persistent client config and
> 	// propagate the config to the places that need it, rather than
> 	// loading the config multiple times

https://github.com/kubernetes/cli-runtime/blob/2cd779a6117f068742c6a60d64267decab243232/pkg/genericclioptions/config_flags.go#L107-L109
