### PR TITLE
Lock config file during runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ K9s uses aliases to navigate most K8s resources.
     headless: false
     # Set to true to hide K9s crumbs. Default false
     crumbsless: false
+    # Makes config file read only. Runtime config changes only stored in memory. Default false
+    lockConfig: false
     # Indicates whether modification commands like delete/kill/edit are disabled. Default is false
     readOnly: false
     # Toggles icons display as not all terminal support these chars.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,6 +105,7 @@ func loadConfiguration() *config.Config {
 
 	k9sCfg.K9s.OverrideHeadless(*k9sFlags.Headless)
 	k9sCfg.K9s.OverrideLogoless(*k9sFlags.Logoless)
+	k9sCfg.K9s.OverrideLockConfig(*k9sFlags.LockConfig)
 	k9sCfg.K9s.OverrideCrumbsless(*k9sFlags.Crumbsless)
 	k9sCfg.K9s.OverrideReadOnly(*k9sFlags.ReadOnly)
 	k9sCfg.K9s.OverrideWrite(*k9sFlags.Write)
@@ -183,6 +184,12 @@ func initK9sFlags() {
 		"logoless",
 		false,
 		"Turn K9s logo off",
+	)
+	rootCmd.Flags().BoolVar(
+		k9sFlags.LockConfig,
+		"lockConfig",
+		false,
+		"Don't write to config file during runtime",
 	)
 	rootCmd.Flags().BoolVar(
 		k9sFlags.Crumbsless,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -241,6 +241,9 @@ func (c *Config) Save() error {
 
 // SaveFile K9s configuration to disk.
 func (c *Config) SaveFile(path string) error {
+	if c.K9s.IsLockConfig() == true {
+		return nil
+	}
 	EnsurePath(path, DefaultDirMod)
 	cfg, err := yaml.Marshal(c)
 	if err != nil {

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -27,6 +27,7 @@ type Flags struct {
 	LogFile       *string
 	Headless      *bool
 	Logoless      *bool
+	LockConfig    *bool
 	Command       *string
 	AllNamespaces *bool
 	ReadOnly      *bool
@@ -43,6 +44,7 @@ func NewFlags() *Flags {
 		LogFile:       strPtr(DefaultLogFile),
 		Headless:      boolPtr(false),
 		Logoless:      boolPtr(false),
+		LockConfig:    boolPtr(false),
 		Command:       strPtr(DefaultCommand),
 		AllNamespaces: boolPtr(false),
 		ReadOnly:      boolPtr(false),

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -16,6 +16,7 @@ type K9s struct {
 	EnableMouse         bool                `yaml:"enableMouse"`
 	Headless            bool                `yaml:"headless"`
 	Logoless            bool                `yaml:"logoless"`
+	LockConfig          bool                `yaml:"lockConfig"`
 	Crumbsless          bool                `yaml:"crumbsless"`
 	ReadOnly            bool                `yaml:"readOnly"`
 	NoIcons             bool                `yaml:"noIcons"`
@@ -28,6 +29,7 @@ type K9s struct {
 	manualRefreshRate   int
 	manualHeadless      *bool
 	manualLogoless      *bool
+	manualLockConfig    *bool
 	manualCrumbsless    *bool
 	manualReadOnly      *bool
 	manualCommand       *string
@@ -69,6 +71,11 @@ func (k *K9s) OverrideHeadless(b bool) {
 // OverrideLogoless toggle the k9s logo manually.
 func (k *K9s) OverrideLogoless(b bool) {
 	k.manualLogoless = &b
+}
+
+// OverrideLockConfig toggle the k9s LockConfig manually.
+func (k *K9s) OverrideLockConfig(b bool) {
+	k.manualLockConfig = &b
 }
 
 // OverrideCrumbsless tooh the crumbslessness manually.
@@ -116,6 +123,16 @@ func (k *K9s) IsLogoless() bool {
 	h := k.Logoless
 	if k.manualLogoless != nil && *k.manualLogoless {
 		h = *k.manualLogoless
+	}
+
+	return h
+}
+
+// IsLockConfig returns LockConfig setting.
+func (k *K9s) IsLockConfig() bool {
+	h := k.LockConfig
+	if k.manualLockConfig != nil && *k.manualLockConfig {
+		h = *k.manualLockConfig
 	}
 
 	return h


### PR DESCRIPTION
This is my proposal to fix #1642. With this change k9s doesn't write back to the config files, and only keep changes in memory. Can be useful in some niche use cases (like described in #1642).

I'm not sure about the naming of the config parameter. Feel free to propose other alternatives.