### PR TITLE
Use correct namespace on context switch (#1002)

### DIFF
--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -62,10 +62,12 @@ func (c *Config) SwitchContext(name string) error {
 		return nil
 	}
 
-	if _, err := c.GetContext(name); err != nil {
+	newContext, err := c.GetContext(name)
+	if err != nil {
 		return fmt.Errorf("context %s does not exist", name)
 	}
 	c.reset()
+	c.flags.Namespace = &(newContext.Namespace)
 	c.flags.Context = &name
 
 	return nil

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -73,7 +73,7 @@ func (a *App) ConOK() bool {
 }
 
 // Init initializes the application.
-func (a *App) Init(version string, rate int) error {
+func (a *App) Init(version string, _ int) error {
 	a.version = model.NormalizeVersion(version)
 
 	ctx := context.WithValue(context.Background(), internal.KeyApp, a)
@@ -394,6 +394,10 @@ func (a *App) switchCtx(name string, loadPods bool) error {
 			log.Warn().Msg("No namespace specified in context. Using K9s config")
 		}
 		a.initFactory(ns)
+		err = a.Config.SetActiveNamespace(ns)
+		if err != nil {
+			log.Warn().Msgf("Failed to change to namespace '%s' in context switch, %v", ns, err)
+		}
 
 		if err := a.command.Reset(true); err != nil {
 			return err
@@ -512,7 +516,7 @@ func (a *App) setIndicator(l model.FlashLevel, msg string) {
 }
 
 // PrevCmd pops the command stack.
-func (a *App) PrevCmd(evt *tcell.EventKey) *tcell.EventKey {
+func (a *App) PrevCmd(_ *tcell.EventKey) *tcell.EventKey {
 	if !a.Content.IsLast() {
 		a.Content.Pop()
 	}


### PR DESCRIPTION
Closes #1002 

I honestly have no real clue if this is the correct way to fix the issue. This part of the code is rather confusing. However, this change seems to fix the problem and manual testing of switching contexts and namespaces appeared to work correctly. The change to **internal/view/app.go** was the actual fix, but the other change looks like it still should(?) happen. Also addressed two Goland warnings.