### PR TITLE
Increase expiry in client_test.go

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -38,7 +38,7 @@ func TestCheckCacheBool(t *testing.T) {
 		},
 	}
 
-	expiry := 1 * time.Millisecond
+	expiry := 10 * time.Millisecond
 	for k := range uu {
 		u := uu[k]
 		c.cache.Add(key, u.val, expiry)


### PR DESCRIPTION
On some resource constrain environments this test might fail due to longer processing (like Raspberry Pi)

```
--- FAIL: TestCheckCacheBool (0.01s)
    --- FAIL: TestCheckCacheBool/setFalse (0.00s)
        client_test.go:50:
                Error Trace:    client_test.go:50
                Error:          Not equal:
                                expected: true
                                actual  : false
                Test:           TestCheckCacheBool/setFalse
```