### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/internal/config/alias.go
+++ b/internal/config/alias.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -105,7 +105,7 @@ func (a *Aliases) Load() error {
 
 // LoadFileAliases loads alias from a given file.
 func (a *Aliases) LoadFileAliases(path string) error {
-	f, err := ioutil.ReadFile(path)
+	f, err := os.ReadFile(path)
 	if err == nil {
 		var aa Aliases
 		if err := yaml.Unmarshal(f, &aa); err != nil {
@@ -171,5 +171,5 @@ func (a *Aliases) SaveAliases(path string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, cfg, 0644)
+	return os.WriteFile(path, cfg, 0644)
 }

--- a/internal/config/bench.go
+++ b/internal/config/bench.go
@@ -1,8 +1,8 @@
 package config
 
 import (
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"gopkg.in/yaml.v2"
 )
@@ -96,7 +96,7 @@ func (s *Bench) Reload(path string) error {
 
 // Load K9s benchmark configs from file.
 func (s *Bench) load(path string) error {
-	f, err := ioutil.ReadFile(path)
+	f, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -218,7 +217,7 @@ func (c *Config) SetConnection(conn client.Connection) {
 
 // Load K9s configuration from file.
 func (c *Config) Load(path string) error {
-	f, err := ioutil.ReadFile(path)
+	f, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -252,7 +251,7 @@ func (c *Config) SaveFile(path string) error {
 		log.Error().Msgf("[Config] Unable to save K9s config file: %v", err)
 		return err
 	}
-	return ioutil.WriteFile(path, cfg, 0644)
+	return os.WriteFile(path, cfg, 0644)
 }
 
 // Validate the configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,7 +2,7 @@ package config_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -216,7 +216,7 @@ func TestConfigSaveFile(t *testing.T) {
 	err := cfg.SaveFile(path)
 	assert.Nil(t, err)
 
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedConfig, string(raw))
 }
@@ -242,7 +242,7 @@ func TestConfigReset(t *testing.T) {
 	err := cfg.SaveFile(path)
 	assert.Nil(t, err)
 
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	assert.Nil(t, err)
 	assert.Equal(t, resetConfig, string(raw))
 }

--- a/internal/config/hotkey.go
+++ b/internal/config/hotkey.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"gopkg.in/yaml.v2"
@@ -36,7 +36,7 @@ func (h HotKeys) Load() error {
 
 // LoadHotKeys loads plugins from a given file.
 func (h HotKeys) LoadHotKeys(path string) error {
-	f, err := ioutil.ReadFile(path)
+	f, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"gopkg.in/yaml.v2"
@@ -40,7 +40,7 @@ func (p Plugins) Load() error {
 
 // LoadPlugins loads plugins from a given file.
 func (p Plugins) LoadPlugins(path string) error {
-	f, err := ioutil.ReadFile(path)
+	f, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/internal/config/styles.go
+++ b/internal/config/styles.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/derailed/tview"
@@ -541,7 +541,7 @@ func (s *Styles) Views() Views {
 
 // Load K9s configuration from file.
 func (s *Styles) Load(path string) error {
-	f, err := ioutil.ReadFile(path)
+	f, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/internal/config/views.go
+++ b/internal/config/views.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"gopkg.in/yaml.v2"
@@ -56,7 +56,7 @@ func (v *CustomView) Reset() {
 
 // Load loads view configurations.
 func (v *CustomView) Load(path string) error {
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/internal/dao/benchmark.go
+++ b/internal/dao/benchmark.go
@@ -3,7 +3,6 @@ package dao
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,7 +40,7 @@ func (b *Benchmark) List(ctx context.Context, _ string) ([]runtime.Object, error
 	}
 	path, _ := ctx.Value(internal.KeyPath).(string)
 
-	ff, err := ioutil.ReadDir(dir)
+	ff, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +50,10 @@ func (b *Benchmark) List(ctx context.Context, _ string) ([]runtime.Object, error
 		if path != "" && !strings.HasPrefix(f.Name(), strings.Replace(path, "/", "_", 1)) {
 			continue
 		}
-		oo = append(oo, render.BenchInfo{File: f, Path: filepath.Join(dir, f.Name())})
+
+		if fi, err := f.Info(); err == nil {
+			oo = append(oo, render.BenchInfo{File: fi, Path: filepath.Join(dir, f.Name())})
+		}
 	}
 
 	return oo, nil

--- a/internal/dao/cruiser_test.go
+++ b/internal/dao/cruiser_test.go
@@ -3,7 +3,7 @@ package dao
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +29,7 @@ func TestCruiserSlice(t *testing.T) {
 // Helpers...
 
 func loadJSON(t assert.TestingT, n string) *unstructured.Unstructured {
-	raw, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.json", n))
+	raw, err := os.ReadFile(fmt.Sprintf("testdata/%s.json", n))
 	assert.Nil(t, err)
 
 	var o unstructured.Unstructured

--- a/internal/dao/dir.go
+++ b/internal/dao/dir.go
@@ -3,7 +3,7 @@ package dao
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -37,7 +37,7 @@ func (a *Dir) List(ctx context.Context, _ string) ([]runtime.Object, error) {
 		return nil, errors.New("No dir in context")
 	}
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +48,8 @@ func (a *Dir) List(ctx context.Context, _ string) ([]runtime.Object, error) {
 			continue
 		}
 		oo = append(oo, render.DirRes{
-			Path: filepath.Join(dir, f.Name()),
-			Info: f,
+			Path:  filepath.Join(dir, f.Name()),
+			Entry: f,
 		})
 	}
 

--- a/internal/dao/ofaas.go
+++ b/internal/dao/ofaas.go
@@ -8,7 +8,7 @@ package dao
 // 	"encoding/json"
 // 	"errors"
 // 	"fmt"
-// 	"io/ioutil"
+// 	"io"
 // 	"net/http"
 // 	"net/url"
 // 	"os"
@@ -193,7 +193,7 @@ package dao
 // 	case http.StatusUnauthorized:
 // 		return fmt.Errorf("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
 // 	default:
-// 		bytesOut, err := ioutil.ReadAll(delRes.Body)
+// 		bytesOut, err := io.ReadAll(delRes.Body)
 // 		if err != nil {
 // 			return err
 // 		}

--- a/internal/dao/registry_test.go
+++ b/internal/dao/registry_test.go
@@ -3,7 +3,7 @@ package dao
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -89,7 +89,7 @@ func TestExtractString(t *testing.T) {
 // Helpers...
 
 func load(t *testing.T, n string) *unstructured.Unstructured {
-	raw, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.json", n))
+	raw, err := os.ReadFile(fmt.Sprintf("testdata/%s.json", n))
 	assert.Nil(t, err)
 
 	var o unstructured.Unstructured

--- a/internal/dao/screen_dump.go
+++ b/internal/dao/screen_dump.go
@@ -3,7 +3,6 @@ package dao
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"regexp"
 
@@ -37,14 +36,16 @@ func (d *ScreenDump) List(ctx context.Context, _ string) ([]runtime.Object, erro
 		return nil, errors.New("no screendump dir found in context")
 	}
 
-	ff, err := ioutil.ReadDir(SanitizeFilename(dir))
+	ff, err := os.ReadDir(SanitizeFilename(dir))
 	if err != nil {
 		return nil, err
 	}
 
 	oo := make([]runtime.Object, len(ff))
 	for i, f := range ff {
-		oo[i] = render.FileRes{File: f, Dir: dir}
+		if fi, err := f.Info(); err == nil {
+			oo[i] = render.FileRes{File: fi, Dir: dir}
+		}
 	}
 
 	return oo, nil

--- a/internal/model/cluster_info.go
+++ b/internal/model/cluster_info.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -200,7 +200,7 @@ func fetchLatestRev() (string, error) {
 		}
 	}()
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/internal/model/table_int_test.go
+++ b/internal/model/table_int_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/derailed/k9s/internal"
@@ -139,7 +139,7 @@ func TestTableGenericHydrate(t *testing.T) {
 // Helpers...
 
 func mustLoad(n string) *unstructured.Unstructured {
-	raw, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.json", n))
+	raw, err := os.ReadFile(fmt.Sprintf("testdata/%s.json", n))
 	if err != nil {
 		panic(err)
 	}
@@ -151,7 +151,7 @@ func mustLoad(n string) *unstructured.Unstructured {
 }
 
 func load(t *testing.T, n string) *unstructured.Unstructured {
-	raw, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.json", n))
+	raw, err := os.ReadFile(fmt.Sprintf("testdata/%s.json", n))
 	assert.Nil(t, err)
 	var o unstructured.Unstructured
 	err = json.Unmarshal(raw, &o)
@@ -160,7 +160,7 @@ func load(t *testing.T, n string) *unstructured.Unstructured {
 }
 
 func raw(t *testing.T, n string) []byte {
-	raw, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.json", n))
+	raw, err := os.ReadFile(fmt.Sprintf("testdata/%s.json", n))
 	assert.Nil(t, err)
 	return raw
 }

--- a/internal/model/table_test.go
+++ b/internal/model/table_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/derailed/k9s/internal"
@@ -122,7 +122,7 @@ func makeTableFactory() tableFactory {
 }
 
 func mustLoad(n string) *unstructured.Unstructured {
-	raw, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.json", n))
+	raw, err := os.ReadFile(fmt.Sprintf("testdata/%s.json", n))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/perf/benchmark.go
+++ b/internal/perf/benchmark.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -138,7 +137,7 @@ func (b *Benchmark) save(cluster string, r io.Reader) error {
 		}
 	}()
 
-	bb, err := ioutil.ReadAll(r)
+	bb, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/internal/render/benchmark.go
+++ b/internal/render/benchmark.go
@@ -3,7 +3,6 @@ package render
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -97,7 +96,7 @@ func (Benchmark) diagnose(ns string, ff Fields) error {
 // Helpers...
 
 func (Benchmark) readFile(file string) (string, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return "", err
 	}

--- a/internal/render/benchmark_int_test.go
+++ b/internal/render/benchmark_int_test.go
@@ -1,7 +1,7 @@
 package render
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -38,7 +38,7 @@ func TestAugmentRow(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			data, err := ioutil.ReadFile(u.file)
+			data, err := os.ReadFile(u.file)
 
 			assert.Nil(t, err)
 			fields := make(Fields, 8)

--- a/internal/render/dir.go
+++ b/internal/render/dir.go
@@ -35,10 +35,10 @@ func (Dir) Render(o interface{}, ns string, r *Row) error {
 	}
 
 	name := "🦄 "
-	if d.Info.IsDir() {
+	if d.Entry.IsDir() {
 		name = "📁 "
 	}
-	name += d.Info.Name()
+	name += d.Entry.Name()
 	r.ID, r.Fields = d.Path, append(r.Fields, name)
 
 	return nil
@@ -49,8 +49,8 @@ func (Dir) Render(o interface{}, ns string, r *Row) error {
 
 // DirRes represents an alias resource.
 type DirRes struct {
-	Info os.FileInfo
-	Path string
+	Entry os.DirEntry
+	Path  string
 }
 
 // GetObjectKind returns a schema object.

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -3,7 +3,7 @@ package render_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +13,7 @@ import (
 // Helpers...
 
 func load(t testing.TB, n string) *unstructured.Unstructured {
-	raw, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.json", n))
+	raw, err := os.ReadFile(fmt.Sprintf("testdata/%s.json", n))
 	assert.Nil(t, err)
 
 	var o unstructured.Unstructured

--- a/internal/view/benchmark.go
+++ b/internal/view/benchmark.go
@@ -2,7 +2,7 @@ package view
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -71,7 +71,7 @@ func benchDir(cfg *config.Config) string {
 }
 
 func readBenchFile(cfg *config.Config, n string) (string, error) {
-	data, err := ioutil.ReadFile(filepath.Join(benchDir(cfg), n))
+	data, err := os.ReadFile(filepath.Join(benchDir(cfg), n))
 	if err != nil {
 		return "", err
 	}

--- a/internal/view/dir.go
+++ b/internal/view/dir.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -90,7 +90,7 @@ func (d *Dir) viewCmd(evt *tcell.EventKey) *tcell.EventKey {
 		return nil
 	}
 
-	yaml, err := ioutil.ReadFile(sel)
+	yaml, err := os.ReadFile(sel)
 	if err != nil {
 		d.App().Flash().Err(err)
 		return nil
@@ -157,7 +157,7 @@ func isKustomized(sel string) bool {
 		return false
 	}
 
-	ff, err := ioutil.ReadDir(sel)
+	ff, err := os.ReadDir(sel)
 	if err != nil {
 		return false
 	}
@@ -176,7 +176,7 @@ func containsDir(sel string) bool {
 		return false
 	}
 
-	ff, err := ioutil.ReadDir(sel)
+	ff, err := os.ReadDir(sel)
 	if err != nil {
 		return false
 	}

--- a/internal/view/log_test.go
+++ b/internal/view/log_test.go
@@ -3,7 +3,7 @@ package view_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -79,9 +79,9 @@ func TestLogViewSave(t *testing.T) {
 	v.Flush(ii.Lines(false))
 	config.K9sDumpDir = "/tmp"
 	dir := filepath.Join(config.K9sDumpDir, app.Config.K9s.CurrentCluster)
-	c1, _ := ioutil.ReadDir(dir)
+	c1, _ := os.ReadDir(dir)
 	v.SaveCmd(nil)
-	c2, _ := ioutil.ReadDir(dir)
+	c2, _ := os.ReadDir(dir)
 	assert.Equal(t, len(c2), len(c1)+1)
 }
 

--- a/internal/view/table_int_test.go
+++ b/internal/view/table_int_test.go
@@ -2,7 +2,7 @@ package view
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -25,10 +25,10 @@ func TestTableSave(t *testing.T) {
 	v.SetTitle("k9s-test")
 
 	dir := filepath.Join(config.K9sDumpDir, v.app.Config.K9s.CurrentCluster)
-	c1, _ := ioutil.ReadDir(dir)
+	c1, _ := os.ReadDir(dir)
 	v.saveCmd(nil)
 
-	c2, _ := ioutil.ReadDir(dir)
+	c2, _ := os.ReadDir(dir)
 	assert.Equal(t, len(c2), len(c1)+1)
 }
 

--- a/internal/xray/container_test.go
+++ b/internal/xray/container_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/derailed/k9s/internal"
@@ -238,7 +238,7 @@ func makeDoubleCMKeysContainer(n string, optional bool) *v1.Container {
 }
 
 func load(t *testing.T, n string) *unstructured.Unstructured {
-	raw, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.json", n))
+	raw, err := os.ReadFile(fmt.Sprintf("testdata/%s.json", n))
 	assert.Nil(t, err)
 
 	var o unstructured.Unstructured


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since k9s has been upgraded to Go 1.17 (#1232), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.