### PR TITLE
feat: allow to disable CTRL-C behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ K9s uses aliases to navigate most K8s resources.
     crumbsless: false
     # Indicates whether modification commands like delete/kill/edit are disabled. Default is false
     readOnly: false
+    # Toggles whether k9s should exit when CTRL-C is pressed. When set to true, you will need to exist k9s via the :quit command. Default is false.
+    noExitOnCtrlC: false
     # Toggles icons display as not all terminal support these chars.
     noIcons: false
     # Logs configuration

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -284,6 +284,7 @@ var expectedConfig = `k9s:
   logoless: false
   crumbsless: false
   readOnly: true
+  noExitOnCtrlC: false
   noIcons: false
   logger:
     tail: 500
@@ -378,6 +379,7 @@ var resetConfig = `k9s:
   logoless: false
   crumbsless: false
   readOnly: false
+  noExitOnCtrlC: false
   noIcons: false
   logger:
     tail: 200

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -18,6 +18,7 @@ type K9s struct {
 	Logoless            bool                `yaml:"logoless"`
 	Crumbsless          bool                `yaml:"crumbsless"`
 	ReadOnly            bool                `yaml:"readOnly"`
+	NoExitOnCtrlC       bool                `yaml:"noExitOnCtrlC"`
 	NoIcons             bool                `yaml:"noIcons"`
 	Logger              *Logger             `yaml:"logger"`
 	CurrentContext      string              `yaml:"currentContext"`

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -193,8 +193,12 @@ func (a *App) quitCmd(evt *tcell.EventKey) *tcell.EventKey {
 	if a.InCmdMode() {
 		return evt
 	}
-	a.BailOut()
 
+	if !a.Config.K9s.NoExitOnCtrlC {
+		a.BailOut()
+	}
+
+	// overwrite the default ctrl-c behavior of tview
 	return nil
 }
 


### PR DESCRIPTION
PR adds a new config entry `noExitOnCtrlC` to make this possible. Doesn't change default behavior of k9s.

Fixes #1599