### PR TITLE
Fix directory path when viewing ScreenDump

### DIFF
--- a/internal/dao/screen_dump.go
+++ b/internal/dao/screen_dump.go
@@ -37,7 +37,7 @@ func (d *ScreenDump) List(ctx context.Context, _ string) ([]runtime.Object, erro
 		return nil, errors.New("no screendump dir found in context")
 	}
 
-	ff, err := os.ReadDir(SanitizeFilename(dir))
+	ff, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -395,7 +395,7 @@ func (l *Log) filterCmd(evt *tcell.EventKey) *tcell.EventKey {
 
 // SaveCmd dumps the logs to file.
 func (l *Log) SaveCmd(*tcell.EventKey) *tcell.EventKey {
-	path, err := saveData(l.app.Config.K9s.GetScreenDumpDir(), l.app.Config.K9s.CurrentContext, l.model.GetPath(), l.logs.GetText(true))
+	path, err := saveData(l.app.Config.K9s.GetScreenDumpDir(), l.app.Config.K9s.CurrentCluster, l.model.GetPath(), l.logs.GetText(true))
 	if err != nil {
 		l.app.Flash().Err(err)
 		return nil

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -395,7 +395,7 @@ func (l *Log) filterCmd(evt *tcell.EventKey) *tcell.EventKey {
 
 // SaveCmd dumps the logs to file.
 func (l *Log) SaveCmd(*tcell.EventKey) *tcell.EventKey {
-	path, err := saveData(l.app.Config.K9s.GetScreenDumpDir(), l.app.Config.K9s.CurrentCluster, l.model.GetPath(), l.logs.GetText(true))
+	path, err := saveData(l.app.Config.K9s.GetScreenDumpDir(), l.app.Config.K9s.CurrentContext, l.model.GetPath(), l.logs.GetText(true))
 	if err != nil {
 		l.app.Flash().Err(err)
 		return nil

--- a/internal/view/screen_dump.go
+++ b/internal/view/screen_dump.go
@@ -8,6 +8,7 @@ import (
 	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/dao"
 	"github.com/derailed/k9s/internal/ui"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rs/zerolog/log"
@@ -34,7 +35,7 @@ func NewScreenDump(gvr client.GVR) ResourceViewer {
 }
 
 func (s *ScreenDump) dirContext(ctx context.Context) context.Context {
-	dir := filepath.Join(s.App().Config.K9s.GetScreenDumpDir(), s.App().Config.K9s.CurrentCluster)
+	dir := filepath.Join(s.App().Config.K9s.GetScreenDumpDir(), dao.SanitizeFilename(s.App().Config.K9s.CurrentCluster))
 	log.Debug().Msgf("SD-DIR %q", dir)
 	config.EnsureFullPath(dir, config.DefaultDirMod)
 

--- a/internal/view/screen_dump.go
+++ b/internal/view/screen_dump.go
@@ -35,7 +35,7 @@ func NewScreenDump(gvr client.GVR) ResourceViewer {
 }
 
 func (s *ScreenDump) dirContext(ctx context.Context) context.Context {
-	dir := filepath.Join(s.App().Config.K9s.GetScreenDumpDir(), dao.SanitizeFilename(s.App().Config.K9s.CurrentCluster))
+	dir := filepath.Join(s.App().Config.K9s.GetScreenDumpDir(), dao.SanitizeFilename(s.App().Config.K9s.CurrentContext))
 	log.Debug().Msgf("SD-DIR %q", dir)
 	config.EnsureFullPath(dir, config.DefaultDirMod)
 

--- a/internal/view/table.go
+++ b/internal/view/table.go
@@ -167,7 +167,7 @@ func (t *Table) BufferActive(state bool, k model.BufferKind) {
 }
 
 func (t *Table) saveCmd(evt *tcell.EventKey) *tcell.EventKey {
-	if path, err := saveTable(t.app.Config.K9s.GetScreenDumpDir(), t.app.Config.K9s.CurrentCluster, t.GVR().R(), t.Path, t.GetFilteredData()); err != nil {
+	if path, err := saveTable(t.app.Config.K9s.GetScreenDumpDir(), t.app.Config.K9s.CurrentContext, t.GVR().R(), t.Path, t.GetFilteredData()); err != nil {
 		t.app.Flash().Err(err)
 	} else {
 		t.app.Flash().Infof("File %s saved successfully!", path)


### PR DESCRIPTION
When having semicolons (`:`) in the k8s context name, k9s saves logs of containers (aka screen dumps) to a directory name that is "sanitized": semicolons replaced by dashes.

```bash
❯ tree
.
├── arn-aws-eks-eu-west-1-XXXXXXXXXXXX-cluster
│   └── dev-core-eks
│       └── gloo-system-gloo-657d5bc648-26fwl-1664095997450849000.log
└── arn:aws:eks:eu-west-1:XXXXXXXXXXXX:cluster
    └── dev-core-eks
```

When requesting the screen dumps it shows the correct log file that was saved earlier but the directory shown in the table is wrong since the semicolons are still there.

```bash
┌─────────────────────────────────────────────────────────────────────────────────────────────────── Screendumps(all)[1] ────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ NAME                                                           DIR                                                                                                                                 AGE↑                    │
│ gloo-system-gloo-657d5bc648-26fwl-1664095997450849000.log      /var/folders/96/5c_jdmv17b30j5h7ggxxknfh0000gp/T/k9s-screens-z0058456/arn:aws:eks:eu-west-1:XXXXXXXXXXXX:cluster/dev-core-eks       1h1m23.95494706s        │
│                                                                                                                                                                                                                            │
```

If you then try to open the log file by pressing Enter, it opens a non-existing file because it uses the wrong directory name.

Another issue is that the logs saving is using `CurrentContext` as directory path inside the SD dir.
If the context name and the cluster name are the same, there is no problem. But if they are not the same then the logs are not showing in the screendumps view as that view is using `CurrentCluster` to check for existing screendumps.

This PR fixes the above issues by also sanitizing the SD dir by using the same sanitizing method as the logs saving + using `CurrentContext` for tables saving + viewing screendumps with `CurrentContext`.