### PR TITLE
fix padding is not 0 in fullscreen using view/details.go component

### DIFF
--- a/internal/view/details.go
+++ b/internal/view/details.go
@@ -215,6 +215,11 @@ func (d *Details) toggleFullScreenCmd(evt *tcell.EventKey) *tcell.EventKey {
 	d.fullScreen = !d.fullScreen
 	d.SetFullScreen(d.fullScreen)
 	d.Box.SetBorder(!d.fullScreen)
+	if d.fullScreen {
+		d.Box.SetBorderPadding(0, 0, 0, 0)
+	} else {
+		d.Box.SetBorderPadding(0, 0, 1, 1)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Sets the border-padding to 0 in fullscreen mode for Details (affecting nodes YAML view and secrets decoder)

Copied behaviour of https://github.com/derailed/k9s/blob/0249f7cf2c2b403348e98f03a26355aadfbdfdda/internal/view/live_view.go#L251-L255

closes https://github.com/derailed/k9s/issues/1450
