### PR TITLE
Bugfix/1639-helm-releases-issue

### DIFF
--- a/internal/dao/helm.go
+++ b/internal/dao/helm.go
@@ -130,7 +130,7 @@ func (h *Helm) Delete(path string, _ *metav1.DeletionPropagation, force bool) er
 
 // EnsureHelmConfig return a new configuration.
 func (h *Helm) EnsureHelmConfig(ns string) (*action.Configuration, error) {
-	if h.cfg != nil && h.ns == ns {
+	if h.cfg != nil {
 		return h.cfg, nil
 	}
 	h.cfg = new(action.Configuration)


### PR DESCRIPTION
This should address https://github.com/derailed/k9s/issues/1639.

@derailed I'm sure there is a good reason this check was there, but it appears to be breaking any interaction with a Helm release. When you first load up the helm releases, they all load fine, but when you attempt to interact with the release (check the values, describe the chart, check the notes, w/e) and then go back to the Helm releases view, only the release you were checking is shown. This fix seems to just be a bandaid for what you were after, but in case you need a quick patch, here you go.  I'll keep looking to find the reason `h.ns` != `ns` when this function is called.