### PR TITLE
Added red skin for production envs

### DIFF
--- a/skins/red.yml
+++ b/skins/red.yml
@@ -1,0 +1,82 @@
+k9s:
+  body:
+    fgColor: red
+    bgColor: black
+    logoColor: red
+  prompt:
+    fgColor: red
+    bgColor: black
+    suggestColor: red
+  info:
+    fgColor: red
+    sectionColor: red
+  dialog:
+    fgColor: red
+    bgColor: black
+    buttonFgColor: black
+    buttonBgColor: red
+    buttonFocusFgColor: white
+    buttonFocusBgColor: red
+    labelFgColor: red
+    fieldFgColor: red
+  frame:
+    border:
+      fgColor: red
+      focusColor: red
+    menu:
+      fgColor: white
+      keyColor: red
+      numKeyColor: red
+    crumbs:
+      fgColor: black
+      bgColor: steelblue
+      activeColor: red
+    status:
+      newColor: lightskyblue
+      modifyColor: greenyellow
+      addColor: white
+      errorColor: redred
+      pendingColor: darkred
+      highlightcolor: red
+      killColor: mediumpurple
+      completedColor: gray
+    title:
+      fgColor: red
+      highlightColor: red
+      counterColor: red
+      filterColor: red
+  views:
+    charts:
+      bgColor: black
+      defaultDialColors:
+        - linegreen
+        - redred
+      defaultChartColors:
+        - linegreen
+        - redred
+    table:
+      fgColor: blue
+      bgColor: black
+      cursorFgColor: black
+      cursorBgColor: red
+      markColor: darkgoldenrod
+      header:
+        fgColor: red
+        bgColor: black
+        sorterColor: red
+    xray:
+      fgColor: blue
+      bgColor: black
+      cursorColor: red
+      graphicColor: darkgoldenrod
+      showIcons: false
+    yaml:
+      keyColor: steelblue
+      colonColor: white
+      valueColor: papayawhip
+    logs:
+      fgColor: white
+      bgColor: black
+      indicator:
+        fgColor: red
+        bgColor: black


### PR DESCRIPTION
Hi,

When I'm working on a production environment, I always like to have a skin which very clearly indicates this (using an alarming color). In the default set of skins I couldn't find one so I created one myself with alarming red font colors.

I assume there are more people using this convention, so maybe you can include this skin in the default set?

Regards,
Jan-Kees