### PR TITLE
Add Docker Desktop Extension installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ K9s is available on Linux, macOS and Windows platforms.
   ```shell
   curl.exe -A MS https://webinstall.dev/k9s | powershell
   ```
+  
+* As a [Docker Desktop Extension](https://docs.docker.com/desktop/extensions/) (for the Docker Desktop built in Kubernetes Server)
+
+  ```shell
+  docker extension install spurin/k9s-dd-extension:latest
+  ```
 
 ---
 


### PR DESCRIPTION
Hi Team,

Awesome project.  I've recently created a Docker Desktop Extension that provides a quick and convenient means of using k9s, in Docker Desktop against the built in Kubernetes server.  When installed, the user see's something like this -

<img width="1382" alt="Screenshot 2022-08-08 at 16 13 46" src="https://user-images.githubusercontent.com/850464/183451791-09ef39cd-63a7-4675-b528-cff41e0b1536.png">

It's all open sourced, related repository is at https://github.com/spurin/k9s-dd-extension

I hope you find this helpful and if you're happy, please accept this pull request.  Going forward, if you'd like to maintain and manage this extension I'd be happy to work something out.


Many Thanks


James Spurin

