### PR TITLE
Set initial terminal window size

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ K9s uses aliases to navigate most K8s resources.
     noExitOnCtrlC: false
     # Toggles icons display as not all terminal support these chars.
     noIcons: false
+    # Sometimes the initial shell window dimensions may be wrong, set this to true to try to fix it. Default false.
+    fixWindowSize: false
     # Logs configuration
     logger:
       # Defines the number of lines to return. Default 100

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ K9s uses aliases to navigate most K8s resources.
     # Toggles icons display as not all terminal support these chars.
     noIcons: false
     # Sometimes the initial shell window dimensions may be wrong, set this to true to try to fix it. Default false.
-    fixWindowSize: false
+    fixShellWindowSize: false
     # Logs configuration
     logger:
       # Defines the number of lines to return. Default 100
@@ -361,7 +361,7 @@ K9s uses aliases to navigate most K8s resources.
           - default
         view:
           active: dp
-    # The path to screen dump. Default: '%temp_dir%/k9s-screens-%username%' (k9s info) 
+    # The path to screen dump. Default: '%temp_dir%/k9s-screens-%username%' (k9s info)
     screenDumpDir: /tmp
   ```
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -286,7 +286,7 @@ var expectedConfig = `k9s:
   readOnly: true
   noExitOnCtrlC: false
   noIcons: false
-  fixWindowSize: false
+  fixShellWindowSize: false
   logger:
     tail: 500
     buffer: 800
@@ -382,7 +382,7 @@ var resetConfig = `k9s:
   readOnly: false
   noExitOnCtrlC: false
   noIcons: false
-  fixWindowSize: false
+  fixShellWindowSize: false
   logger:
     tail: 200
     buffer: 2000

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -286,6 +286,7 @@ var expectedConfig = `k9s:
   readOnly: true
   noExitOnCtrlC: false
   noIcons: false
+  fixWindowSize: false
   logger:
     tail: 500
     buffer: 800
@@ -381,6 +382,7 @@ var resetConfig = `k9s:
   readOnly: false
   noExitOnCtrlC: false
   noIcons: false
+  fixWindowSize: false
   logger:
     tail: 200
     buffer: 2000

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -21,7 +21,7 @@ type K9s struct {
 	NoExitOnCtrlC       bool                `yaml:"noExitOnCtrlC"`
 	NoIcons             bool                `yaml:"noIcons"`
 	Logger              *Logger             `yaml:"logger"`
-	FixWindowSize       bool                `yaml:"fixWindowSize"`
+	FixShellWindowSize  bool                `yaml:"fixShellWindowSize"`
 	CurrentContext      string              `yaml:"currentContext"`
 	CurrentCluster      string              `yaml:"currentCluster"`
 	Clusters            map[string]*Cluster `yaml:"clusters,omitempty"`

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -21,6 +21,7 @@ type K9s struct {
 	NoExitOnCtrlC       bool                `yaml:"noExitOnCtrlC"`
 	NoIcons             bool                `yaml:"noIcons"`
 	Logger              *Logger             `yaml:"logger"`
+	FixWindowSize       bool                `yaml:"fixWindowSize"`
 	CurrentContext      string              `yaml:"currentContext"`
 	CurrentCluster      string              `yaml:"currentCluster"`
 	Clusters            map[string]*Cluster `yaml:"clusters,omitempty"`

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
 
 	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
@@ -287,12 +289,31 @@ func shellIn(a *App, fqn, co string) {
 	if err != nil {
 		log.Warn().Err(err).Msgf("os detect failed")
 	}
-	args := computeShellArgs(fqn, co, a.Conn().Config().Flags().KubeConfig, os)
+
+	env := make(map[string]string)
+
+	if a.Config.K9s.FixWindowSize {
+		if cols, lines, ok := getWindowSize(); ok {
+			env["COLUMNS"] = fmt.Sprint(cols)
+			env["LINES"] = fmt.Sprint(lines)
+		}
+	}
+
+	args := computeShellArgs(fqn, co, a.Conn().Config().Flags().KubeConfig, os, env)
 
 	c := color.New(color.BgGreen).Add(color.FgBlack).Add(color.Bold)
 	if !runK(a, shellOpts{clear: true, banner: c.Sprintf(bannerFmt, fqn, co), args: args}) {
 		a.Flash().Err(errors.New("Shell exec failed"))
 	}
+}
+
+func getWindowSize() (cols int, lines int, ok bool) {
+	cmd := exec.Command("stty", "size")
+	cmd.Stdin = os.Stdin
+	out, _ := cmd.Output()
+	n, err := fmt.Sscanf(string(out), "%d %d", &lines, &cols)
+	ok = n == 2 && err == nil && cols > 0 && lines > 0
+	return
 }
 
 func containerAttachIn(a *App, comp model.Component, path, co string) error {
@@ -337,12 +358,19 @@ func attachIn(a *App, path, co string) {
 	}
 }
 
-func computeShellArgs(path, co string, kcfg *string, os string) []string {
+func computeShellArgs(path, co string, kcfg *string, os string, env map[string]string) []string {
 	args := buildShellArgs("exec", path, co, kcfg)
 	if os == windowsOS {
 		return append(args, "--", powerShell)
 	}
-	return append(args, "--", "sh", "-c", shellCheck)
+	args = append(args, "--")
+	if len(env) > 0 {
+		args = append(args, "env")
+		for k, v := range env {
+			args = append(args, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+	return append(args, "sh", "-c", shellCheck)
 }
 
 func buildShellArgs(cmd, path, co string, kcfg *string) []string {

--- a/internal/view/pod_int_test.go
+++ b/internal/view/pod_int_test.go
@@ -55,7 +55,7 @@ func TestComputeShellArgs(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			args := computeShellArgs(u.fqn, u.co, u.cfg, u.os)
+			args := computeShellArgs(u.fqn, u.co, u.cfg, u.os, nil)
 			assert.Equal(t, u.e, strings.Join(args, " "))
 		})
 	}

--- a/internal/view/pod_int_test.go
+++ b/internal/view/pod_int_test.go
@@ -55,7 +55,8 @@ func TestComputeShellArgs(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			args := computeShellArgs(u.fqn, u.co, u.cfg, u.os, nil)
+			var terminalSize TerminalSize
+			args := computeShellArgs(u.fqn, u.co, u.cfg, u.os, terminalSize)
 			assert.Equal(t, u.e, strings.Join(args, " "))
 		})
 	}


### PR DESCRIPTION
Refreshed version of https://github.com/derailed/k9s/pull/1280 (rebased, fixed merge conflicts, addressed feedback).
Fixes https://github.com/derailed/k9s/issues/1267

The exec ends up looking something like this:

```
/usr/local/bin/kubectl --context mycontext exec -it -n mynamespace pod-name -c php-fpm -- env COLUMNS=173 LINES=29 sh -c command -v bash >/dev/null && exec bash || exec sh
```

Replicating the terminal sizing issue is a bit strange though. I consistently had the terminal sizing issues forever, but upon first trying out this patch it became a bit inconsistent even when not using the patched version. I'm going to use this branch as my default, and will report back if it ever crops back up again.