### PR TITLE
Convert command to lowercase in the command palette

### DIFF
--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -113,12 +113,13 @@ func (c *Command) run(cmd, path string, clearStack bool) error {
 		return nil
 	}
 	cmds := strings.Split(cmd, " ")
-	gvr, v, err := c.viewMetaFor(cmds[0])
+	command := strings.ToLower(cmds[0])
+	gvr, v, err := c.viewMetaFor(command)
 	if err != nil {
 		return err
 	}
 
-	switch cmds[0] {
+	switch command {
 	case "ctx", "context", "contexts":
 		if len(cmds) == 2 {
 			return useContext(c.app, cmds[1])
@@ -138,7 +139,7 @@ func (c *Command) run(cmd, path string, clearStack bool) error {
 		if err := c.app.switchNS(ns); err != nil {
 			return err
 		}
-		if !c.alias.Check(cmds[0]) {
+		if !c.alias.Check(command) {
 			return fmt.Errorf("`%s` Command not found", cmd)
 		}
 		return c.exec(cmd, gvr, c.componentFor(gvr, path, v), clearStack)


### PR DESCRIPTION
This PR resolves the issue that typing `PODS`/`Pod` in the command palette shows `command not found`.

I also checked all aliases only contain one uppercase key `Q` and it is handled separately in `specialCmd`.

```
map[?:help Q:quit a:aliases admissionregistration.k8s.io/v1/mutatingwebhookconfigurations:admissionregistration.k8s.io/v1/mutatingwebhookconfigurations admissionregistration.k8s.io/v1/validatingwebhookconfigurations:admissionregistration.k8s.io/v1/validatingwebhookconfigurations alias:aliases aliases:aliases apiextensions.k8s.io/v1/customresourcedefinitions:apiextensions.k8s.io/v1/customresourcedefinitions apiregistration.k8s.io/v1/apiservices:apiregistration.k8s.io/v1/apiservices apiservice:apiregistration.k8s.io/v1/apiservices apiservices:apiregistration.k8s.io/v1/apiservices apps/v1/controllerrevisions:apps/v1/controllerrevisions apps/v1/daemonsets:apps/v1/daemonsets apps/v1/deployments:apps/v1/deployments apps/v1/replicasets:apps/v1/replicasets apps/v1/statefulsets:apps/v1/statefulsets authentication.k8s.io/v1/tokenreviews:authentication.k8s.io/v1/tokenreviews authorization.k8s.io/v1/localsubjectaccessreviews:authorization.k8s.io/v1/localsubjectaccessreviews authorization.k8s.io/v1/selfsubjectaccessreviews:authorization.k8s.io/v1/selfsubjectaccessreviews authorization.k8s.io/v1/selfsubjectrulesreviews:authorization.k8s.io/v1/selfsubjectrulesreviews authorization.k8s.io/v1/subjectaccessreviews:authorization.k8s.io/v1/subjectaccessreviews autoscaling/v1/horizontalpodautoscalers:autoscaling/v1/horizontalpodautoscalers batch/v1/cronjobs:batch/v1/cronjobs batch/v1/jobs:batch/v1/jobs be:benchmarks bench:benchmarks benchmark:benchmarks benchmarks:benchmarks binding:v1/bindings bindings:v1/bindings cdi:cdi.kubevirt.io/v1beta1/cdis cdi.kubevirt.io/v1alpha1/cdiconfigs:cdi.kubevirt.io/v1alpha1/cdiconfigs cdi.kubevirt.io/v1alpha1/cdis:cdi.kubevirt.io/v1alpha1/cdis cdi.kubevirt.io/v1alpha1/datavolumes:cdi.kubevirt.io/v1alpha1/datavolumes cdi.kubevirt.io/v1beta1/cdiconfigs:cdi.kubevirt.io/v1beta1/cdiconfigs cdi.kubevirt.io/v1beta1/cdis:cdi.kubevirt.io/v1beta1/cdis cdi.kubevirt.io/v1beta1/dataimportcrons:cdi.kubevirt.io/v1beta1/dataimportcrons cdi.kubevirt.io/v1beta1/datasources:cdi.kubevirt.io/v1beta1/datasources cdi.kubevirt.io/v1beta1/datavolumes:cdi.kubevirt.io/v1beta1/datavolumes cdi.kubevirt.io/v1beta1/objecttransfers:cdi.kubevirt.io/v1beta1/objecttransfers cdi.kubevirt.io/v1beta1/storageprofiles:cdi.kubevirt.io/v1beta1/storageprofiles cdiconfig:cdi.kubevirt.io/v1beta1/cdiconfigs cdiconfigs:cdi.kubevirt.io/v1beta1/cdiconfigs cdis:cdi.kubevirt.io/v1beta1/cdis ceph.rook.io/v1/cephblockpools:ceph.rook.io/v1/cephblockpools ceph.rook.io/v1/cephclients:ceph.rook.io/v1/cephclients ceph.rook.io/v1/cephclusters:ceph.rook.io/v1/cephclusters ceph.rook.io/v1/cephfilesystemmirrors:ceph.rook.io/v1/cephfilesystemmirrors ceph.rook.io/v1/cephfilesystems:ceph.rook.io/v1/cephfilesystems ceph.rook.io/v1/cephnfses:ceph.rook.io/v1/cephnfses ceph.rook.io/v1/cephobjectrealms:ceph.rook.io/v1/cephobjectrealms ceph.rook.io/v1/cephobjectstores:ceph.rook.io/v1/cephobjectstores ceph.rook.io/v1/cephobjectstoreusers:ceph.rook.io/v1/cephobjectstoreusers ceph.rook.io/v1/cephobjectzonegroups:ceph.rook.io/v1/cephobjectzonegroups ceph.rook.io/v1/cephobjectzones:ceph.rook.io/v1/cephobjectzones ceph.rook.io/v1/cephrbdmirrors:ceph.rook.io/v1/cephrbdmirrors cephblockpool:ceph.rook.io/v1/cephblockpools cephblockpools:ceph.rook.io/v1/cephblockpools cephclient:ceph.rook.io/v1/cephclients cephclients:ceph.rook.io/v1/cephclients cephcluster:ceph.rook.io/v1/cephclusters cephclusters:ceph.rook.io/v1/cephclusters cephfilesystem:ceph.rook.io/v1/cephfilesystems cephfilesystemmirror:ceph.rook.io/v1/cephfilesystemmirrors cephfilesystemmirrors:ceph.rook.io/v1/cephfilesystemmirrors cephfilesystems:ceph.rook.io/v1/cephfilesystems cephnfs:ceph.rook.io/v1/cephnfses cephnfses:ceph.rook.io/v1/cephnfses cephobjectrealm:ceph.rook.io/v1/cephobjectrealms cephobjectrealms:ceph.rook.io/v1/cephobjectrealms cephobjectstore:ceph.rook.io/v1/cephobjectstores cephobjectstores:ceph.rook.io/v1/cephobjectstores cephobjectstoreuser:ceph.rook.io/v1/cephobjectstoreusers cephobjectstoreusers:ceph.rook.io/v1/cephobjectstoreusers cephobjectzone:ceph.rook.io/v1/cephobjectzones cephobjectzonegroup:ceph.rook.io/v1/cephobjectzonegroups cephobjectzonegroups:ceph.rook.io/v1/cephobjectzonegroups cephobjectzones:ceph.rook.io/v1/cephobjectzones cephrbdmirror:ceph.rook.io/v1/cephrbdmirrors cephrbdmirrors:ceph.rook.io/v1/cephrbdmirrors certificates.k8s.io/v1/certificatesigningrequests:certificates.k8s.io/v1/certificatesigningrequests certificatesigningrequest:certificates.k8s.io/v1/certificatesigningrequests certificatesigningrequests:certificates.k8s.io/v1/certificatesigningrequests chart:helm charts:helm cj:batch/v1/cronjobs clusterrole:rbac.authorization.k8s.io/v1/clusterroles clusterrolebinding:rbac.authorization.k8s.io/v1/clusterrolebindings clusterrolebindings:rbac.authorization.k8s.io/v1/clusterrolebindings clusterroles:rbac.authorization.k8s.io/v1/clusterroles cm:v1/configmaps componentstatus:v1/componentstatuses componentstatuses:v1/componentstatuses configmap:v1/configmaps configmaps:v1/configmaps context:contexts contexts:contexts controllerrevision:apps/v1/controllerrevisions controllerrevisions:apps/v1/controllerrevisions coordination.k8s.io/v1/leases:coordination.k8s.io/v1/leases cr:rbac.authorization.k8s.io/v1/clusterroles crb:rbac.authorization.k8s.io/v1/clusterrolebindings crd:apiextensions.k8s.io/v1/customresourcedefinitions crds:apiextensions.k8s.io/v1/customresourcedefinitions cronjob:batch/v1/cronjobs cronjobs:batch/v1/cronjobs cs:v1/componentstatuses csi.aliyun.com/v1alpha1/nodelocalstorageinitconfigs:csi.aliyun.com/v1alpha1/nodelocalstorageinitconfigs csi.aliyun.com/v1alpha1/nodelocalstorages:csi.aliyun.com/v1alpha1/nodelocalstorages csidriver:storage.k8s.io/v1/csidrivers csidrivers:storage.k8s.io/v1/csidrivers csinode:storage.k8s.io/v1/csinodes csinodes:storage.k8s.io/v1/csinodes csistoragecapacities:storage.k8s.io/v1beta1/csistoragecapacities csistoragecapacity:storage.k8s.io/v1beta1/csistoragecapacities csr:certificates.k8s.io/v1/certificatesigningrequests ctx:contexts customresourcedefinition:apiextensions.k8s.io/v1/customresourcedefinitions customresourcedefinitions:apiextensions.k8s.io/v1/customresourcedefinitions d:dir daemonset:apps/v1/daemonsets daemonsets:apps/v1/daemonsets dataimportcron:cdi.kubevirt.io/v1beta1/dataimportcrons dataimportcrons:cdi.kubevirt.io/v1beta1/dataimportcrons datasource:cdi.kubevirt.io/v1beta1/datasources datasources:cdi.kubevirt.io/v1beta1/datasources datavolume:cdi.kubevirt.io/v1beta1/datavolumes datavolumes:cdi.kubevirt.io/v1beta1/datavolumes deploy:apps/v1/deployments deployment:apps/v1/deployments deployments:apps/v1/deployments dir:dir discovery.k8s.io/v1/endpointslices:discovery.k8s.io/v1/endpointslices dp:apps/v1/deployments ds:apps/v1/daemonsets dv:cdi.kubevirt.io/v1beta1/datavolumes dvs:cdi.kubevirt.io/v1beta1/datavolumes endpoints:v1/endpoints endpointslice:discovery.k8s.io/v1/endpointslices endpointslices:discovery.k8s.io/v1/endpointslices ep:v1/endpoints ev:v1/events event:v1/events events:v1/events flowcontrol.apiserver.k8s.io/v1beta1/flowschemas:flowcontrol.apiserver.k8s.io/v1beta1/flowschemas flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations:flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations flowschema:flowcontrol.apiserver.k8s.io/v1beta1/flowschemas flowschemas:flowcontrol.apiserver.k8s.io/v1beta1/flowschemas group:groups groups:groups grp:groups h:help helm:helm help:help hm:helm horizontalpodautoscaler:autoscaling/v1/horizontalpodautoscalers horizontalpodautoscalers:autoscaling/v1/horizontalpodautoscalers hpa:autoscaling/v1/horizontalpodautoscalers hz:pulses ing:networking.k8s.io/v1/ingresses ingress:networking.k8s.io/v1/ingresses ingressclass:networking.k8s.io/v1/ingressclasses ingressclasses:networking.k8s.io/v1/ingressclasses ingresses:networking.k8s.io/v1/ingresses jo:batch/v1/jobs job:batch/v1/jobs jobs:batch/v1/jobs lease:coordination.k8s.io/v1/leases leases:coordination.k8s.io/v1/leases limitrange:v1/limitranges limitranges:v1/limitranges limits:v1/limitranges localsubjectaccessreview:authorization.k8s.io/v1/localsubjectaccessreviews localsubjectaccessreviews:authorization.k8s.io/v1/localsubjectaccessreviews mutatingwebhookconfiguration:admissionregistration.k8s.io/v1/mutatingwebhookconfigurations mutatingwebhookconfigurations:admissionregistration.k8s.io/v1/mutatingwebhookconfigurations namespace:v1/namespaces namespaces:v1/namespaces netpol:networking.k8s.io/v1/networkpolicies networking.k8s.io/v1/ingressclasses:networking.k8s.io/v1/ingressclasses networking.k8s.io/v1/ingresses:networking.k8s.io/v1/ingresses networking.k8s.io/v1/networkpolicies:networking.k8s.io/v1/networkpolicies networkpolicies:networking.k8s.io/v1/networkpolicies networkpolicy:networking.k8s.io/v1/networkpolicies nfs:ceph.rook.io/v1/cephnfses nls:csi.aliyun.com/v1alpha1/nodelocalstorages nlsc:csi.aliyun.com/v1alpha1/nodelocalstorageinitconfigs no:v1/nodes node:v1/nodes node.k8s.io/v1/runtimeclasses:node.k8s.io/v1/runtimeclasses nodelocalstorage:csi.aliyun.com/v1alpha1/nodelocalstorages nodelocalstorageinitconfig:csi.aliyun.com/v1alpha1/nodelocalstorageinitconfigs nodelocalstorageinitconfigs:csi.aliyun.com/v1alpha1/nodelocalstorageinitconfigs nodelocalstorages:csi.aliyun.com/v1alpha1/nodelocalstorages nodes:v1/nodes np:networking.k8s.io/v1/networkpolicies ns:v1/namespaces ob:objectbucket.io/v1alpha1/objectbuckets obc:objectbucket.io/v1alpha1/objectbucketclaims obcs:objectbucket.io/v1alpha1/objectbucketclaims objectbucket:objectbucket.io/v1alpha1/objectbuckets objectbucket.io/v1alpha1/objectbucketclaims:objectbucket.io/v1alpha1/objectbucketclaims objectbucket.io/v1alpha1/objectbuckets:objectbucket.io/v1alpha1/objectbuckets objectbucketclaim:objectbucket.io/v1alpha1/objectbucketclaims objectbucketclaims:objectbucket.io/v1alpha1/objectbucketclaims objectbuckets:objectbucket.io/v1alpha1/objectbuckets objecttransfer:cdi.kubevirt.io/v1beta1/objecttransfers objecttransfers:cdi.kubevirt.io/v1beta1/objecttransfers objectuser:ceph.rook.io/v1/cephobjectstoreusers obs:objectbucket.io/v1alpha1/objectbuckets ot:cdi.kubevirt.io/v1beta1/objecttransfers ots:cdi.kubevirt.io/v1beta1/objecttransfers pc:scheduling.k8s.io/v1/priorityclasses pdb:policy/v1/poddisruptionbudgets persistentvolume:v1/persistentvolumes persistentvolumeclaim:v1/persistentvolumeclaims persistentvolumeclaims:v1/persistentvolumeclaims persistentvolumes:v1/persistentvolumes pf:portforwards po:v1/pods pod:v1/pods poddisruptionbudget:policy/v1/poddisruptionbudgets poddisruptionbudgets:policy/v1/poddisruptionbudgets pods:v1/pods podsecuritypolicies:policy/v1beta1/podsecuritypolicies podsecuritypolicy:policy/v1beta1/podsecuritypolicies podtemplate:v1/podtemplates podtemplates:v1/podtemplates policy/v1/poddisruptionbudgets:policy/v1/poddisruptionbudgets policy/v1beta1/podsecuritypolicies:policy/v1beta1/podsecuritypolicies pop:popeye popeye:popeye portforward:portforwards portforwards:portforwards priorityclass:scheduling.k8s.io/v1/priorityclasses priorityclasses:scheduling.k8s.io/v1/priorityclasses prioritylevelconfiguration:flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations prioritylevelconfigurations:flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations psp:policy/v1beta1/podsecuritypolicies pu:pulses pulse:pulses pulses:pulses pv:v1/persistentvolumes pvc:v1/persistentvolumeclaims q:quit quit:quit quota:v1/resourcequotas rb:rbac.authorization.k8s.io/v1/rolebindings rbac.authorization.k8s.io/v1/clusterrolebindings:rbac.authorization.k8s.io/v1/clusterrolebindings rbac.authorization.k8s.io/v1/clusterroles:rbac.authorization.k8s.io/v1/clusterroles rbac.authorization.k8s.io/v1/rolebindings:rbac.authorization.k8s.io/v1/rolebindings rbac.authorization.k8s.io/v1/roles:rbac.authorization.k8s.io/v1/roles rc:v1/replicationcontrollers rcou:ceph.rook.io/v1/cephobjectstoreusers replicaset:apps/v1/replicasets replicasets:apps/v1/replicasets replication.storage.openshift.io/v1alpha1/volumereplicationclasses:replication.storage.openshift.io/v1alpha1/volumereplicationclasses replication.storage.openshift.io/v1alpha1/volumereplications:replication.storage.openshift.io/v1alpha1/volumereplications replicationcontroller:v1/replicationcontrollers replicationcontrollers:v1/replicationcontrollers resourcequota:v1/resourcequotas resourcequotas:v1/resourcequotas ro:rbac.authorization.k8s.io/v1/roles role:rbac.authorization.k8s.io/v1/roles rolebinding:rbac.authorization.k8s.io/v1/rolebindings rolebindings:rbac.authorization.k8s.io/v1/rolebindings roles:rbac.authorization.k8s.io/v1/roles rook.io/v1alpha2/volumes:rook.io/v1alpha2/volumes rs:apps/v1/replicasets runtimeclass:node.k8s.io/v1/runtimeclasses runtimeclasses:node.k8s.io/v1/runtimeclasses rv:rook.io/v1alpha2/volumes sa:v1/serviceaccounts sc:storage.k8s.io/v1/storageclasses scheduling.k8s.io/v1/priorityclasses:scheduling.k8s.io/v1/priorityclasses screendump:screendumps screendumps:screendumps sd:screendumps sec:v1/secrets secret:v1/secrets secrets:v1/secrets selfsubjectaccessreview:authorization.k8s.io/v1/selfsubjectaccessreviews selfsubjectaccessreviews:authorization.k8s.io/v1/selfsubjectaccessreviews selfsubjectrulesreview:authorization.k8s.io/v1/selfsubjectrulesreviews selfsubjectrulesreviews:authorization.k8s.io/v1/selfsubjectrulesreviews service:v1/services serviceaccount:v1/serviceaccounts serviceaccounts:v1/serviceaccounts services:v1/services snapshot.storage.k8s.io/v1/volumesnapshotclasses:snapshot.storage.k8s.io/v1/volumesnapshotclasses snapshot.storage.k8s.io/v1/volumesnapshotcontents:snapshot.storage.k8s.io/v1/volumesnapshotcontents snapshot.storage.k8s.io/v1/volumesnapshots:snapshot.storage.k8s.io/v1/volumesnapshots statefulset:apps/v1/statefulsets statefulsets:apps/v1/statefulsets storage.k8s.io/v1/csidrivers:storage.k8s.io/v1/csidrivers storage.k8s.io/v1/csinodes:storage.k8s.io/v1/csinodes storage.k8s.io/v1/storageclasses:storage.k8s.io/v1/storageclasses storage.k8s.io/v1/volumeattachments:storage.k8s.io/v1/volumeattachments storage.k8s.io/v1beta1/csistoragecapacities:storage.k8s.io/v1beta1/csistoragecapacities storageclass:storage.k8s.io/v1/storageclasses storageclasses:storage.k8s.io/v1/storageclasses storageprofile:cdi.kubevirt.io/v1beta1/storageprofiles storageprofiles:cdi.kubevirt.io/v1beta1/storageprofiles sts:apps/v1/statefulsets subjectaccessreview:authorization.k8s.io/v1/subjectaccessreviews subjectaccessreviews:authorization.k8s.io/v1/subjectaccessreviews svc:v1/services tokenreview:authentication.k8s.io/v1/tokenreviews tokenreviews:authentication.k8s.io/v1/tokenreviews upload.cdi.kubevirt.io/v1beta1/uploadtokenrequests:upload.cdi.kubevirt.io/v1beta1/uploadtokenrequests uploadtokenrequest:upload.cdi.kubevirt.io/v1beta1/uploadtokenrequests uploadtokenrequests:upload.cdi.kubevirt.io/v1beta1/uploadtokenrequests user:users users:users usr:users utr:upload.cdi.kubevirt.io/v1beta1/uploadtokenrequests utrs:upload.cdi.kubevirt.io/v1beta1/uploadtokenrequests v1/bindings:v1/bindings v1/componentstatuses:v1/componentstatuses v1/configmaps:v1/configmaps v1/endpoints:v1/endpoints v1/events:v1/events v1/limitranges:v1/limitranges v1/namespaces:v1/namespaces v1/nodes:v1/nodes v1/persistentvolumeclaims:v1/persistentvolumeclaims v1/persistentvolumes:v1/persistentvolumes v1/pods:v1/pods v1/podtemplates:v1/podtemplates v1/replicationcontrollers:v1/replicationcontrollers v1/resourcequotas:v1/resourcequotas v1/secrets:v1/secrets v1/serviceaccounts:v1/serviceaccounts v1/services:v1/services validatingwebhookconfiguration:admissionregistration.k8s.io/v1/validatingwebhookconfigurations validatingwebhookconfigurations:admissionregistration.k8s.io/v1/validatingwebhookconfigurations volume:rook.io/v1alpha2/volumes volumeattachment:storage.k8s.io/v1/volumeattachments volumeattachments:storage.k8s.io/v1/volumeattachments volumereplication:replication.storage.openshift.io/v1alpha1/volumereplications volumereplicationclass:replication.storage.openshift.io/v1alpha1/volumereplicationclasses volumereplicationclasses:replication.storage.openshift.io/v1alpha1/volumereplicationclasses volumereplications:replication.storage.openshift.io/v1alpha1/volumereplications volumes:rook.io/v1alpha2/volumes volumesnapshot:snapshot.storage.k8s.io/v1/volumesnapshots volumesnapshotclass:snapshot.storage.k8s.io/v1/volumesnapshotclasses volumesnapshotclasses:snapshot.storage.k8s.io/v1/volumesnapshotclasses volumesnapshotcontent:snapshot.storage.k8s.io/v1/volumesnapshotcontents volumesnapshotcontents:snapshot.storage.k8s.io/v1/volumesnapshotcontents volumesnapshots:snapshot.storage.k8s.io/v1/volumesnapshots vr:replication.storage.openshift.io/v1alpha1/volumereplications vrc:replication.storage.openshift.io/v1alpha1/volumereplicationclasses x:xrays xray:xrays xrays:xrays]
```