### PR TITLE
Skin to preserve your terminal session background color

### DIFF
--- a/skins/transparent.yml
+++ b/skins/transparent.yml
@@ -1,0 +1,26 @@
+# Preserve your terminal session background color
+k9s:
+  body:
+    bgColor: default
+  promt:
+    bgColor: default
+  dialog:
+    bgColor: default
+  frame:
+    crumbs:
+      bgColor: default
+    title:
+      bgColor: default
+  views:
+    charts:
+      bgColor: default
+    table:
+      bgColor: default
+      header:
+        bgColor: default
+    xray:
+      bgColor: default
+    logs:
+      bgColor: default
+      indicator:
+        bgColor: default


### PR DESCRIPTION
Uses the `default` color on all `bgColor` properties, in order to preserve the terminal session background color.