### PR TITLE
Add missing style to kiss

### DIFF
--- a/skins/kiss.yml
+++ b/skins/kiss.yml
@@ -63,3 +63,6 @@ k9s:
     logs:
       fgColor: default
       bgColor: default
+      indicator:
+        fgColor: default
+        bgColor: default


### PR DESCRIPTION
"kiss" style misses the configuration for `Logs.Indicator`. That makes the style look weird on a light terminal. This PR adds the missing style.

**Before:**
<img width="1440" alt="Screenshot 2021-10-18 at 21 57 08" src="https://user-images.githubusercontent.com/88045/137799001-d83b6ac3-61b8-4863-8b44-94f34fecfb84.png">

**After:**
<img width="1440" alt="Screenshot 2021-10-18 at 22 04 35" src="https://user-images.githubusercontent.com/88045/137799224-692d9ef1-b31b-4783-8a99-b6bcf18427d2.png">
