### PR TITLE
Enable using kubectl from the current directory to k9s

### DIFF
--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -41,6 +41,9 @@ type shellOpts struct {
 
 func runK(a *App, opts shellOpts) bool {
 	bin, err := exec.LookPath("kubectl")
+	if errors.Is(err, exec.ErrDot) {
+		err = nil
+	}
 	if err != nil {
 		log.Error().Err(err).Msgf("kubectl command is not in your path")
 		return false
@@ -137,6 +140,9 @@ func execute(opts shellOpts) error {
 
 func runKu(a *App, opts shellOpts) (string, error) {
 	bin, err := exec.LookPath("kubectl")
+	if errors.Is(err, exec.ErrDot) {
+		err = nil
+	}
 	if err != nil {
 		log.Error().Err(err).Msgf("kubectl command is not in your path")
 		return "", err


### PR DESCRIPTION
Enables using kubectl from the current directory to k9s.

```go
// # Executables in the current directory
//
// The functions Command and LookPath look for a program
// in the directories listed in the current path, following the
// conventions of the host operating system.
// Operating systems have for decades included the current
// directory in this search, sometimes implicitly and sometimes
// configured explicitly that way by default.
// Modern practice is that including the current directory
// is usually unexpected and often leads to security problems.
//
// To avoid those security problems, as of Go 1.19, this package will not resolve a program
// using an implicit or explicit path entry relative to the current directory.
// That is, if you run exec.LookPath("go"), it will not successfully return
// ./go on Unix nor .\go.exe on Windows, no matter how the path is configured.
// Instead, if the usual path algorithms would result in that answer,
// these functions return an error err satisfying errors.Is(err, ErrDot).
//
// For example, consider these two program snippets:
//
//	path, err := exec.LookPath("prog")
//	if err != nil {
//		log.Fatal(err)
//	}
//	use(path)
//
// and
//
//	cmd := exec.Command("prog")
//	if err := cmd.Run(); err != nil {
//		log.Fatal(err)
//	}
//
// These will not find and run ./prog or .\prog.exe,
// no matter how the current path is configured.
//
// Code that always wants to run a program from the current directory
// can be rewritten to say "./prog" instead of "prog".
//
// Code that insists on including results from relative path entries
// can instead override the error using an errors.Is check:
//
//	path, err := exec.LookPath("prog")
//	if errors.Is(err, exec.ErrDot) {
//		err = nil
//	}
//	if err != nil {
//		log.Fatal(err)
//	}
//	use(path)
//
// and
//
//	cmd := exec.Command("prog")
//	if errors.Is(cmd.Err, exec.ErrDot) {
//		cmd.Err = nil
//	}
//	if err := cmd.Run(); err != nil {
//		log.Fatal(err)
//	}
//
// Setting the environment variable GODEBUG=execerrdot=0
// disables generation of ErrDot entirely, temporarily restoring the pre-Go 1.19
// behavior for programs that are unable to apply more targeted fixes.
// A future version of Go may remove support for this variable.
//
// Before adding such overrides, make sure you understand the
// security implications of doing so.
// See https://go.dev/blog/path-security for more information.
```

https://go.dev/src/os/exec/exec.go

I have searched the whole source code to ensure that these two are the only areas where kubectl is explicitly called.