### PR TITLE
Fix TestToAge

### DIFF
--- a/internal/render/helpers_test.go
+++ b/internal/render/helpers_test.go
@@ -98,7 +98,7 @@ func TestToAge(t *testing.T) {
 		},
 		"good": {
 			t: testTime().Add(-10 * time.Second),
-			e: "3y196d",
+			e: "3y197d",
 		},
 	}
 


### PR DESCRIPTION
Closes https://github.com/derailed/k9s/issues/1626 as it bumps the expected output from toAge tests.