### PR TITLE
Ensure correct text in prompt when suspending cronjob

### DIFF
--- a/internal/view/cronjob.go
+++ b/internal/view/cronjob.go
@@ -121,7 +121,7 @@ func (c *CronJob) showSuspendDialog(sel string) {
 		c.App().Flash().Errf("Unable to assert current status")
 		return
 	}
-	suspended := strings.TrimSpace(cell.Text) == "true"
+	suspended := strings.TrimSpace(cell.Text) == "True"
 	title := "Suspend"
 	if suspended {
 		title = "Resume"


### PR DESCRIPTION
Currently, regardless of the current Cronjob suspension status, the popup asks if we want to suspend it. This turns out to be from comparing "true" when the actual text displayed is "True".