### PR TITLE
[bugfix] Add a closing tag when showing timestamp in log view

### DIFF
--- a/internal/dao/log_item.go
+++ b/internal/dao/log_item.go
@@ -73,6 +73,7 @@ func (l *LogItem) Render(paint string, showTime bool, bb *bytes.Buffer) {
 		for i := len(l.Bytes[:index]); i < 30; i++ {
 			bb.WriteByte(' ')
 		}
+		bb.WriteString("[-::]")
 	}
 
 	if l.Pod != "" {

--- a/internal/dao/log_item_test.go
+++ b/internal/dao/log_item_test.go
@@ -63,7 +63,7 @@ func TestLogItemRender(t *testing.T) {
 				ShowTimestamp:   true,
 			},
 			log: fmt.Sprintf("%s %s\n", "2018-12-14T10:36:43.326972-07:00", "Testing 1,2,3..."),
-			e:   "[gray::b]2018-12-14T10:36:43.326972-07:00 [yellow::]fred [yellow::b]blee[-::-] Testing 1,2,3...\n",
+			e:   "[gray::b]2018-12-14T10:36:43.326972-07:00 [-::][yellow::]fred [yellow::b]blee[-::-] Testing 1,2,3...\n",
 		},
 		"log-level": {
 			opts: dao.LogOptions{

--- a/internal/dao/log_items_test.go
+++ b/internal/dao/log_items_test.go
@@ -108,7 +108,7 @@ func TestLogItemsRender(t *testing.T) {
 				Container:     "blee",
 				ShowTimestamp: true,
 			},
-			e: "[gray::b]2018-12-14T10:36:43.326972-07:00 [teal::]fred [teal::b]blee[-::-] Testing 1,2,3...\n",
+			e: "[gray::b]2018-12-14T10:36:43.326972-07:00 [-::][teal::]fred [teal::b]blee[-::-] Testing 1,2,3...\n",
 		},
 	}
 


### PR DESCRIPTION
This is how it looks in the current published exe when viewing a log with timestamps toggled on:
<img width="682" alt="Screenshot 2022-09-23 at 23 45 37" src="https://user-images.githubusercontent.com/1915543/192066889-cda92655-fb71-4141-a820-56647cf17dc9.png">

This is how it looks with this patch
<img width="693" alt="Screenshot 2022-09-23 at 23 49 46" src="https://user-images.githubusercontent.com/1915543/192066914-07f13573-aa9b-48ae-8fed-03b7357ac8a1.png">
