### PR TITLE
Add s390x support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
       - arm64
       - arm
       - ppc64le
+      - s390x
     goarm:
       - 7
     flags:


### PR DESCRIPTION
It would be great to have k9s available on s390x. I add it to gorealeaser config, so a binary for s390x is created.