### PR TITLE
Fix persistentvolumes not showing terminating status

### DIFF
--- a/internal/render/pv.go
+++ b/internal/render/pv.go
@@ -75,7 +75,7 @@ func (p PersistentVolume) Render(o interface{}, ns string, r *Row) error {
 
 	phase := pv.Status.Phase
 	if pv.ObjectMeta.DeletionTimestamp != nil {
-		phase = "Terminated"
+		phase = "Terminating"
 	}
 	var claim string
 	if pv.Spec.ClaimRef != nil {
@@ -94,7 +94,7 @@ func (p PersistentVolume) Render(o interface{}, ns string, r *Row) error {
 		size.String(),
 		accessMode(pv.Spec.AccessModes),
 		string(pv.Spec.PersistentVolumeReclaimPolicy),
-		string(pv.Status.Phase),
+		string(phase),
 		claim,
 		class,
 		pv.Status.Reason,

--- a/internal/render/pv_test.go
+++ b/internal/render/pv_test.go
@@ -15,3 +15,12 @@ func TestPersistentVolumeRender(t *testing.T) {
 	assert.Equal(t, "-/pvc-07aa4e2c-8726-11e9-a8e8-42010a80015b", r.ID)
 	assert.Equal(t, render.Fields{"pvc-07aa4e2c-8726-11e9-a8e8-42010a80015b", "1Gi", "RWO", "Delete", "Bound", "default/www-nginx-sts-1", "standard"}, r.Fields[:7])
 }
+
+func TestTerminatingPersistentVolumeRender(t *testing.T) {
+	c := render.PersistentVolume{}
+	r := render.NewRow(9)
+	c.Render(load(t, "pv_terminating"), "-", &r)
+
+	assert.Equal(t, "-/pvc-a4d86f51-916c-476b-83af-b551c91a8ac0", r.ID)
+	assert.Equal(t, render.Fields{"pvc-a4d86f51-916c-476b-83af-b551c91a8ac0", "1Gi", "RWO", "Delete", "Terminating", "default/www-nginx-sts-2", "standard"}, r.Fields[:7])
+}

--- a/internal/render/testdata/pv_terminating.json
+++ b/internal/render/testdata/pv_terminating.json
@@ -1,0 +1,74 @@
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolume",
+  "metadata": {
+    "annotations": {
+      "kubernetes.io/createdby": "gce-pd-dynamic-provisioner",
+      "pv.kubernetes.io/bound-by-controller": "yes",
+      "pv.kubernetes.io/provisioned-by": "kubernetes.io/gce-pd"
+    },
+    "creationTimestamp": "2022-06-22T03:45:57Z",
+    "deletionGracePeriodSeconds": 0,
+    "deletionTimestamp": "2022-07-21T14:11:00Z",
+    "finalizers": [
+      "kubernetes.io/pv-protection"
+    ],
+    "labels": {
+      "topology.kubernetes.io/region": "asia-southeast1",
+      "topology.kubernetes.io/zone": "asia-southeast1-b"
+    },
+    "name": "pvc-a4d86f51-916c-476b-83af-b551c91a8ac0",
+    "resourceVersion": "29037811",
+    "uid": "aa195b1a-0e00-43e6-aad9-d4b016904930"
+  },
+  "spec": {
+    "accessModes": [
+      "ReadWriteOnce"
+    ],
+    "capacity": {
+      "storage": "1Gi"
+    },
+    "claimRef": {
+      "apiVersion": "v1",
+      "kind": "PersistentVolumeClaim",
+      "name": "www-nginx-sts-2",
+      "namespace": "default",
+      "resourceVersion": "4028123",
+      "uid": "a4d86f51-916c-476b-83af-b551c91a8ac0"
+    },
+    "gcePersistentDisk": {
+      "fsType": "ext4",
+      "pdName": "gke-k9s-fd5bf60e-pvc-a4d86f51-916c-476b-83af-b551c91a8ac0"
+    },
+    "nodeAffinity": {
+      "required": {
+        "nodeSelectorTerms": [
+          {
+            "matchExpressions": [
+              {
+                "key": "topology.kubernetes.io/zone",
+                "operator": "In",
+                "values": [
+                  "asia-southeast1-b"
+                ]
+              },
+              {
+                "key": "topology.kubernetes.io/region",
+                "operator": "In",
+                "values": [
+                  "asia-southeast1"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "persistentVolumeReclaimPolicy": "Delete",
+    "storageClassName": "standard",
+    "volumeMode": "Filesystem"
+  },
+  "status": {
+    "phase": "Bound"
+  }
+}


### PR DESCRIPTION
Fixes: #1674 

Before:
![image](https://user-images.githubusercontent.com/22258021/181871800-94c778a1-7ddd-4d1b-83f5-c91bcb1a10fc.png)

After:
![image](https://user-images.githubusercontent.com/22258021/181871844-f9c3cf64-d8d1-4246-a1b7-b22b4f6dd7ed.png)

(note the status column)

Ground-truth from `kubectl`:
```sh
$ k get pv pvc-cec37aa2-5232-40ac-873a-51a631e16173 
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS        CLAIM                                  STORAGECLASS   REASON   AGE
pvc-cec37aa2-5232-40ac-873a-51a631e16173   10Gi       RWO            Delete           Terminating   stag-manabie-kafka/kafka-pvc-kafka-1   standard                42d
```