### PR TITLE
Add a helpful alias for vim users

### DIFF
--- a/internal/config/alias.go
+++ b/internal/config/alias.go
@@ -143,7 +143,7 @@ func (a *Aliases) loadDefaultAliases() {
 	a.Alias["np"] = "networking.k8s.io/v1/networkpolicies"
 
 	a.declare("help", "h", "?")
-	a.declare("quit", "q", "Q")
+	a.declare("quit", "q", "q!", "Q")
 	a.declare("aliases", "alias", "a")
 	a.declare("popeye", "pop")
 	a.declare("helm", "charts", "chart", "hm")

--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -179,7 +179,7 @@ func (c *Command) specialCmd(cmd, path string) bool {
 	case "cow":
 		c.app.cowCmd(path)
 		return true
-	case "q", "Q", "quit":
+	case "q", "Q", "q!", "quit":
 		c.app.BailOut()
 		return true
 	case "?", "h", "help":


### PR DESCRIPTION
As a `vim` user, I always do a `:q!`.
I therefore propose adding it as an alias.

It's just to improve the productivity of vim users.