### PR TITLE
Fix the flux plugin to use the context of the currently running instance

### DIFF
--- a/plugins/flux.yml
+++ b/plugins/flux.yml
@@ -13,7 +13,7 @@ plugin:
     background: false
     args:
       - -c
-      - "flux $([ $(kubectl get helmreleases -n $NAMESPACE $NAME -o=custom-columns=TYPE:.spec.suspend | tail -1) = \"true\" ] && echo \"resume\" || echo \"suspend\") helmrelease -n $NAMESPACE $NAME | less"
+      - "flux --context $CONTEXT $([ $(kubectl --context $CONTEXT get helmreleases -n $NAMESPACE $NAME -o=custom-columns=TYPE:.spec.suspend | tail -1) = \"true\" ] && echo \"resume\" || echo \"suspend\") helmrelease -n $NAMESPACE $NAME | less"
   toggle-kustomization:
     shortCut: Shift-T
     confirm: true
@@ -24,7 +24,7 @@ plugin:
     background: false
     args:
       - -c
-      - "flux $([ $(kubectl get kustomizations -n $NAMESPACE $NAME -o=custom-columns=TYPE:.spec.suspend | tail -1) = \"true\" ] && echo \"resume\" || echo \"suspend\") kustomization -n $NAMESPACE $NAME | less"
+      - "flux --context $CONTEXT $([ $(kubectl --context $CONTEXT get kustomizations -n $NAMESPACE $NAME -o=custom-columns=TYPE:.spec.suspend | tail -1) = \"true\" ] && echo \"resume\" || echo \"suspend\") kustomization -n $NAMESPACE $NAME | less"
   reconcile-git:
     shortCut: Shift-R
     confirm: false
@@ -35,7 +35,7 @@ plugin:
     background: false
     args:
     - -c
-    - "flux reconcile source git -n $NAMESPACE $NAME | less"
+    - "flux --context $CONTEXT reconcile source git -n $NAMESPACE $NAME | less"
   reconcile-hr:
     shortCut: Shift-R
     confirm: false
@@ -46,7 +46,7 @@ plugin:
     background: false
     args:
     - -c
-    - "flux reconcile helmrelease -n $NAMESPACE $NAME | less"
+    - "flux --context $CONTEXT reconcile helmrelease -n $NAMESPACE $NAME | less"
   reconcile-ks:
     shortCut: Shift-R
     confirm: false
@@ -57,7 +57,7 @@ plugin:
     background: false
     args:
     - -c
-    - "flux reconcile kustomization -n $NAMESPACE $NAME | less"
+    - "flux --context $CONTEXT reconcile kustomization -n $NAMESPACE $NAME | less"
   trace:
     shortCut: Shift-A
     confirm: false
@@ -68,4 +68,4 @@ plugin:
     background: false
     args:
     - -c
-    - "flux trace $NAME --kind `echo $RESOURCE_NAME | sed -E 's/(s|es)$//g'` --api-version $RESOURCE_GROUP/$RESOURCE_VERSION --namespace $NAMESPACE $NAME | less"
+    - "flux --context $CONTEXT trace $NAME --kind `echo $RESOURCE_NAME | sed -E 's/(s|es)$//g'` --api-version $RESOURCE_GROUP/$RESOURCE_VERSION --namespace $NAMESPACE $NAME | less"


### PR DESCRIPTION
Rather than the default context.

This means if you run k9s --context XXX, any flux commands run by the plugin will run on the correct context