### PR TITLE
feat: change sort col using two fixed keys

### DIFF
--- a/internal/render/row_event.go
+++ b/internal/render/row_event.go
@@ -196,7 +196,7 @@ func (r RowEvents) FindIndex(id string) (int, bool) {
 }
 
 // Sort rows based on column index and order.
-func (r RowEvents) Sort(ns string, sortCol int, ageCol, numCol, asc bool) {
+func (r RowEvents) Sort(ns string, sortCol int, ageCol, numCol, qtyCol, asc bool) {
 	if sortCol == -1 {
 		return
 	}
@@ -208,6 +208,7 @@ func (r RowEvents) Sort(ns string, sortCol int, ageCol, numCol, asc bool) {
 		Asc:        asc,
 		IsNumber:   numCol,
 		IsDuration: ageCol,
+		IsQuantity: qtyCol,
 	}
 	sort.Sort(t)
 
@@ -239,6 +240,7 @@ type RowEventSorter struct {
 	NS         string
 	IsNumber   bool
 	IsDuration bool
+	IsQuantity bool
 	Asc        bool
 }
 
@@ -252,7 +254,7 @@ func (r RowEventSorter) Swap(i, j int) {
 
 func (r RowEventSorter) Less(i, j int) bool {
 	f1, f2 := r.Events[i].Row.Fields, r.Events[j].Row.Fields
-	return Less(r.Asc, r.IsNumber, r.IsDuration, f1[r.Index], f2[r.Index])
+	return Less(r.Asc, r.IsNumber, r.IsDuration, r.IsQuantity, f1[r.Index], f2[r.Index])
 }
 
 // ----------------------------------------------------------------------------

--- a/internal/render/row_event_test.go
+++ b/internal/render/row_event_test.go
@@ -409,10 +409,10 @@ func TestRowEventsDelete(t *testing.T) {
 
 func TestRowEventsSort(t *testing.T) {
 	uu := map[string]struct {
-		re            render.RowEvents
-		col           int
-		age, num, asc bool
-		e             render.RowEvents
+		re                 render.RowEvents
+		col                int
+		age, num, qty, asc bool
+		e                  render.RowEvents
 	}{
 		"age_time": {
 			re: render.RowEvents{
@@ -442,6 +442,38 @@ func TestRowEventsSort(t *testing.T) {
 				{Row: render.Row{ID: "B", Fields: render.Fields{"0", "2", "1m10s"}}},
 				{Row: render.Row{ID: "C", Fields: render.Fields{"10", "2", "3h20m5s"}}},
 				{Row: render.Row{ID: "A", Fields: render.Fields{"1", "2", "32d"}}},
+			},
+		},
+		"qty": {
+			re: render.RowEvents{
+				{Row: render.Row{ID: "B", Fields: render.Fields{"0", "2", "900Mi"}}},
+				{Row: render.Row{ID: "C", Fields: render.Fields{"10", "2", "100Mi"}}},
+				{Row: render.Row{ID: "A", Fields: render.Fields{"1", "2", "8Gi"}}},
+			},
+
+			col: 2,
+			asc: true,
+			qty: true,
+			e: render.RowEvents{
+				{Row: render.Row{ID: "C", Fields: render.Fields{"10", "2", "100Mi"}}},
+				{Row: render.Row{ID: "B", Fields: render.Fields{"0", "2", "900Mi"}}},
+				{Row: render.Row{ID: "A", Fields: render.Fields{"1", "2", "8Gi"}}},
+			},
+		},
+		"qty_desc": {
+			re: render.RowEvents{
+				{Row: render.Row{ID: "B", Fields: render.Fields{"0", "2", "900Mi"}}},
+				{Row: render.Row{ID: "C", Fields: render.Fields{"10", "2", "100Mi"}}},
+				{Row: render.Row{ID: "A", Fields: render.Fields{"1", "2", "8Gi"}}},
+			},
+
+			col: 2,
+			asc: false,
+			qty: true,
+			e: render.RowEvents{
+				{Row: render.Row{ID: "A", Fields: render.Fields{"1", "2", "8Gi"}}},
+				{Row: render.Row{ID: "B", Fields: render.Fields{"0", "2", "900Mi"}}},
+				{Row: render.Row{ID: "C", Fields: render.Fields{"10", "2", "100Mi"}}},
 			},
 		},
 		"col0": {
@@ -483,7 +515,7 @@ func TestRowEventsSort(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			u.re.Sort("", u.col, u.age, u.num, u.asc)
+			u.re.Sort("", u.col, u.age, u.num, u.qty, u.asc)
 			assert.Equal(t, u.e, u.re)
 		})
 	}

--- a/internal/ui/key.go
+++ b/internal/ui/key.go
@@ -10,6 +10,8 @@ func initKeys() {
 	tcell.KeyNames[tcell.Key(KeyHelp)] = "?"
 	tcell.KeyNames[tcell.Key(KeySlash)] = "/"
 	tcell.KeyNames[tcell.Key(KeySpace)] = "space"
+	tcell.KeyNames[tcell.Key(KeyLess)] = "<"
+	tcell.KeyNames[tcell.Key(KeyGreater)] = ">"
 
 	initNumbKeys()
 	initStdKeys()
@@ -73,10 +75,12 @@ const (
 	KeyX
 	KeyY
 	KeyZ
-	KeyHelp  = 63
-	KeySlash = 47
-	KeyColon = 58
-	KeySpace = 32
+	KeyHelp    = 63
+	KeySlash   = 47
+	KeyColon   = 58
+	KeySpace   = 32
+	KeyLess    = 60
+	KeyGreater = 62
 )
 
 // Define Shift Keys.

--- a/internal/ui/types.go
+++ b/internal/ui/types.go
@@ -18,6 +18,14 @@ type (
 		name string
 		asc  bool
 	}
+
+	// SortChange changes the column on which to sort
+	SortChange bool
+)
+
+const (
+	SortNextCol SortChange = true
+	SortPrevCol SortChange = false
 )
 
 // Namespaceable represents a namespaceable model.

--- a/internal/view/alias_test.go
+++ b/internal/view/alias_test.go
@@ -23,7 +23,7 @@ func TestAliasNew(t *testing.T) {
 
 	assert.Nil(t, v.Init(makeContext()))
 	assert.Equal(t, "Aliases", v.Name())
-	assert.Equal(t, 6, len(v.Hints()))
+	assert.Equal(t, 9, len(v.Hints()))
 }
 
 func TestAliasSearch(t *testing.T) {

--- a/internal/view/cm_test.go
+++ b/internal/view/cm_test.go
@@ -13,5 +13,5 @@ func TestConfigMapNew(t *testing.T) {
 
 	assert.Nil(t, s.Init(makeCtx()))
 	assert.Equal(t, "ConfigMaps", s.Name())
-	assert.Equal(t, 6, len(s.Hints()))
+	assert.Equal(t, 9, len(s.Hints()))
 }

--- a/internal/view/container_test.go
+++ b/internal/view/container_test.go
@@ -13,5 +13,5 @@ func TestContainerNew(t *testing.T) {
 
 	assert.Nil(t, c.Init(makeCtx()))
 	assert.Equal(t, "Containers", c.Name())
-	assert.Equal(t, 18, len(c.Hints()))
+	assert.Equal(t, 21, len(c.Hints()))
 }

--- a/internal/view/context_test.go
+++ b/internal/view/context_test.go
@@ -13,5 +13,5 @@ func TestContext(t *testing.T) {
 
 	assert.Nil(t, ctx.Init(makeCtx()))
 	assert.Equal(t, "Contexts", ctx.Name())
-	assert.Equal(t, 4, len(ctx.Hints()))
+	assert.Equal(t, 7, len(ctx.Hints()))
 }

--- a/internal/view/dir_test.go
+++ b/internal/view/dir_test.go
@@ -12,5 +12,5 @@ func TestDir(t *testing.T) {
 
 	assert.Nil(t, v.Init(makeCtx()))
 	assert.Equal(t, "Directory", v.Name())
-	assert.Equal(t, 7, len(v.Hints()))
+	assert.Equal(t, 10, len(v.Hints()))
 }

--- a/internal/view/dp_test.go
+++ b/internal/view/dp_test.go
@@ -13,5 +13,5 @@ func TestDeploy(t *testing.T) {
 
 	assert.Nil(t, v.Init(makeCtx()))
 	assert.Equal(t, "Deployments", v.Name())
-	assert.Equal(t, 14, len(v.Hints()))
+	assert.Equal(t, 17, len(v.Hints()))
 }

--- a/internal/view/ds_test.go
+++ b/internal/view/ds_test.go
@@ -13,5 +13,5 @@ func TestDaemonSet(t *testing.T) {
 
 	assert.Nil(t, v.Init(makeCtx()))
 	assert.Equal(t, "DaemonSets", v.Name())
-	assert.Equal(t, 15, len(v.Hints()))
+	assert.Equal(t, 18, len(v.Hints()))
 }

--- a/internal/view/help_test.go
+++ b/internal/view/help_test.go
@@ -21,7 +21,7 @@ func TestHelp(t *testing.T) {
 	v := view.NewHelp(app)
 
 	assert.Nil(t, v.Init(ctx))
-	assert.Equal(t, 25, v.GetRowCount())
+	assert.Equal(t, 28, v.GetRowCount())
 	assert.Equal(t, 6, v.GetColumnCount())
 	assert.Equal(t, "<a>", strings.TrimSpace(v.GetCell(1, 0).Text))
 	assert.Equal(t, "Attach", strings.TrimSpace(v.GetCell(1, 1).Text))

--- a/internal/view/ns_test.go
+++ b/internal/view/ns_test.go
@@ -13,5 +13,5 @@ func TestNSCleanser(t *testing.T) {
 
 	assert.Nil(t, ns.Init(makeCtx()))
 	assert.Equal(t, "Namespaces", ns.Name())
-	assert.Equal(t, 7, len(ns.Hints()))
+	assert.Equal(t, 10, len(ns.Hints()))
 }

--- a/internal/view/pf_test.go
+++ b/internal/view/pf_test.go
@@ -13,5 +13,5 @@ func TestPortForwardNew(t *testing.T) {
 
 	assert.Nil(t, pf.Init(makeCtx()))
 	assert.Equal(t, "PortForwards", pf.Name())
-	assert.Equal(t, 10, len(pf.Hints()))
+	assert.Equal(t, 13, len(pf.Hints()))
 }

--- a/internal/view/pod_test.go
+++ b/internal/view/pod_test.go
@@ -16,7 +16,7 @@ func TestPodNew(t *testing.T) {
 
 	assert.Nil(t, po.Init(makeCtx()))
 	assert.Equal(t, "Pods", po.Name())
-	assert.Equal(t, 24, len(po.Hints()))
+	assert.Equal(t, 27, len(po.Hints()))
 }
 
 // Helpers...

--- a/internal/view/pvc_test.go
+++ b/internal/view/pvc_test.go
@@ -13,5 +13,5 @@ func TestPVCNew(t *testing.T) {
 
 	assert.Nil(t, v.Init(makeCtx()))
 	assert.Equal(t, "PersistentVolumeClaims", v.Name())
-	assert.Equal(t, 10, len(v.Hints()))
+	assert.Equal(t, 13, len(v.Hints()))
 }

--- a/internal/view/rbac_test.go
+++ b/internal/view/rbac_test.go
@@ -13,5 +13,5 @@ func TestRbacNew(t *testing.T) {
 
 	assert.Nil(t, v.Init(makeCtx()))
 	assert.Equal(t, "Rbac", v.Name())
-	assert.Equal(t, 5, len(v.Hints()))
+	assert.Equal(t, 8, len(v.Hints()))
 }

--- a/internal/view/reference_test.go
+++ b/internal/view/reference_test.go
@@ -13,5 +13,5 @@ func TestReferenceNew(t *testing.T) {
 
 	assert.Nil(t, s.Init(makeCtx()))
 	assert.Equal(t, "References", s.Name())
-	assert.Equal(t, 4, len(s.Hints()))
+	assert.Equal(t, 7, len(s.Hints()))
 }

--- a/internal/view/screen_dump_test.go
+++ b/internal/view/screen_dump_test.go
@@ -13,5 +13,5 @@ func TestScreenDumpNew(t *testing.T) {
 
 	assert.Nil(t, po.Init(makeCtx()))
 	assert.Equal(t, "ScreenDumps", po.Name())
-	assert.Equal(t, 5, len(po.Hints()))
+	assert.Equal(t, 8, len(po.Hints()))
 }

--- a/internal/view/secret_test.go
+++ b/internal/view/secret_test.go
@@ -13,5 +13,5 @@ func TestSecretNew(t *testing.T) {
 
 	assert.Nil(t, s.Init(makeCtx()))
 	assert.Equal(t, "Secrets", s.Name())
-	assert.Equal(t, 7, len(s.Hints()))
+	assert.Equal(t, 10, len(s.Hints()))
 }

--- a/internal/view/sts_test.go
+++ b/internal/view/sts_test.go
@@ -13,5 +13,5 @@ func TestStatefulSetNew(t *testing.T) {
 
 	assert.Nil(t, s.Init(makeCtx()))
 	assert.Equal(t, "StatefulSets", s.Name())
-	assert.Equal(t, 12, len(s.Hints()))
+	assert.Equal(t, 15, len(s.Hints()))
 }

--- a/internal/view/svc_test.go
+++ b/internal/view/svc_test.go
@@ -162,5 +162,5 @@ func TestServiceNew(t *testing.T) {
 
 	assert.Nil(t, s.Init(makeCtx()))
 	assert.Equal(t, "Services", s.Name())
-	assert.Equal(t, 10, len(s.Hints()))
+	assert.Equal(t, 13, len(s.Hints()))
 }

--- a/internal/view/table.go
+++ b/internal/view/table.go
@@ -181,6 +181,9 @@ func (t *Table) bindKeys() {
 		tcell.KeyCtrlW:         ui.NewKeyAction("Toggle Wide", t.toggleWideCmd, false),
 		ui.KeyShiftN:           ui.NewKeyAction("Sort Name", t.SortColCmd(nameCol, true), false),
 		ui.KeyShiftA:           ui.NewKeyAction("Sort Age", t.SortColCmd(ageCol, true), false),
+		ui.KeyQ:                ui.NewKeyAction("Reverse sort order", t.SortInvertCmd, false),
+		ui.KeyLess:             ui.NewKeyAction("Sort Previous Column", t.SortColChange(ui.SortPrevCol), false),
+		ui.KeyGreater:          ui.NewKeyAction("Sort Next Column", t.SortColChange(ui.SortNextCol), false),
 	})
 }
 

--- a/internal/view/table_int_test.go
+++ b/internal/view/table_int_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,7 +65,7 @@ func TestTableNew(t *testing.T) {
 func TestTableViewFilter(t *testing.T) {
 	v := NewTable(client.NewGVR("test"))
 	v.Init(makeContext())
-	v.SetModel(&mockTableModel{})
+	v.SetModel(defaultModelMock())
 	v.Refresh()
 	v.CmdBuff().SetActive(true)
 	v.CmdBuff().SetText("blee")
@@ -75,7 +76,7 @@ func TestTableViewFilter(t *testing.T) {
 func TestTableViewSort(t *testing.T) {
 	v := NewTable(client.NewGVR("test"))
 	v.Init(makeContext())
-	v.SetModel(&mockTableModel{})
+	v.SetModel(defaultModelMock())
 	v.SortColCmd("NAME", true)(nil)
 	assert.Equal(t, 3, v.GetRowCount())
 	assert.Equal(t, "blee", v.GetCell(1, 0).Text)
@@ -85,44 +86,190 @@ func TestTableViewSort(t *testing.T) {
 	assert.Equal(t, "fred", v.GetCell(1, 0).Text)
 }
 
+func TestTableViewSortChangeSmoke(t *testing.T) {
+	v := NewTable(client.NewGVR("test"))
+	v.Init(makeContext())
+	v.SetModel(defaultModelMock())
+	v.SortColCmd("NAME", true)(nil)
+	assert.Equal(t, 3, v.GetRowCount())
+	assert.Equal(t, "blee", v.GetCell(1, 0).Text)
+
+	v.SortColChange(ui.SortNextCol)(nil)
+	v.SortColChange(ui.SortNextCol)(nil)
+	sortCol, asc := v.GetSortCol()
+	assert.Equal(t, "AGE", sortCol)
+	assert.Equal(t, true, asc)
+	assert.Equal(t, "fred", v.GetCell(1, 0).Text)
+
+	v.SortInvertCmd(nil)
+	_, asc = v.GetSortCol()
+	assert.Equal(t, false, asc)
+	assert.Equal(t, "blee", v.GetCell(1, 0).Text)
+}
+
+type SortSteps []struct {
+	change  ui.SortChange
+	reverse bool
+
+	sortCol string
+	asc     bool
+	value   string
+	col     int
+}
+
+func TestTableViewSortWrapAround(t *testing.T) {
+	v := NewTable(client.NewGVR("test"))
+	v.Init(makeContext())
+	v.SetModel(modelMockForSortingMinimal())
+	v.SortColCmd("NAME", true)(nil)
+	assert.Equal(t, 3, v.GetRowCount())
+
+	steps := SortSteps{
+		{change: ui.SortNextCol, sortCol: "FRED", asc: true, value: "fred1", col: 1},
+		{change: ui.SortNextCol, sortCol: "AGE", asc: true, value: "90s", col: 2},
+		{change: ui.SortNextCol, sortCol: "NAME", asc: true, value: "name1", col: 0},
+		{change: ui.SortNextCol, reverse: true, sortCol: "FRED", asc: false, value: "fred2", col: 1},
+		{change: ui.SortPrevCol, sortCol: "NAME", asc: false, value: "name2", col: 0},
+		{change: ui.SortPrevCol, sortCol: "AGE", asc: false, value: "110s", col: 2},
+		{change: ui.SortPrevCol, sortCol: "FRED", asc: false, value: "fred2", col: 1},
+	}
+
+	runSortSteps(t, v, steps)
+}
+
+func TestTableViewFullSortWrapAround(t *testing.T) {
+	v := NewTable(client.NewGVR("test"))
+	v.ToggleWide() // Enable wide display
+	v.Init(makeContext())
+	v.SetModel(modelMockForSortingFull())
+	v.Update(makeTableDataForSorting(), true) // Enable metrics
+	v.SortColCmd("NAME", true)(nil)
+	assert.Equal(t, 3, v.GetRowCount())
+
+	steps := SortSteps{
+		{change: ui.SortNextCol, sortCol: "LABELS", asc: true, value: "k8s-app=kube-dns1", col: 2},
+		{change: ui.SortNextCol, sortCol: "FRED", asc: true, value: "fred1", col: 3},
+		{change: ui.SortNextCol, sortCol: "CPU", asc: true, value: "10", col: 4},
+		{change: ui.SortNextCol, sortCol: "AGE", asc: true, value: "90s", col: 5},
+		{change: ui.SortNextCol, sortCol: "NAMESPACE", asc: true, value: "ns1", col: 0},
+		{change: ui.SortNextCol, reverse: true, sortCol: "NAME", asc: false, value: "name2", col: 1},
+		{change: ui.SortPrevCol, sortCol: "NAMESPACE", asc: false, value: "ns1", col: 0},
+		{change: ui.SortPrevCol, sortCol: "AGE", asc: false, value: "110s", col: 5},
+		{change: ui.SortPrevCol, sortCol: "CPU", asc: false, value: "20", col: 4},
+		{change: ui.SortPrevCol, sortCol: "FRED", asc: false, value: "fred2", col: 3},
+		{change: ui.SortPrevCol, sortCol: "LABELS", asc: false, value: "k8s-app=kube-dns2", col: 2},
+	}
+
+	runSortSteps(t, v, steps)
+}
+
+func runSortSteps(t *testing.T, v *Table, steps SortSteps) {
+	for _, step := range steps {
+		v.SortColChange(step.change)(nil)
+		if step.reverse {
+			v.SortInvertCmd(nil)
+		}
+		sortCol, asc := v.GetSortCol()
+		assert.Equal(t, step.sortCol, sortCol)
+		assert.Equal(t, step.asc, asc)
+		assert.Equal(t, step.value, strings.TrimSpace(v.GetCell(1, step.col).Text))
+	}
+}
+
+func TestTableViewSortCapacity(t *testing.T) {
+	v := NewTable(client.NewGVR("test"))
+	v.Init(makeContext())
+
+	data := render.NewTableData()
+	data.Header = render.Header{
+		render.HeaderColumn{Name: "NAMESPACE"},
+		render.HeaderColumn{Name: "NAME", Align: tview.AlignRight},
+		render.HeaderColumn{Name: "CAPACITY"},
+		render.HeaderColumn{Name: "AGE", Time: true, Decorator: render.AgeDecorator},
+	}
+	data.RowEvents = render.RowEvents{
+		render.RowEvent{
+			Row: render.Row{
+				Fields: render.Fields{"ns1", "a", "100Mi", "3m"},
+			},
+		},
+		render.RowEvent{
+			Row: render.Row{
+				Fields: render.Fields{"ns1", "b", "900Mi", "1m"},
+			},
+		},
+		render.RowEvent{
+			Row: render.Row{
+				Fields: render.Fields{"ns1", "c", "8Gi", "10m"},
+			},
+		},
+	}
+	data.Namespace = ""
+
+	v.SetSortCol("CAPACITY", true)
+	v.Update(*data, false)
+	assert.Equal(t, "100Mi", strings.TrimSpace(v.GetCell(1, 2).Text))
+	assert.Equal(t, "900Mi", strings.TrimSpace(v.GetCell(2, 2).Text))
+	assert.Equal(t, "8Gi", strings.TrimSpace(v.GetCell(3, 2).Text))
+	v.SetSortCol("CAPACITY", false)
+	v.Update(*data, false)
+	assert.Equal(t, "8Gi", strings.TrimSpace(v.GetCell(1, 2).Text))
+	assert.Equal(t, "900Mi", strings.TrimSpace(v.GetCell(2, 2).Text))
+	assert.Equal(t, "100Mi", strings.TrimSpace(v.GetCell(3, 2).Text))
+}
+
 // ----------------------------------------------------------------------------
 // Helpers...
 
-type mockTableModel struct{}
-
-var _ ui.Tabular = (*mockTableModel)(nil)
-
-func (t *mockTableModel) SetInstance(string)                 {}
-func (t *mockTableModel) SetLabelFilter(string)              {}
-func (t *mockTableModel) Empty() bool                        { return false }
-func (t *mockTableModel) HasMetrics() bool                   { return true }
-func (t *mockTableModel) Peek() render.TableData             { return makeTableData() }
-func (t *mockTableModel) Refresh(context.Context) error      { return nil }
-func (t *mockTableModel) ClusterWide() bool                  { return false }
-func (t *mockTableModel) GetNamespace() string               { return "blee" }
-func (t *mockTableModel) SetNamespace(string)                {}
-func (t *mockTableModel) ToggleToast()                       {}
-func (t *mockTableModel) AddListener(model.TableListener)    {}
-func (t *mockTableModel) RemoveListener(model.TableListener) {}
-func (t *mockTableModel) Watch(context.Context) error        { return nil }
-func (t *mockTableModel) Get(context.Context, string) (runtime.Object, error) {
-	return nil, nil
+type tableModelMock struct {
+	MockHasMetrics  func() bool
+	MockPeek        func() render.TableData
+	MockClusterWide func() bool
 }
 
-func (t *mockTableModel) Delete(context.Context, string, bool, bool) error {
-	return nil
+func (fake *tableModelMock) HasMetrics() bool                                        { return fake.MockHasMetrics() }
+func (fake *tableModelMock) Peek() render.TableData                                  { return fake.MockPeek() }
+func (fake *tableModelMock) ClusterWide() bool                                       { return fake.MockClusterWide() }
+func (fake *tableModelMock) SetInstance(string)                                      {}
+func (fake *tableModelMock) SetLabelFilter(string)                                   {}
+func (fake *tableModelMock) Empty() bool                                             { return false }
+func (fake *tableModelMock) Refresh(context.Context) error                           { return nil }
+func (fake *tableModelMock) GetNamespace() string                                    { return "blee" }
+func (fake *tableModelMock) SetNamespace(string)                                     {}
+func (fake *tableModelMock) ToggleToast()                                            {}
+func (fake *tableModelMock) AddListener(model.TableListener)                         {}
+func (fake *tableModelMock) RemoveListener(model.TableListener)                      {}
+func (fake *tableModelMock) Watch(context.Context) error                             { return nil }
+func (fake *tableModelMock) Get(context.Context, string) (runtime.Object, error)     { return nil, nil }
+func (fake *tableModelMock) Delete(context.Context, string, bool, bool) error        { return nil }
+func (fake *tableModelMock) Describe(context.Context, string) (string, error)        { return "", nil }
+func (fake *tableModelMock) ToYAML(ctx context.Context, path string) (string, error) { return "", nil }
+func (fake *tableModelMock) InNamespace(string) bool                                 { return true }
+func (fake *tableModelMock) SetRefreshRate(time.Duration)                            {}
+
+func defaultModelMock() *tableModelMock {
+	return &tableModelMock{
+		MockHasMetrics:  func() bool { return true },
+		MockPeek:        func() render.TableData { return makeTableData() },
+		MockClusterWide: func() bool { return false },
+	}
 }
 
-func (t *mockTableModel) Describe(context.Context, string) (string, error) {
-	return "", nil
+func modelMockForSortingMinimal() *tableModelMock {
+	return &tableModelMock{
+		MockHasMetrics:  func() bool { return false },
+		MockPeek:        func() render.TableData { return makeTableDataForSorting() },
+		MockClusterWide: func() bool { return false },
+	}
 }
 
-func (t *mockTableModel) ToYAML(ctx context.Context, path string) (string, error) {
-	return "", nil
+func modelMockForSortingFull() *tableModelMock {
+	return &tableModelMock{
+		MockHasMetrics:  func() bool { return true },
+		MockPeek:        func() render.TableData { return makeTableDataForSorting() },
+		MockClusterWide: func() bool { return true },
+	}
 }
-
-func (t *mockTableModel) InNamespace(string) bool      { return true }
-func (t *mockTableModel) SetRefreshRate(time.Duration) {}
 
 func makeTableData() render.TableData {
 	t := render.NewTableData()
@@ -144,6 +291,34 @@ func makeTableData() render.TableData {
 				Fields: render.Fields{"ns1", "fred", "15", "1m"},
 			},
 			Deltas: render.DeltaRow{"", "", "20", ""},
+		},
+	}
+	t.Namespace = ""
+
+	return *t
+}
+
+func makeTableDataForSorting() render.TableData {
+	t := render.NewTableData()
+
+	t.Header = render.Header{
+		render.HeaderColumn{Name: "NAMESPACE"},
+		render.HeaderColumn{Name: "NAME", Align: tview.AlignRight},
+		render.HeaderColumn{Name: "LABELS", Wide: true},
+		render.HeaderColumn{Name: "FRED"},
+		render.HeaderColumn{Name: "CPU", MX: true},
+		render.HeaderColumn{Name: "AGE", Time: true, Decorator: render.AgeDecorator},
+	}
+	t.RowEvents = render.RowEvents{
+		render.RowEvent{
+			Row: render.Row{
+				Fields: render.Fields{"ns1", "name1", "k8s-app=kube-dns2", "fred2", "20", "90s"},
+			},
+		},
+		render.RowEvent{
+			Row: render.Row{
+				Fields: render.Fields{"ns1", "name2", "k8s-app=kube-dns1", "fred1", "10", "110s"},
+			},
 		},
 	}
 	t.Namespace = ""


### PR DESCRIPTION
My attempt at this feature request: #1000

### Description
Change the sort col using two fixed keys, `<` and `>`.
`q` changes the sort order. The behaviour is now similar to `top`

### Demo
[![asciicast](https://asciinema.org/a/435671.svg)](https://asciinema.org/a/435671)
(The player doesn't show the key inputs sadly)

### Implementation details
* Used the `q` key instead of `r` because it is already used in some places (e.g. node drain). I assumed you do not want to change the default keybindings even though I am personally in favour of refactoring with `r`
* I believe the sort implementation could benefit from a refactor. Currently, the values are sorted on the displayed string value. I took the inspiration from `age` to fix sorting on `capacity`, but it isn't ideal. It can lead to issues like this too: #885. The original value or a specific compare function should be kept on the level of the `Fields` or even `Row`.
* Not a Go dev, sorry upfront for non-idiomatic code

Closes #1000