### PR TITLE
Fix GracePeriodSeconds

### DIFF
--- a/internal/dao/generic.go
+++ b/internal/dao/generic.go
@@ -98,14 +98,13 @@ func (g *Generic) Delete(ctx context.Context, path string, propagation *metav1.D
 		return fmt.Errorf("user is not authorized to delete %s", path)
 	}
 
-	const defaultKillGrace = 1
-	var grace int64
-	if force {
-		grace = defaultKillGrace
-	}
 	opts := metav1.DeleteOptions{
-		PropagationPolicy:  propagation,
-		GracePeriodSeconds: &grace,
+		PropagationPolicy: propagation,
+	}
+
+	if force {
+		var defaultKillGrace int64 = 1
+		opts.GracePeriodSeconds = &defaultKillGrace
 	}
 
 	dial, err := g.dynClient()


### PR DESCRIPTION
`var x int64` means the value is 0 rather than the intended nil
(default).

`Delete` doesn't provide a way to configure the grace period anyway so
remove the variable and only override on a `force`

Fixes #1738 

Considering how painful this bug is I'd love to write a test for it but since `generic` doesn't already have any I'd need a pointer to a good example to start from.