### PR TITLE
[Gruvbox Dark Skin] Improve contrast by changing the table `cursorFgColor` to match the `bgColor`

### DIFF
--- a/skins/gruvbox-dark.yml
+++ b/skins/gruvbox-dark.yml
@@ -70,7 +70,7 @@ k9s:
     table:
       fgColor: *foreground
       bgColor: *background
-      cursorFgColor: *foreground
+      cursorFgColor: *background
       cursorBgColor: *current_line
       header:
         fgColor: *foreground


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/424602/132017276-2732932e-b748-403b-8010-2ae53ebe6ef4.png)
![grafik](https://user-images.githubusercontent.com/424602/132017249-54ab7eb3-7f88-4c34-ab44-77b5196fc4a3.png)
![grafik](https://user-images.githubusercontent.com/424602/132017385-60fbd766-f08c-4a7f-b6d5-2a47f7bdee30.png)

After:
![grafik](https://user-images.githubusercontent.com/424602/132017494-656aaa2d-9830-4885-8138-fd5a3de67035.png)
![grafik](https://user-images.githubusercontent.com/424602/132017528-1177c25b-925e-40b0-b844-dc7ba7b62674.png)
![grafik](https://user-images.githubusercontent.com/424602/132017575-098af957-c6e7-47a3-ae7a-dadc47c5b665.png)

As you can see, the text in the table header is now readable when it's selected, too.