### PR TITLE
Fix typo in FastForwards annotation name

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ Entering the command mode and typing a resource name or alias, could be cumberso
 
 As of v0.25.0, you can leverage the `FastForwards` feature to tell K9s how to default port-forwards. In situations where you are dealing with multiple containers or containers exposing multiple ports, it can be cumbersome to specify the desired port-forward from the dialog as in most cases, you already know which container/port tuple you desire. For these use cases, you can now annotate your manifests with the following annotations:
 
-1. k9scli.io/auto-portforwards -> activates one or more port-forwards directly bypassing the port-forward dialog all together.
+1. k9scli.io/auto-port-forwards -> activates one or more port-forwards directly bypassing the port-forward dialog all together.
 2. k9scli.io/portforwards      -> pre-selects one or more port-forwards when launching the port-forward dialog.
 
 The annotation value takes on the shape `container-name::[local-port:]container-port`


### PR DESCRIPTION
Took me a while to get auto forwards working - read the code and figured out the name in the README.md file was wrong :)