### PR TITLE
Node shell pods tolerate all taints

### DIFF
--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -341,6 +341,11 @@ func k9sShellPod(node string, cfg *config.ShellPod) v1.Pod {
 				},
 			},
 			Containers: []v1.Container{c},
+			Tolerations: []v1.Toleration{
+				{
+					Operator: v1.TolerationOperator("Exists"),
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Currently, k9s cannot spawn a node shell on nodes with taints such as, e.g.:

```
taints:
  - effect: NoExecute
    key: component
    value: <some value>
```

I believe that when a user requests a node shell, it is his intention to ignore any taints by default.


This PR adds a

```
tolerations:
  - operator: "Exists"
```

toleration to the node shell pod spec, causing it to ignore all taints.

Ref.: https://docs.openshift.com/container-platform/4.5/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-all_nodes-scheduler-taints-tolerations
