### PR TITLE
Fix accessMode getting exception

### DIFF
--- a/internal/render/pv.go
+++ b/internal/render/pv.go
@@ -126,15 +126,15 @@ func (PersistentVolume) volumeMode(m *v1.PersistentVolumeMode) string {
 func accessMode(aa []v1.PersistentVolumeAccessMode) string {
 	dd := accessDedup(aa)
 	s := make([]string, 0, len(dd))
-	for i := 0; i < len(aa); i++ {
+	for _, am := range dd {
 		switch {
-		case accessContains(dd, v1.ReadWriteOnce):
+		case am == v1.ReadWriteOnce:
 			s = append(s, "RWO")
-		case accessContains(dd, v1.ReadOnlyMany):
+		case am == v1.ReadOnlyMany:
 			s = append(s, "ROX")
-		case accessContains(dd, v1.ReadWriteMany):
+		case am == v1.ReadWriteMany:
 			s = append(s, "RWX")
-		case accessContains(dd, v1.ReadWriteOncePod):
+		case am == v1.ReadWriteOncePod:
 			s = append(s, "RWOP")
 		}
 	}


### PR DESCRIPTION
The result obtained in the old way is always the first ReadWriteOnce(RWO)
# accessMode
![image](https://user-images.githubusercontent.com/13899572/141967805-3d0b5167-dc85-4a62-ae18-8d45bdaa0211.png)
# accessMode (Fixed)
![image](https://user-images.githubusercontent.com/13899572/141967825-8feb7c35-55b9-418e-8eac-f378ecdb37fa.png)
