### PR TITLE
kubectl-jq did not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ K9s allows you to extend your command line and tooling by defining your very own
 * Confirm option (when enabled) lets you see the command that is going to be executed and gives you an option to confirm or prevent execution
 * Description will be printed next to the shortcut in the k9s menu
 * Scopes defines a collection of resources names/short-names for the views associated with the plugin. You can specify `all` to provide this shortcut for all views.
-* Command represents ad-hoc commands the plugin runs upon activation
+* Command represents ad-hoc commands the plugin runs upon activation. The command needs to be available in `$PATH` or have a full path defined (`~` is not honored).
 * Background specifies whether or not the command runs in the background
 * Args specifies the various arguments that should apply to the command above
 

--- a/plugins/log_jq.yml
+++ b/plugins/log_jq.yml
@@ -6,10 +6,10 @@ plugin:
     description: "Logs (jq)"
     scopes:
       - po
-    command: kubectl
+    # Replace PATH with the proper path where 'kubectl-jq' can be found, or add that location into '$PATH' and remove 'PATH/' altogether
+    command: PATH/kubectl-jq
     background: false
     args:
-      - jq
       - $NAME
       - $NAMESPACE
       - $CONTEXT


### PR DESCRIPTION
The plugin did not work for me.

The file `kubectl-plugins/kubectl-jq` only asks for 3 variables but `log_jq.yml` provided 4, with 'jq' being the first, which isn't a proper value for `-f $1` (that pod does not exist).

After we fixed that, we'd get this error:

```
ERR Command exited: exec: "kubectl-jq": executable file not found in $PATH error="exec: \"kubectl-jq\": executable file not found in $PATH"
```

So we hardcoded the path to kubectl-jq, which fixed that. To clarify this, I amended the README.md

* Made 'kubectl-jq' work for me
* Amended documentation and yaml for clarity.