### PR TITLE
fix: correct typo

### DIFF
--- a/skins/axual.yml
+++ b/skins/axual.yml
@@ -63,7 +63,7 @@ k9s:
       modifyColor: *blue
       addColor: *blue
       errorColor: *red
-      highlightcolor: *yellow
+      highlightColor: *yellow
       killColor: *red
       completedColor: *grey
 

--- a/skins/black_and_wtf.yml
+++ b/skins/black_and_wtf.yml
@@ -50,7 +50,7 @@ k9s:
       modifyColor: *text
       addColor: *ghost
       errorColor: *err
-      highlightcolor: *dslate
+      highlightColor: *dslate
       killColor: *slate
       completedColor: *gray
     title:

--- a/skins/dracula.yml
+++ b/skins/dracula.yml
@@ -59,7 +59,7 @@ k9s:
       modifyColor: *purple
       addColor: *green
       errorColor: *red
-      highlightcolor: *orange
+      highlightColor: *orange
       killColor: *comment
       completedColor: *comment
     # Border title styles.

--- a/skins/gruvbox-dark.yml
+++ b/skins/gruvbox-dark.yml
@@ -49,7 +49,7 @@ k9s:
       modifyColor: *blue
       addColor: *green
       errorColor: *red
-      highlightcolor: *orange
+      highlightColor: *orange
       killColor: *comment
       completedColor: *comment
     title:

--- a/skins/gruvbox-light.yml
+++ b/skins/gruvbox-light.yml
@@ -55,7 +55,7 @@ k9s:
       modifyColor: *blue
       addColor: *green
       errorColor: *red
-      highlightcolor: *orange
+      highlightColor: *orange
       killColor: *comment
       completedColor: *comment
     title:

--- a/skins/in_the_navy.yml
+++ b/skins/in_the_navy.yml
@@ -57,7 +57,7 @@ k9s:
       modifyColor: *powder
       addColor: *sky
       errorColor: *err
-      highlightcolor: *royal
+      highlightColor: *royal
       killColor: *slate
       completedColor: *gray
     title:

--- a/skins/kiss.yml
+++ b/skins/kiss.yml
@@ -37,7 +37,7 @@ k9s:
       modifyColor: default
       addColor: default
       errorColor: default
-      highlightcolor: default
+      highlightColor: default
       killColor: default
       completedColor: default
     title:

--- a/skins/monokai.yml
+++ b/skins/monokai.yml
@@ -59,7 +59,7 @@ k9s:
       addColor: *green
       pendingColor: *orange
       errorColor: *magenta
-      highlightcolor: *blue
+      highlightColor: *blue
       killColor: *green
       completedColor: *darkBlue
     # Border title styles.

--- a/skins/nord.yml
+++ b/skins/nord.yml
@@ -57,7 +57,7 @@ k9s:
       modifyColor: *magenta
       addColor: *green
       errorColor: *red
-      highlightcolor: *orange
+      highlightColor: *orange
       killColor: *comment
       completedColor: *comment
     # Border title styles.

--- a/skins/one_dark.yml
+++ b/skins/one_dark.yml
@@ -50,7 +50,7 @@ k9s:
       addColor: *grey
       pendingColor: *orange
       errorColor: *red
-      highlightcolor: *yellow
+      highlightColor: *yellow
       killColor: *purple
       completedColor: *grey
     title:

--- a/skins/red.yml
+++ b/skins/red.yml
@@ -37,7 +37,7 @@ k9s:
       addColor: white
       errorColor: red
       pendingColor: darkred
-      highlightcolor: red
+      highlightColor: red
       killColor: red
       completedColor: gray
     title:

--- a/skins/rose_pine.yml
+++ b/skins/rose_pine.yml
@@ -59,7 +59,7 @@ k9s:
       modifyColor: *purple
       addColor: *green
       errorColor: *red
-      highlightcolor: *orange
+      highlightColor: *orange
       killColor: *comment
       completedColor: *comment
     # Border title styles.

--- a/skins/snazzy.yml
+++ b/skins/snazzy.yml
@@ -36,7 +36,7 @@ k9s:
       modifyColor: "#5af78e"
       addColor: "#57c7ff"
       errorColor: "#ff5c57"
-      highlightcolor: "#f3f99d"
+      highlightColor: "#f3f99d"
       killColor: mediumpurple
       completedColor: gray
     title:

--- a/skins/solarized_dark.yml
+++ b/skins/solarized_dark.yml
@@ -49,7 +49,7 @@ k9s:
       modifyColor: *blue
       addColor: *green
       errorColor: *red
-      highlightcolor: *orange
+      highlightColor: *orange
       killColor: *comment
       completedColor: *comment
     title:

--- a/skins/solarized_light.yml
+++ b/skins/solarized_light.yml
@@ -50,7 +50,7 @@ k9s:
       modifyColor: *blue
       addColor: *green
       errorColor: *red
-      highlightcolor: *orange
+      highlightColor: *orange
       killColor: *comment
       completedColor: *comment
     title:

--- a/skins/stock.yml
+++ b/skins/stock.yml
@@ -37,7 +37,7 @@ k9s:
       addColor: white
       errorColor: orangered
       pendingColor: darkorange
-      highlightcolor: aqua
+      highlightColor: aqua
       killColor: mediumpurple
       completedColor: gray
     title:


### PR DESCRIPTION
If you look at the source, it should be `highlightColor`, not `highlightcolor`
https://github.com/derailed/k9s/blob/1c29fcaf6193fbe6f36cb9eec1b320b1822af235/internal/config/styles.go#L106