### PR TITLE
DRAFT: Add config to use local TZ for pod logs instead of UTC

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -292,6 +292,7 @@ var expectedConfig = `k9s:
     fullScreenLogs: false
     textWrap: false
     showTime: false
+    useUTC: false
   currentContext: blee
   currentCluster: blee
   clusters:
@@ -386,6 +387,7 @@ var resetConfig = `k9s:
     fullScreenLogs: false
     textWrap: false
     showTime: false
+    useUTC: false
   currentContext: blee
   currentCluster: blee
   clusters:

--- a/internal/config/logger.go
+++ b/internal/config/logger.go
@@ -21,6 +21,7 @@ type Logger struct {
 	FullScreenLogs bool  `yaml:"fullScreenLogs"`
 	TextWrap       bool  `yaml:"textWrap"`
 	ShowTime       bool  `yaml:"showTime"`
+	UseUTC         bool  `yaml:"useUTC"`
 }
 
 // NewLogger returns a new instance.

--- a/internal/dao/log_item.go
+++ b/internal/dao/log_item.go
@@ -15,6 +15,7 @@ type LogItem struct {
 	SingleContainer bool
 	Bytes           []byte
 	IsError         bool
+	Time            string
 }
 
 // NewLogItem returns a new item.
@@ -39,13 +40,22 @@ func (l *LogItem) ID() string {
 	return l.Container
 }
 
-// GetTimestamp fetch log lime timestamp
+// GetTimestamp fetch log time timestamp
 func (l *LogItem) GetTimestamp() string {
 	index := bytes.Index(l.Bytes, []byte{' '})
 	if index < 0 {
 		return ""
 	}
 	return string(l.Bytes[:index])
+}
+
+// GetLogWithoutTimestamp fetch log message without timestamp
+func (l *LogItem) GetLogWithoutTimestamp() []byte {
+	index := bytes.Index(l.Bytes, []byte{' '})
+	if index < 0 {
+		return l.Bytes
+	}
+	return l.Bytes[index+1:]
 }
 
 // Info returns pod and container information.
@@ -65,12 +75,11 @@ func (l *LogItem) Size() int {
 
 // Render returns a log line as string.
 func (l *LogItem) Render(paint string, showTime bool, bb *bytes.Buffer) {
-	index := bytes.Index(l.Bytes, []byte{' '})
-	if showTime && index > 0 {
+	if showTime && l.Time != "" {
 		bb.WriteString("[gray::b]")
-		bb.Write(l.Bytes[:index])
+		bb.Write([]byte(l.Time))
 		bb.WriteString(" ")
-		for i := len(l.Bytes[:index]); i < 30; i++ {
+		for i := len(l.Time); i < 30; i++ {
 			bb.WriteByte(' ')
 		}
 	}
@@ -88,9 +97,5 @@ func (l *LogItem) Render(paint string, showTime bool, bb *bytes.Buffer) {
 		bb.WriteString("[-::] ")
 	}
 
-	if index > 0 {
-		bb.Write(l.Bytes[index+1:])
-	} else {
-		bb.Write(l.Bytes)
-	}
+	bb.Write(l.Bytes)
 }

--- a/internal/dao/log_item_test.go
+++ b/internal/dao/log_item_test.go
@@ -50,7 +50,7 @@ func TestLogItemRender(t *testing.T) {
 			opts: dao.LogOptions{
 				Path:            "blee/fred",
 				Container:       "blee",
-				SingleContainer: true,
+				SingleContainer: false,
 			},
 			log: fmt.Sprintf("%s %s\n", "2018-12-14T10:36:43.326972-07:00", "Testing 1,2,3..."),
 			e:   "[yellow::]fred [yellow::b]blee[-::-] Testing 1,2,3...\n",
@@ -59,8 +59,9 @@ func TestLogItemRender(t *testing.T) {
 			opts: dao.LogOptions{
 				Path:            "blee/fred",
 				Container:       "blee",
-				SingleContainer: true,
+				SingleContainer: false,
 				ShowTimestamp:   true,
+				UseUTC:          true,
 			},
 			log: fmt.Sprintf("%s %s\n", "2018-12-14T10:36:43.326972-07:00", "Testing 1,2,3..."),
 			e:   "[gray::b]2018-12-14T10:36:43.326972-07:00 [yellow::]fred [yellow::b]blee[-::-] Testing 1,2,3...\n",
@@ -80,7 +81,7 @@ func TestLogItemRender(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			i := dao.NewLogItem([]byte(u.log))
+			i := u.opts.ToLogItem([]byte(u.log))
 			_, n := client.Namespaced(u.opts.Path)
 			i.Pod, i.Container = n, u.opts.Container
 

--- a/internal/dao/log_items_test.go
+++ b/internal/dao/log_items_test.go
@@ -62,7 +62,7 @@ func TestLogItemsFilter(t *testing.T) {
 		u := uu[k]
 		ii := dao.NewLogItems()
 		ii.Add(
-			dao.NewLogItem([]byte(fmt.Sprintf("%s %s\n", "2018-12-14T10:36:43.326972-07:00", "Testing 1,2,3..."))),
+			u.opts.ToLogItem([]byte(fmt.Sprintf("%s %s\n", "2018-12-14T10:36:43.326972-07:00", "Testing 1,2,3..."))),
 			dao.NewLogItemFromString("Bumble bee tuna"),
 			dao.NewLogItemFromString("Jean Batiste Emmanuel Zorg"),
 		)
@@ -107,6 +107,7 @@ func TestLogItemsRender(t *testing.T) {
 				Path:          "blee/fred",
 				Container:     "blee",
 				ShowTimestamp: true,
+				UseUTC:        true,
 			},
 			e: "[gray::b]2018-12-14T10:36:43.326972-07:00 [teal::]fred [teal::b]blee[-::-] Testing 1,2,3...\n",
 		},
@@ -115,8 +116,8 @@ func TestLogItemsRender(t *testing.T) {
 	s := []byte(fmt.Sprintf("%s %s\n", "2018-12-14T10:36:43.326972-07:00", "Testing 1,2,3..."))
 	for k := range uu {
 		ii := dao.NewLogItems()
-		ii.Add(dao.NewLogItem(s))
 		u := uu[k]
+		ii.Add(u.opts.ToLogItem(s))
 		_, n := client.Namespaced(u.opts.Path)
 		ii.Items()[0].Pod, ii.Items()[0].Container = n, u.opts.Container
 		t.Run(k, func(t *testing.T) {

--- a/internal/model/log.go
+++ b/internal/model/log.go
@@ -108,6 +108,7 @@ func (l *Log) SetSinceSeconds(ctx context.Context, i int64) {
 func (l *Log) Configure(opts *config.Logger) {
 	l.logOptions.Lines = int64(opts.TailCount)
 	l.logOptions.SinceSeconds = opts.SinceSeconds
+	l.logOptions.UseUTC = opts.UseUTC
 }
 
 // GetPath returns resource path.

--- a/internal/view/log_int_test.go
+++ b/internal/view/log_int_test.go
@@ -73,9 +73,10 @@ func TestLogTimestamp(t *testing.T) {
 	ii := dao.NewLogItems()
 	ii.Add(
 		&dao.LogItem{
+			Time:      "ttt",
 			Pod:       "fred/blee",
 			Container: "c1",
-			Bytes:     []byte("ttt Testing 1, 2, 3\n"),
+			Bytes:     []byte("Testing 1, 2, 3\n"),
 		},
 	)
 	var list logList


### PR DESCRIPTION
Added new config logging.useUTC=false
If we have `useUtc = false` - we use local user TZ
Fixed unit test

Fix #1302 