### PR TITLE
Retry view with pod resource on error

### DIFF
--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -115,7 +115,12 @@ func (c *Command) run(cmd, path string, clearStack bool) error {
 	cmds := strings.Split(cmd, " ")
 	gvr, v, err := c.viewMetaFor(cmds[0])
 	if err != nil {
-		return err
+		if cmds[0] == "pod" {
+			return err
+		}
+
+		// Maybe the resource kind got deleted, try again with pod view.
+		return c.run("pod", "", clearStack)
 	}
 
 	switch cmds[0] {


### PR DESCRIPTION
When a certain resource kind was stored as the last active view but got deleted on the cluster, k9s fails with:

```
 ____  __.________
|    |/ _/   __   \______
|      < \____    /  ___/
|    |  \   /    /\___ \
|____|__ \ /____//____  >
        \/            \/

Boom!! app run failed `<$RESOURCE>` command not found.
```

This PR is a workaround by retrying with the `pod` resource before failing.

Fixes  #1346.