### PR TITLE
Fix current selection color contrast in Gruvbox skin

### DIFF
--- a/skins/gruvbox-dark.yml
+++ b/skins/gruvbox-dark.yml
@@ -70,7 +70,7 @@ k9s:
     table:
       fgColor: *foreground
       bgColor: *background
-      cursorFgColor: *background
+      cursorFgColor: "#fff"
       cursorBgColor: *current_line
       header:
         fgColor: *foreground


### PR DESCRIPTION
I am running iTerm v3.4.12 with [Gruvbox Dark](https://github.com/mbadolato/iTerm2-Color-Schemes/blob/master/schemes/Gruvbox%20Dark.itermcolors) theme connected to a remote Linux host running k9s v0.25.6.

This is the default view, no skin:
![image](https://user-images.githubusercontent.com/3342/143473344-3269528e-9122-4ffb-b359-812ece63f0ab.png)

This is with [gruvbox-dark.yml](https://github.com/derailed/k9s/blob/master/skins/gruvbox-dark.yml):
<img width="1005" alt="Screenshot 2021-11-25 at 15 03 10" src="https://user-images.githubusercontent.com/3342/143473461-643b18a3-50e6-4f9d-ad0e-050ff7282e8d.png">

And this is the same skin with the change in this PR:
<img width="1014" alt="Screenshot 2021-11-25 at 15 55 08" src="https://user-images.githubusercontent.com/3342/143473516-d9bbe487-32fc-4787-8ee2-3995c13fc015.png">

---

If I use iTerm v3.4.12 with [Gruvbox Light](https://github.com/mbadolato/iTerm2-Color-Schemes/blob/master/schemes/Gruvbox%20Light.itermcolors), this is what the default [gruvbox-dark.yml](https://github.com/derailed/k9s/blob/master/skins/gruvbox-dark.yml) k9s skin looks like:
<img width="1010" alt="Screenshot 2021-11-25 at 15 56 03" src="https://user-images.githubusercontent.com/3342/143473707-544050a0-889e-4c65-844b-d25f5db709ab.png">

After this PR:
<img width="1014" alt="Screenshot 2021-11-25 at 15 58 36" src="https://user-images.githubusercontent.com/3342/143473748-ff074d64-52f2-4bf8-b10c-2d9237e1aa1c.png">