### PR TITLE
[bugfix] Log toggles: add a space after "On" in logs view

### DIFF
--- a/internal/view/log_indicator.go
+++ b/internal/view/log_indicator.go
@@ -113,32 +113,32 @@ func (l *LogIndicator) Refresh() {
 
 	if l.shouldDisplayAllContainers {
 		if l.allContainers {
-			l.indicator = append(l.indicator, "[::b]AllContainers:[limegreen::b]On[-::]"+spacer...)
+			l.indicator = append(l.indicator, "[::b]AllContainers:[limegreen::b]On[-::] "+spacer...)
 		} else {
 			l.indicator = append(l.indicator, "[::b]AllContainers:[gray::d]Off[-::]"+spacer...)
 		}
 	}
 
 	if l.AutoScroll() {
-		l.indicator = append(l.indicator, "[::b]Autoscroll:[limegreen::b]On[-::]"+spacer...)
+		l.indicator = append(l.indicator, "[::b]Autoscroll:[limegreen::b]On[-::] "+spacer...)
 	} else {
 		l.indicator = append(l.indicator, "[::b]Autoscroll:[gray::d]Off[-::]"+spacer...)
 	}
 
 	if l.FullScreen() {
-		l.indicator = append(l.indicator, "[::b]FullScreen:[limegreen::b]On[-::]"+spacer...)
+		l.indicator = append(l.indicator, "[::b]FullScreen:[limegreen::b]On[-::] "+spacer...)
 	} else {
 		l.indicator = append(l.indicator, "[::b]FullScreen:[gray::d]Off[-::]"+spacer...)
 	}
 
 	if l.Timestamp() {
-		l.indicator = append(l.indicator, "[::b]Timestamps:[limegreen::b]On[-::]"+spacer...)
+		l.indicator = append(l.indicator, "[::b]Timestamps:[limegreen::b]On[-::] "+spacer...)
 	} else {
 		l.indicator = append(l.indicator, "[::b]Timestamps:[gray::d]Off[-::]"+spacer...)
 	}
 
 	if l.TextWrap() {
-		l.indicator = append(l.indicator, "[::b]Wrap:[limegreen::b]On[-::]"...)
+		l.indicator = append(l.indicator, "[::b]Wrap:[limegreen::b]On[-::] "...)
 	} else {
 		l.indicator = append(l.indicator, "[::b]Wrap:[gray::d]Off[-::]"...)
 	}

--- a/internal/view/log_indicator_test.go
+++ b/internal/view/log_indicator_test.go
@@ -15,10 +15,10 @@ func TestLogIndicatorRefresh(t *testing.T) {
 		e  string
 	}{
 		"all-containers": {
-			view.NewLogIndicator(config.NewConfig(nil), defaults, true), "[::b]AllContainers:[gray::d]Off[-::]     [::b]Autoscroll:[limegreen::b]On[-::]     [::b]FullScreen:[gray::d]Off[-::]     [::b]Timestamps:[gray::d]Off[-::]     [::b]Wrap:[gray::d]Off[-::]\n",
+			view.NewLogIndicator(config.NewConfig(nil), defaults, true), "[::b]AllContainers:[gray::d]Off[-::]     [::b]Autoscroll:[limegreen::b]On[-::]      [::b]FullScreen:[gray::d]Off[-::]     [::b]Timestamps:[gray::d]Off[-::]     [::b]Wrap:[gray::d]Off[-::]\n",
 		},
 		"plain": {
-			view.NewLogIndicator(config.NewConfig(nil), defaults, false), "[::b]Autoscroll:[limegreen::b]On[-::]     [::b]FullScreen:[gray::d]Off[-::]     [::b]Timestamps:[gray::d]Off[-::]     [::b]Wrap:[gray::d]Off[-::]\n",
+			view.NewLogIndicator(config.NewConfig(nil), defaults, false), "[::b]Autoscroll:[limegreen::b]On[-::]      [::b]FullScreen:[gray::d]Off[-::]     [::b]Timestamps:[gray::d]Off[-::]     [::b]Wrap:[gray::d]Off[-::]\n",
 		},
 	}
 


### PR DESCRIPTION
Toggling any of the log commands on and off causes the log indicator to dance around - I assume this is because the line is centered, and when on it is N characters long, when off N+1 characters, and so on centering, the x-offset gets rounded.

This commit just adds an extra space after each "On" string so that it occupies the same width as the "Off" string ... and the when furiously toggling, the line remains blissfully static.