### PR TITLE
Add flux trace shortcut to flux plugin

### DIFF
--- a/plugins/flux.yaml
+++ b/plugins/flux.yaml
@@ -58,3 +58,14 @@ plugin:
     args:
     - -c
     - "flux reconcile kustomization -n $NAMESPACE $NAME | less"
+  trace:
+    shortCut: Shift-A
+    confirm: false
+    description: Flux trace
+    scopes:
+    - all
+    command: sh
+    background: false
+    args:
+    - -c
+    - "flux trace $NAME --kind `echo $RESOURCE_NAME | sed s/s$//g` --api-version $RESOURCE_GROUP/$RESOURCE_VERSION --namespace $NAMESPACE $NAME | less"

--- a/plugins/flux.yaml
+++ b/plugins/flux.yaml
@@ -68,4 +68,4 @@ plugin:
     background: false
     args:
     - -c
-    - "flux trace $NAME --kind `echo $RESOURCE_NAME | sed s/s$//g` --api-version $RESOURCE_GROUP/$RESOURCE_VERSION --namespace $NAMESPACE $NAME | less"
+    - "flux trace $NAME --kind `echo $RESOURCE_NAME | sed -E 's/(s|es)$//g'` --api-version $RESOURCE_GROUP/$RESOURCE_VERSION --namespace $NAMESPACE $NAME | less"


### PR DESCRIPTION
Implementation notes: $RESOURCE_NAME is exported in plural form (e.g. cronjobs, pods) so the script trims the trailing s if any.

Was tested on Pods, CronJobs, Namespaces, ConfigMaps, Ingresses 