### PR TITLE
Add condition for setting current and target values from AverageValue on HPA renderer

### DIFF
--- a/internal/render/hpa.go
+++ b/internal/render/hpa.go
@@ -182,10 +182,18 @@ func toMetricsV2b2(specs []autoscalingv2beta2.MetricSpec, statuses []autoscaling
 			}
 			list = append(list, current+"/"+spec.Pods.Target.AverageValue.String())
 		case autoscalingv2beta2.ObjectMetricSourceType:
+			var target string
 			if len(statuses) > i && statuses[i].Object != nil {
-				current = statuses[i].Object.Current.Value.String()
+				if (statuses[i].Object.Current.AverageValue != nil && !statuses[i].Object.Current.AverageValue.IsZero()) ||
+					(spec.Object.Target.AverageValue != nil && !spec.Object.Target.AverageValue.IsZero()) {
+					current = statuses[i].Object.Current.AverageValue.String()
+					target = spec.Object.Target.AverageValue.String()
+				} else {
+					current = statuses[i].Object.Current.Value.String()
+					target = spec.Object.Target.Value.String()
+				}
 			}
-			list = append(list, current+"/"+spec.Object.Target.Value.String())
+			list = append(list, current+"/"+target)
 		case autoscalingv2beta2.ResourceMetricSourceType:
 			list = append(list, resourceMetricsV2b2(i, spec, statuses))
 		default:

--- a/internal/render/hpa_test.go
+++ b/internal/render/hpa_test.go
@@ -15,3 +15,21 @@ func TestHorizontalPodAutoscalerRender(t *testing.T) {
 	assert.Equal(t, "default/nginx", r.ID)
 	assert.Equal(t, render.Fields{"default", "nginx", "nginx", "<unknown>/10%", "1", "10"}, r.Fields[:6])
 }
+
+func TestHorizontalPodAutoscalerRenderAverageValueObjectMetric(t *testing.T) {
+	c := render.HorizontalPodAutoscaler{}
+	r := render.NewRow(7)
+	c.Render(load(t, "hpa_avg_value"), "", &r)
+
+	assert.Equal(t, "default/nginx", r.ID)
+	assert.Equal(t, render.Fields{"default", "nginx", "nginx", "100m/1", "1", "10"}, r.Fields[:6])
+}
+
+func TestHorizontalPodAutoscalerRenderValueObjectMetric(t *testing.T) {
+	c := render.HorizontalPodAutoscaler{}
+	r := render.NewRow(7)
+	c.Render(load(t, "hpa_value"), "", &r)
+
+	assert.Equal(t, "default/nginx", r.ID)
+	assert.Equal(t, render.Fields{"default", "nginx", "nginx", "200m/2", "1", "10"}, r.Fields[:6])
+}

--- a/internal/render/testdata/hpa_avg_value.json
+++ b/internal/render/testdata/hpa_avg_value.json
@@ -1,0 +1,59 @@
+{
+  "apiVersion": "autoscaling/v2beta2",
+  "kind": "HorizontalPodAutoscaler",
+  "metadata": {
+    "annotations": {
+      "autoscaling.alpha.kubernetes.io/conditions": "[{\"type\":\"AbleToScale\",\"status\":\"False\",\"lastTransitionTime\":\"2019-07-19T20:56:05Z\",\"reason\":\"FailedGetScale\",\"message\":\"the HPA controller was unable to get the target's current scale: deployments/scale.extensions \\\"nginx\\\" not found\"}]",
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"autoscaling/v1\",\"kind\":\"HorizontalPodAutoscaler\",\"metadata\":{\"annotations\":{},\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"maxReplicas\":10,\"minReplicas\":1,\"scaleTargetRef\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"nginx\"},\"targetCPUUtilizationPercentage\":10}}\n"
+    },
+    "creationTimestamp": "2019-07-19T20:55:50Z",
+    "name": "nginx",
+    "namespace": "default",
+    "resourceVersion": "38623948",
+    "selfLink": "/apis/autoscaling/v2beta2/namespaces/default/horizontalpodautoscalers/nginx",
+    "uid": "97104229-aa67-11e9-990f-42010a800218"
+  },
+  "spec": {
+    "maxReplicas": 10,
+    "minReplicas": 1,
+    "scaleTargetRef": {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "name": "nginx"
+    },
+    "metrics": [
+      {
+        "type":"Object",
+        "object": {
+          "target":{
+            "type": "Object",
+            "value":"0",
+            "averageValue":"1000m"
+          },
+          "metricName":"custom_metric_a",
+          "currentValue":"0",
+          "averageValue":"100m"
+        }
+      }
+    ],
+    "targetCPUUtilizationPercentage": 10
+  },
+  "status": {
+    "currentReplicas": 0,
+    "desiredReplicas": 0,
+    "currentMetrics": [
+      {
+        "type":"Object",
+        "object":{
+          "metric":{
+            "name":"custom_metric_a"
+          },
+          "current":{
+            "value":"0",
+            "averageValue":"100m"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/internal/render/testdata/hpa_value.json
+++ b/internal/render/testdata/hpa_value.json
@@ -1,0 +1,59 @@
+{
+  "apiVersion": "autoscaling/v2beta2",
+  "kind": "HorizontalPodAutoscaler",
+  "metadata": {
+    "annotations": {
+      "autoscaling.alpha.kubernetes.io/conditions": "[{\"type\":\"AbleToScale\",\"status\":\"False\",\"lastTransitionTime\":\"2019-07-19T20:56:05Z\",\"reason\":\"FailedGetScale\",\"message\":\"the HPA controller was unable to get the target's current scale: deployments/scale.extensions \\\"nginx\\\" not found\"}]",
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"autoscaling/v1\",\"kind\":\"HorizontalPodAutoscaler\",\"metadata\":{\"annotations\":{},\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"maxReplicas\":10,\"minReplicas\":1,\"scaleTargetRef\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"nginx\"},\"targetCPUUtilizationPercentage\":10}}\n"
+    },
+    "creationTimestamp": "2019-07-19T20:55:50Z",
+    "name": "nginx",
+    "namespace": "default",
+    "resourceVersion": "38623948",
+    "selfLink": "/apis/autoscaling/v2beta2/namespaces/default/horizontalpodautoscalers/nginx",
+    "uid": "97104229-aa67-11e9-990f-42010a800218"
+  },
+  "spec": {
+    "maxReplicas": 10,
+    "minReplicas": 1,
+    "scaleTargetRef": {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "name": "nginx"
+    },
+    "metrics": [
+      {
+        "type":"Object",
+        "object": {
+          "target":{
+            "type": "Object",
+            "value":"2000m",
+            "averageValue":"0"
+          },
+          "metricName":"custom_metric_a",
+          "currentValue":"200m",
+          "averageValue":"0"
+        }
+      }
+    ],
+    "targetCPUUtilizationPercentage": 10
+  },
+  "status": {
+    "currentReplicas": 0,
+    "desiredReplicas": 0,
+    "currentMetrics": [
+      {
+        "type":"Object",
+        "object":{
+          "metric":{
+            "name":"custom_metric_a"
+          },
+          "current":{
+            "value":"200m",
+            "averageValue":"0"
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes **Issue** #1440.

The proposed fix is to check for non-nil, non-zero current and target `AverageValue` values and, when found, use those when building the entry for the `TARGETS%` column when rendering an `hpa` object. 

When no non-nil, non-zero `AverageValue` is found, we fallback to the existing case where the `Value` fields are used.

There are test cases for both `Value` and `AverageValue` cases.