### PR TITLE
Revert "Support bash's process substitution on kubeconfig flag"

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -192,7 +192,7 @@ func initK9sFlags() {
 }
 
 func initK8sFlags() {
-	k8sFlags = genericclioptions.NewConfigFlags(true)
+	k8sFlags = genericclioptions.NewConfigFlags(false)
 
 	rootCmd.Flags().StringVar(
 		k8sFlags.KubeConfig,


### PR DESCRIPTION
Reverts derailed/k9s#1211 - no workey ;( Prevents from switching context. Need to investigate...
