### PR TITLE
fix #1258 - default port-forward container and port

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/term v0.0.0-20210406210042-72f3dc4e9b72 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:H
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
-github.com/adrg/xdg v0.3.0 h1:BO+k4wFj0IoTolBF1Apn8oZrX3LQrEbBA8+/9vyW9J4=
-github.com/adrg/xdg v0.3.0/go.mod h1:7I2hH/IT30IsupOpKZ5ue7/qNi3CoKzD6tL3HwpaRMQ=
+github.com/adrg/xdg v0.3.4 h1:0BivHfQ0LSGQrFTaEZ0hyQLm/HAidci7m+1cT6wKKdA=
+github.com/adrg/xdg v0.3.4/go.mod h1:61xAR2VZcggl2St4O9ohF5qCKe08+JDmE4VNzPFQvOQ=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/internal/view/helpers.go
+++ b/internal/view/helpers.go
@@ -17,6 +17,15 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+func parsePFAnn(s string) (string, string, bool) {
+	tokens := strings.Split(s, ":")
+	if len(tokens) != 2 {
+		return "", "", false
+	}
+
+	return tokens[0], tokens[1], true
+}
+
 func k8sEnv(c *client.Config) Env {
 	ctx, err := c.CurrentContextName()
 	if err != nil {

--- a/internal/view/helpers_test.go
+++ b/internal/view/helpers_test.go
@@ -19,6 +19,41 @@ func init() {
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 }
 
+func TestParsePFAnn(t *testing.T) {
+	uu := map[string]struct {
+		ann, co, port string
+		ok            bool
+	}{
+		"named-port": {
+			ann:  "fred:blee",
+			co:   "fred",
+			port: "blee",
+			ok:   true,
+		},
+		"port-num": {
+			ann:  "fred:1234",
+			co:   "fred",
+			port: "1234",
+			ok:   true,
+		},
+		"toast": {
+			ann: "zorg",
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			co, port, ok := parsePFAnn(u.ann)
+			if u.ok {
+				assert.Equal(t, u.co, co)
+				assert.Equal(t, u.port, port)
+				assert.Equal(t, u.ok, ok)
+			}
+		})
+	}
+}
+
 func TestExtractApp(t *testing.T) {
 	app := NewApp(config.NewConfig(nil))
 


### PR DESCRIPTION
Using an annotation on a pod with multiple containers and ports, you can now specify a default container and port for which to activate a port forward.

Example:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: fred
  annotations:
    k9s.imhotep.io/default-portforward-container: blee:8081
    # Or use a port name...
    k9s.imhotep.io/default-portforward-container: blee:p2
spec:
  containers:
    - name: blee
      ports:
       - name: p1
         containerPort: 8000
       - name: p2
         containerPort: 8081
      ...
    - name: zorg
      ...
```