### PR TITLE
Replace clipboard package (#868)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ replace github.com/gdamore/tcell/v2 => github.com/derailed/tcell/v2 v2.3.1-rc.2
 
 require (
 	github.com/adrg/xdg v0.4.0
-	github.com/atotto/clipboard v0.1.4
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/derailed/popeye v0.10.1
@@ -24,6 +23,7 @@ require (
 	github.com/sahilm/fuzzy v0.1.0
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.0
+	golang.design/x/clipboard v0.6.2
 	golang.org/x/text v0.3.7
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.9.2
@@ -146,6 +146,9 @@ require (
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
+	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 // indirect
+	golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // indirect
+	golang.org/x/mobile v0.0.0-20210716004757-34ab1303b554 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 h1:4daAzAu0S6Vi7/lbWECcX0j45yZReDZ56BQsrVBOEEY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
-github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
-github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/aws-sdk-go v1.38.49 h1:E31vxjCe6a5I+mJLmUGaZobiWmg9KdWaud9IfceYeYQ=
 github.com/aws/aws-sdk-go v1.38.49/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
@@ -792,6 +790,8 @@ go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9i
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
+golang.design/x/clipboard v0.6.2 h1:a3Np4qfKnLWwfFJQhUWU3IDeRfmVuqWl+QPtP4CSYGw=
+golang.design/x/clipboard v0.6.2/go.mod h1:kqBSweBP0/im4SZGGjLrppH0D400Hnfo5WbFKSNK8N4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -812,15 +812,19 @@ golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
+golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
 golang.org/x/exp v0.0.0-20190829153037-c13cbed26979/go.mod h1:86+5VVa7VpoJ4kLfm080zCjGlMRFzhUhsZKEZO7MGek=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
 golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
+golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.0.0-20211028202545-6944b10bf410 h1:hTftEOvwiOq2+O8k2D5/Q7COC7k5Qcrgc2TFURJYnvQ=
+golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -835,6 +839,8 @@ golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPI
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
+golang.org/x/mobile v0.0.0-20210716004757-34ab1303b554 h1:3In5TnfvnuXTF/uflgpYxSCEGP2NdYT37KsPh3VjZYU=
+golang.org/x/mobile v0.0.0-20210716004757-34ab1303b554/go.mod h1:jFTmtFYCV0MFtXBU+J5V/+5AUeVS0ON/0WkE/KSrl6E=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=

--- a/internal/view/details.go
+++ b/internal/view/details.go
@@ -2,7 +2,6 @@ package view
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/derailed/tview"
 	"github.com/gdamore/tcell/v2"
 	"github.com/sahilm/fuzzy"
-	"golang.design/x/clipboard"
 )
 
 const detailsTitleFmt = "[fg:bg:b] %s([hilite:bg:b]%s[fg:bg:-])[fg:bg:-] "
@@ -294,16 +292,7 @@ func (d *Details) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 }
 
 func (d *Details) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
-	d.app.Flash().Info("Content copied to clipboard...")
-	if err := clipboard.Init(); err != nil {
-		d.app.Flash().Err(err)
-	} else {
-		if clipboard.Write(clipboard.FmtText, []byte(d.text.GetText(true))) == nil {
-			d.app.Flash().Err(errors.New("Failed to write to clipboard"))
-		}
-	}
-
-	return nil
+	return cpCmd(d.app.Flash(), d.text.GetText(true))(evt)
 }
 
 func (d *Details) updateTitle() {

--- a/internal/view/details.go
+++ b/internal/view/details.go
@@ -296,10 +296,11 @@ func (d *Details) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 func (d *Details) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	d.app.Flash().Info("Content copied to clipboard...")
 	if err := clipboard.Init(); err != nil {
-		d.app.Flash().Err(err)
-	}
-	if clipboard.Write(clipboard.FmtText, []byte(d.text.GetText(true))) == nil {
-		d.app.Flash().Err(errors.New("Failed to write to clipboard"))
+		panic(err)
+	} else {
+		if clipboard.Write(clipboard.FmtText, []byte(d.text.GetText(true))) == nil {
+			d.app.Flash().Err(errors.New("Failed to write to clipboard"))
+		}
 	}
 
 	return nil

--- a/internal/view/details.go
+++ b/internal/view/details.go
@@ -124,7 +124,7 @@ func (d *Details) bindKeys() {
 		tcell.KeyEnter:  ui.NewSharedKeyAction("Filter", d.filterCmd, false),
 		tcell.KeyEscape: ui.NewKeyAction("Back", d.resetCmd, false),
 		tcell.KeyCtrlS:  ui.NewKeyAction("Save", d.saveCmd, false),
-		ui.KeyC:         ui.NewKeyAction("Copy", d.cpCmd, true),
+		ui.KeyC:         ui.NewKeyAction("Copy", cpCmd(d.app.Flash(), d.text), true),
 		ui.KeyF:         ui.NewKeyAction("Toggle FullScreen", d.toggleFullScreenCmd, true),
 		ui.KeyN:         ui.NewKeyAction("Next Match", d.nextCmd, true),
 		ui.KeyShiftN:    ui.NewKeyAction("Prev Match", d.prevCmd, true),
@@ -289,10 +289,6 @@ func (d *Details) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 	}
 
 	return nil
-}
-
-func (d *Details) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
-	return cpCmd(d.app.Flash(), d.text.GetText(true))(evt)
 }
 
 func (d *Details) updateTitle() {

--- a/internal/view/details.go
+++ b/internal/view/details.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/atotto/clipboard"
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/model"
 	"github.com/derailed/k9s/internal/ui"
 	"github.com/derailed/tview"
 	"github.com/gdamore/tcell/v2"
 	"github.com/sahilm/fuzzy"
+	"golang.design/x/clipboard"
 )
 
 const detailsTitleFmt = "[fg:bg:b] %s([hilite:bg:b]%s[fg:bg:-])[fg:bg:-] "
@@ -294,9 +294,10 @@ func (d *Details) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 
 func (d *Details) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	d.app.Flash().Info("Content copied to clipboard...")
-	if err := clipboard.WriteAll(d.text.GetText(true)); err != nil {
+	if err := clipboard.Init(); err != nil {
 		d.app.Flash().Err(err)
 	}
+	clipboard.Write(clipboard.FmtText, []byte(d.text.GetText(true)))
 
 	return nil
 }

--- a/internal/view/details.go
+++ b/internal/view/details.go
@@ -296,7 +296,7 @@ func (d *Details) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 func (d *Details) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	d.app.Flash().Info("Content copied to clipboard...")
 	if err := clipboard.Init(); err != nil {
-		panic(err)
+		d.app.Flash().Err(err)
 	} else {
 		if clipboard.Write(clipboard.FmtText, []byte(d.text.GetText(true))) == nil {
 			d.app.Flash().Err(errors.New("Failed to write to clipboard"))

--- a/internal/view/details.go
+++ b/internal/view/details.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -297,7 +298,9 @@ func (d *Details) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	if err := clipboard.Init(); err != nil {
 		d.app.Flash().Err(err)
 	}
-	clipboard.Write(clipboard.FmtText, []byte(d.text.GetText(true)))
+	if clipboard.Write(clipboard.FmtText, []byte(d.text.GetText(true))) == nil {
+		d.app.Flash().Err(errors.New("Failed to write to clipboard"))
+	}
 
 	return nil
 }

--- a/internal/view/helpers.go
+++ b/internal/view/helpers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/derailed/k9s/internal/model"
 	"github.com/derailed/k9s/internal/render"
 	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/tview"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rs/zerolog/log"
 	"golang.design/x/clipboard"
@@ -226,9 +227,9 @@ func clipboardWrite(text string) error {
 	return nil
 }
 
-func cpCmd(flash *model.Flash, text string) func(*tcell.EventKey) *tcell.EventKey {
+func cpCmd(flash *model.Flash, v *tview.TextView) func(*tcell.EventKey) *tcell.EventKey {
 	return func(evt *tcell.EventKey) *tcell.EventKey {
-		if err := clipboardWrite(text); err != nil {
+		if err := clipboardWrite(v.GetText(true)); err != nil {
 			flash.Err(err)
 			return evt
 		}

--- a/internal/view/helpers.go
+++ b/internal/view/helpers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/derailed/k9s/internal/ui"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rs/zerolog/log"
+	"golang.design/x/clipboard"
 )
 
 func parsePFAnn(s string) (string, string, bool) {
@@ -213,4 +214,25 @@ func decorateCpuMemHeaderRows(app *App, data *render.TableData) *render.TableDat
 	}
 
 	return data
+}
+
+func clipboardWrite(text string) error {
+	if err := clipboard.Init(); err != nil {
+		return err
+	}
+	if clipboard.Write(clipboard.FmtText, []byte(text)) == nil {
+		return errors.New("unable to write to clipboard")
+	}
+	return nil
+}
+
+func cpCmd(flash *model.Flash, text string) func(*tcell.EventKey) *tcell.EventKey {
+	return func(evt *tcell.EventKey) *tcell.EventKey {
+		if err := clipboardWrite(text); err != nil {
+			flash.Err(err)
+			return evt
+		}
+		flash.Info("Content copied to clipboard...")
+		return nil
+	}
 }

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -345,10 +345,11 @@ func (v *LiveView) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 func (v *LiveView) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	v.app.Flash().Info("Content copied to clipboard...")
 	if err := clipboard.Init(); err != nil {
-		v.app.Flash().Err(err)
-	}
-	if clipboard.Write(clipboard.FmtText, []byte(v.text.GetText(true))) == nil {
-		v.app.Flash().Err(errors.New("Failed to write to clipboard"))
+		panic(err)
+	} else {
+		if clipboard.Write(clipboard.FmtText, []byte(v.text.GetText(true))) == nil {
+			v.app.Flash().Err(errors.New("Failed to write to clipboard"))
+		}
 	}
 
 	return nil

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -345,7 +345,7 @@ func (v *LiveView) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 func (v *LiveView) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	v.app.Flash().Info("Content copied to clipboard...")
 	if err := clipboard.Init(); err != nil {
-		panic(err)
+		v.app.Flash().Err(err)
 	} else {
 		if clipboard.Write(clipboard.FmtText, []byte(v.text.GetText(true))) == nil {
 			v.app.Flash().Err(errors.New("Failed to write to clipboard"))

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/atotto/clipboard"
 	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/model"
@@ -15,6 +14,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/sahilm/fuzzy"
+	"golang.design/x/clipboard"
 )
 
 const liveViewTitleFmt = "[fg:bg:b] %s([hilite:bg:b]%s[fg:bg:-])[fg:bg:-] "
@@ -343,9 +343,10 @@ func (v *LiveView) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 
 func (v *LiveView) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	v.app.Flash().Info("Content copied to clipboard...")
-	if err := clipboard.WriteAll(v.text.GetText(true)); err != nil {
+	if err := clipboard.Init(); err != nil {
 		v.app.Flash().Err(err)
 	}
+	clipboard.Write(clipboard.FmtText, []byte(v.text.GetText(true)))
 
 	return nil
 }

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -135,7 +135,7 @@ func (v *LiveView) bindKeys() {
 		tcell.KeyEnter:  ui.NewSharedKeyAction("Filter", v.filterCmd, false),
 		tcell.KeyEscape: ui.NewKeyAction("Back", v.resetCmd, false),
 		tcell.KeyCtrlS:  ui.NewKeyAction("Save", v.saveCmd, false),
-		ui.KeyC:         ui.NewKeyAction("Copy", v.cpCmd, true),
+		ui.KeyC:         ui.NewKeyAction("Copy", cpCmd(v.app.Flash(), v.text), true),
 		ui.KeyF:         ui.NewKeyAction("Toggle FullScreen", v.toggleFullScreenCmd, true),
 		ui.KeyR:         ui.NewKeyAction("Toggle Auto-Refresh", v.toggleRefreshCmd, true),
 		ui.KeyN:         ui.NewKeyAction("Next Match", v.nextCmd, true),
@@ -338,10 +338,6 @@ func (v *LiveView) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 	}
 
 	return nil
-}
-
-func (v *LiveView) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
-	return cpCmd(v.app.Flash(), v.text.GetText(true))(evt)
 }
 
 func (v *LiveView) updateTitle() {

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -2,7 +2,6 @@ package view
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -15,7 +14,6 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/sahilm/fuzzy"
-	"golang.design/x/clipboard"
 )
 
 const liveViewTitleFmt = "[fg:bg:b] %s([hilite:bg:b]%s[fg:bg:-])[fg:bg:-] "
@@ -343,16 +341,7 @@ func (v *LiveView) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 }
 
 func (v *LiveView) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
-	v.app.Flash().Info("Content copied to clipboard...")
-	if err := clipboard.Init(); err != nil {
-		v.app.Flash().Err(err)
-	} else {
-		if clipboard.Write(clipboard.FmtText, []byte(v.text.GetText(true))) == nil {
-			v.app.Flash().Err(errors.New("Failed to write to clipboard"))
-		}
-	}
-
-	return nil
+	return cpCmd(v.app.Flash(), v.text.GetText(true))(evt)
 }
 
 func (v *LiveView) updateTitle() {

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -346,7 +347,9 @@ func (v *LiveView) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	if err := clipboard.Init(); err != nil {
 		v.app.Flash().Err(err)
 	}
-	clipboard.Write(clipboard.FmtText, []byte(v.text.GetText(true)))
+	if clipboard.Write(clipboard.FmtText, []byte(v.text.GetText(true))) == nil {
+		v.app.Flash().Err(errors.New("Failed to write to clipboard"))
+	}
 
 	return nil
 }

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/atotto/clipboard"
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/color"
 	"github.com/derailed/k9s/internal/config"
@@ -20,6 +19,7 @@ import (
 	"github.com/derailed/tview"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rs/zerolog/log"
+	"golang.design/x/clipboard"
 )
 
 const (
@@ -408,9 +408,10 @@ func (l *Log) SaveCmd(*tcell.EventKey) *tcell.EventKey {
 
 func (l *Log) cpCmd(*tcell.EventKey) *tcell.EventKey {
 	l.app.Flash().Info("Content copied to clipboard...")
-	if err := clipboard.WriteAll(l.logs.GetText(true)); err != nil {
+	if err := clipboard.Init(); err != nil {
 		l.app.Flash().Err(err)
 	}
+	clipboard.Write(clipboard.FmtText, []byte(l.logs.GetText(true)))
 	return nil
 }
 

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -2,7 +2,6 @@ package view
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -20,7 +19,6 @@ import (
 	"github.com/derailed/tview"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rs/zerolog/log"
-	"golang.design/x/clipboard"
 )
 
 const (
@@ -407,16 +405,8 @@ func (l *Log) SaveCmd(*tcell.EventKey) *tcell.EventKey {
 	return nil
 }
 
-func (l *Log) cpCmd(*tcell.EventKey) *tcell.EventKey {
-	l.app.Flash().Info("Content copied to clipboard...")
-	if err := clipboard.Init(); err != nil {
-		l.app.Flash().Err(err)
-	} else {
-		if clipboard.Write(clipboard.FmtText, []byte(l.logs.GetText(true))) == nil {
-			l.app.Flash().Err(errors.New("Failed to write to clipboard"))
-		}
-	}
-	return nil
+func (l *Log) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
+	return cpCmd(l.app.Flash(), l.logs.TextView.GetText(true))(evt)
 }
 
 func ensureDir(dir string) error {

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -410,10 +410,11 @@ func (l *Log) SaveCmd(*tcell.EventKey) *tcell.EventKey {
 func (l *Log) cpCmd(*tcell.EventKey) *tcell.EventKey {
 	l.app.Flash().Info("Content copied to clipboard...")
 	if err := clipboard.Init(); err != nil {
-		l.app.Flash().Err(err)
-	}
-	if clipboard.Write(clipboard.FmtText, []byte(l.logs.GetText(true))) == nil {
-		l.app.Flash().Err(errors.New("Failed to write to clipboard"))
+		panic(err)
+	} else {
+		if clipboard.Write(clipboard.FmtText, []byte(l.logs.GetText(true))) == nil {
+			l.app.Flash().Err(errors.New("Failed to write to clipboard"))
+		}
 	}
 	return nil
 }

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -411,7 +412,9 @@ func (l *Log) cpCmd(*tcell.EventKey) *tcell.EventKey {
 	if err := clipboard.Init(); err != nil {
 		l.app.Flash().Err(err)
 	}
-	clipboard.Write(clipboard.FmtText, []byte(l.logs.GetText(true)))
+	if clipboard.Write(clipboard.FmtText, []byte(l.logs.GetText(true))) == nil {
+		l.app.Flash().Err(errors.New("Failed to write to clipboard"))
+	}
 	return nil
 }
 

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -251,7 +251,7 @@ func (l *Log) bindKeys() {
 		ui.KeyT:         ui.NewKeyAction("Toggle Timestamp", l.toggleTimestampCmd, true),
 		ui.KeyW:         ui.NewKeyAction("Toggle Wrap", l.toggleTextWrapCmd, true),
 		tcell.KeyCtrlS:  ui.NewKeyAction("Save", l.SaveCmd, true),
-		ui.KeyC:         ui.NewKeyAction("Copy", l.cpCmd, true),
+		ui.KeyC:         ui.NewKeyAction("Copy", cpCmd(l.app.Flash(), l.logs.TextView), true),
 	})
 	if l.model.HasDefaultContainer() {
 		l.logs.Actions().Set(ui.KeyActions{
@@ -403,10 +403,6 @@ func (l *Log) SaveCmd(*tcell.EventKey) *tcell.EventKey {
 	l.app.Flash().Infof("Log %s saved successfully!", path)
 
 	return nil
-}
-
-func (l *Log) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
-	return cpCmd(l.app.Flash(), l.logs.TextView.GetText(true))(evt)
 }
 
 func ensureDir(dir string) error {

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -410,7 +410,7 @@ func (l *Log) SaveCmd(*tcell.EventKey) *tcell.EventKey {
 func (l *Log) cpCmd(*tcell.EventKey) *tcell.EventKey {
 	l.app.Flash().Info("Content copied to clipboard...")
 	if err := clipboard.Init(); err != nil {
-		panic(err)
+		l.app.Flash().Err(err)
 	} else {
 		if clipboard.Write(clipboard.FmtText, []byte(l.logs.GetText(true))) == nil {
 			l.app.Flash().Err(errors.New("Failed to write to clipboard"))

--- a/internal/view/logger.go
+++ b/internal/view/logger.go
@@ -165,7 +165,7 @@ func (l *Logger) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 func (l *Logger) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	l.app.Flash().Info("Content copied to clipboard...")
 	if err := clipboard.Init(); err != nil {
-		panic(err)
+		l.app.Flash().Err(err)
 	} else {
 		if clipboard.Write(clipboard.FmtText, []byte(l.GetText(true))) == nil {
 			l.app.Flash().Err(errors.New("Failed to write to clipboard"))

--- a/internal/view/logger.go
+++ b/internal/view/logger.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"context"
+	"errors"
 
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/model"
@@ -166,7 +167,9 @@ func (l *Logger) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	if err := clipboard.Init(); err != nil {
 		l.app.Flash().Err(err)
 	}
-	clipboard.Write(clipboard.FmtText, []byte(l.GetText(true)))
+	if clipboard.Write(clipboard.FmtText, []byte(l.GetText(true))) == nil {
+		l.app.Flash().Err(errors.New("Failed to write to clipboard"))
+	}
 
 	return nil
 }

--- a/internal/view/logger.go
+++ b/internal/view/logger.go
@@ -3,12 +3,12 @@ package view
 import (
 	"context"
 
-	"github.com/atotto/clipboard"
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/model"
 	"github.com/derailed/k9s/internal/ui"
 	"github.com/derailed/tview"
 	"github.com/gdamore/tcell/v2"
+	"golang.design/x/clipboard"
 )
 
 // Logger represents a generic log viewer.
@@ -163,9 +163,10 @@ func (l *Logger) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 
 func (l *Logger) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	l.app.Flash().Info("Content copied to clipboard...")
-	if err := clipboard.WriteAll(l.GetText(true)); err != nil {
+	if err := clipboard.Init(); err != nil {
 		l.app.Flash().Err(err)
 	}
+	clipboard.Write(clipboard.FmtText, []byte(l.GetText(true)))
 
 	return nil
 }

--- a/internal/view/logger.go
+++ b/internal/view/logger.go
@@ -165,10 +165,11 @@ func (l *Logger) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 func (l *Logger) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	l.app.Flash().Info("Content copied to clipboard...")
 	if err := clipboard.Init(); err != nil {
-		l.app.Flash().Err(err)
-	}
-	if clipboard.Write(clipboard.FmtText, []byte(l.GetText(true))) == nil {
-		l.app.Flash().Err(errors.New("Failed to write to clipboard"))
+		panic(err)
+	} else {
+		if clipboard.Write(clipboard.FmtText, []byte(l.GetText(true))) == nil {
+			l.app.Flash().Err(errors.New("Failed to write to clipboard"))
+		}
 	}
 
 	return nil

--- a/internal/view/logger.go
+++ b/internal/view/logger.go
@@ -2,14 +2,12 @@ package view
 
 import (
 	"context"
-	"errors"
 
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/model"
 	"github.com/derailed/k9s/internal/ui"
 	"github.com/derailed/tview"
 	"github.com/gdamore/tcell/v2"
-	"golang.design/x/clipboard"
 )
 
 // Logger represents a generic log viewer.
@@ -163,14 +161,5 @@ func (l *Logger) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 }
 
 func (l *Logger) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
-	l.app.Flash().Info("Content copied to clipboard...")
-	if err := clipboard.Init(); err != nil {
-		l.app.Flash().Err(err)
-	} else {
-		if clipboard.Write(clipboard.FmtText, []byte(l.GetText(true))) == nil {
-			l.app.Flash().Err(errors.New("Failed to write to clipboard"))
-		}
-	}
-
-	return nil
+	return cpCmd(l.app.Flash(), l.TextView.GetText(true))(evt)
 }

--- a/internal/view/logger.go
+++ b/internal/view/logger.go
@@ -69,7 +69,7 @@ func (l *Logger) bindKeys() {
 	l.actions.Set(ui.KeyActions{
 		tcell.KeyEscape: ui.NewKeyAction("Back", l.resetCmd, false),
 		tcell.KeyCtrlS:  ui.NewKeyAction("Save", l.saveCmd, false),
-		ui.KeyC:         ui.NewKeyAction("Copy", l.cpCmd, true),
+		ui.KeyC:         ui.NewKeyAction("Copy", cpCmd(l.app.Flash(), l.TextView), true),
 		ui.KeySlash:     ui.NewSharedKeyAction("Filter Mode", l.activateCmd, false),
 		tcell.KeyDelete: ui.NewSharedKeyAction("Erase", l.eraseCmd, false),
 	})
@@ -158,8 +158,4 @@ func (l *Logger) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
 	}
 
 	return nil
-}
-
-func (l *Logger) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
-	return cpCmd(l.app.Flash(), l.TextView.GetText(true))(evt)
 }

--- a/internal/view/table.go
+++ b/internal/view/table.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -214,7 +215,9 @@ func (t *Table) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	if err := clipboard.Init(); err != nil {
 		t.app.Flash().Err(err)
 	}
-	clipboard.Write(clipboard.FmtText, []byte(n))
+	if clipboard.Write(clipboard.FmtText, []byte(n)) == nil {
+		t.app.Flash().Err(errors.New("Failed to write to clipboard"))
+	}
 
 	return nil
 }

--- a/internal/view/table.go
+++ b/internal/view/table.go
@@ -5,13 +5,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atotto/clipboard"
 	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/model"
 	"github.com/derailed/k9s/internal/ui"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rs/zerolog/log"
+	"golang.design/x/clipboard"
 )
 
 // Table represents a table viewer.
@@ -211,9 +211,10 @@ func (t *Table) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	_, n := client.Namespaced(path)
 	log.Debug().Msgf("Copied selection to clipboard %q", n)
 	t.app.Flash().Info("Current selection copied to clipboard...")
-	if err := clipboard.WriteAll(n); err != nil {
+	if err := clipboard.Init(); err != nil {
 		t.app.Flash().Err(err)
 	}
+	clipboard.Write(clipboard.FmtText, []byte(n))
 
 	return nil
 }

--- a/internal/view/table.go
+++ b/internal/view/table.go
@@ -213,10 +213,11 @@ func (t *Table) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	log.Debug().Msgf("Copied selection to clipboard %q", n)
 	t.app.Flash().Info("Current selection copied to clipboard...")
 	if err := clipboard.Init(); err != nil {
-		t.app.Flash().Err(err)
-	}
-	if clipboard.Write(clipboard.FmtText, []byte(n)) == nil {
-		t.app.Flash().Err(errors.New("Failed to write to clipboard"))
+		panic(err)
+	} else {
+		if clipboard.Write(clipboard.FmtText, []byte(n)) == nil {
+			t.app.Flash().Err(errors.New("Failed to write to clipboard"))
+		}
 	}
 
 	return nil

--- a/internal/view/table.go
+++ b/internal/view/table.go
@@ -9,6 +9,7 @@ import (
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/model"
 	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/tview"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rs/zerolog/log"
 )
@@ -206,9 +207,11 @@ func (t *Table) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	if path == "" {
 		return evt
 	}
-
 	_, n := client.Namespaced(path)
-	return cpCmd(t.app.Flash(), n)(evt)
+	v := tview.NewTextView().SetText(n)
+	cpCmd(t.app.Flash(), v)(evt)
+
+	return nil
 }
 
 func (t *Table) markCmd(evt *tcell.EventKey) *tcell.EventKey {

--- a/internal/view/table.go
+++ b/internal/view/table.go
@@ -9,7 +9,6 @@ import (
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/model"
 	"github.com/derailed/k9s/internal/ui"
-	"github.com/derailed/tview"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rs/zerolog/log"
 )
@@ -208,8 +207,12 @@ func (t *Table) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 		return evt
 	}
 	_, n := client.Namespaced(path)
-	v := tview.NewTextView().SetText(n)
-	cpCmd(t.app.Flash(), v)(evt)
+	err := clipboardWrite(n)
+	if err != nil {
+		t.app.Flash().Err(err)
+	} else {
+		t.app.Flash().Info("Current selection copied to clipboard...")
+	}
 
 	return nil
 }

--- a/internal/view/table.go
+++ b/internal/view/table.go
@@ -2,7 +2,6 @@ package view
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"time"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/derailed/k9s/internal/ui"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rs/zerolog/log"
-	"golang.design/x/clipboard"
 )
 
 // Table represents a table viewer.
@@ -210,17 +208,7 @@ func (t *Table) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	}
 
 	_, n := client.Namespaced(path)
-	log.Debug().Msgf("Copied selection to clipboard %q", n)
-	t.app.Flash().Info("Current selection copied to clipboard...")
-	if err := clipboard.Init(); err != nil {
-		t.app.Flash().Err(err)
-	} else {
-		if clipboard.Write(clipboard.FmtText, []byte(n)) == nil {
-			t.app.Flash().Err(errors.New("Failed to write to clipboard"))
-		}
-	}
-
-	return nil
+	return cpCmd(t.app.Flash(), n)(evt)
 }
 
 func (t *Table) markCmd(evt *tcell.EventKey) *tcell.EventKey {

--- a/internal/view/table.go
+++ b/internal/view/table.go
@@ -213,7 +213,7 @@ func (t *Table) cpCmd(evt *tcell.EventKey) *tcell.EventKey {
 	log.Debug().Msgf("Copied selection to clipboard %q", n)
 	t.app.Flash().Info("Current selection copied to clipboard...")
 	if err := clipboard.Init(); err != nil {
-		panic(err)
+		t.app.Flash().Err(err)
 	} else {
 		if clipboard.Write(clipboard.FmtText, []byte(n)) == nil {
 			t.app.Flash().Err(errors.New("Failed to write to clipboard"))


### PR DESCRIPTION
Fixes #868

---

replaced into https://github.com/golang-design/clipboard (https://pkg.go.dev/golang.design/x/clipboard)

because atotto/clipboard is stale and is not working on WSL