### PR TITLE
Removed cusor colors that are too light to read

### DIFF
--- a/skins/dracula.yml
+++ b/skins/dracula.yml
@@ -83,8 +83,6 @@ k9s:
     table:
       fgColor: *foreground
       bgColor: *background
-      cursorFgColor: *foreground
-      cursorBgColor: *current_line
       # Header row styles.
       header:
         fgColor: *foreground

--- a/skins/monokai.yml
+++ b/skins/monokai.yml
@@ -104,8 +104,6 @@ k9s:
     table:
       fgColor: *foreground
       bgColor: *background
-      cursorFgColor: *foreground
-      cursorBgColor: *backgroundOpaque
       markColor: *magenta
       # Header row styles.
       header:

--- a/skins/nord.yml
+++ b/skins/nord.yml
@@ -81,8 +81,6 @@ k9s:
     table:
       fgColor: *foreground
       bgColor: default
-      cursorFgColor: *foreground
-      cursorBgColor: *current_line
       # Header row styles.
       header:
         fgColor: *foreground

--- a/skins/snazzy.yml
+++ b/skins/snazzy.yml
@@ -58,8 +58,6 @@ k9s:
     table:
       fgColor: "#57c7ff"
       bgColor: "#282a36"
-      cursorFgColor: "#57c7ff"
-      cursorBgColor: "#5af78e"
       markColor: darkgoldenrod
       header:
         fgColor: white


### PR DESCRIPTION
Per issue #1260 i modified the Dracula theme to remove the `cursorFgColor` and `cursorBqColor` on a few themes where it was unreadable.  The default coloring looked fine to me, but I happy to set some different defaults