### PR TITLE
List all helm releases

### DIFF
--- a/internal/dao/helm.go
+++ b/internal/dao/helm.go
@@ -31,7 +31,18 @@ func (h *Helm) List(ctx context.Context, ns string) ([]runtime.Object, error) {
 	if err != nil {
 		return nil, err
 	}
-	rr, err := action.NewList(cfg).Run()
+
+	// List all helm releases
+	client := action.NewList(cfg)
+	client.Uninstalled = true
+	client.Superseded = true
+	client.Uninstalling = true
+	client.Deployed = true
+	client.Failed = true
+	client.Pending = true
+	client.SetStateMask()
+
+	rr, err := client.Run()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The `:helm` view does not list all helm releases such as `pending-*` and `uninstalling`.
This PR shows all release states. It would be nice if this is configurable in the future, but all releases is a better default than the current limited view.

Fixes https://github.com/derailed/k9s/issues/1146