### PR TITLE
Set focus colors on scale dialog buttons

### DIFF
--- a/internal/view/scale_extender.go
+++ b/internal/view/scale_extender.go
@@ -111,6 +111,16 @@ func (s *ScaleExtender) makeScaleForm(sel string) (*tview.Form, error) {
 		s.dismissDialog()
 	})
 
+	styles := s.App().Styles.Dialog()
+	for i := 0; i < 2; i++ {
+		b := f.GetButton(i)
+		if b == nil {
+			continue
+		}
+		b.SetBackgroundColorActivated(styles.ButtonFocusBgColor.Color())
+		b.SetLabelColorActivated(styles.ButtonFocusFgColor.Color())
+	}
+
 	return f, nil
 }
 


### PR DESCRIPTION
Before this change the scale dialog looks like this when a button is selected:

![image](https://user-images.githubusercontent.com/658281/136047309-a480c7e8-7f8b-433b-8d06-afa88008d014.png)

After this change, the buttons are correctly styled using the focus colors set in my skin file:

![image](https://user-images.githubusercontent.com/658281/136047494-2c62c645-1107-4bb1-8217-c228c82f9e55.png)
