### PR TITLE
Use default terminal colors for better readability (#1290)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,7 @@ func run(cmd *cobra.Command, args []string) {
 			log.Error().Msg(string(debug.Stack()))
 			printLogo(color.Red)
 			fmt.Printf("%s", color.Colorize("Boom!! ", color.Red))
-			fmt.Println(color.Colorize(fmt.Sprintf("%v.", err), color.LightGray))
+			fmt.Printf("%v.\n", err)
 		}
 	}()
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -41,7 +41,7 @@ func printVersion(short bool) {
 
 func printTuple(fmat, section, value string, outputColor color.Paint) {
 	if outputColor != -1 {
-		fmt.Fprintf(out, fmat, color.Colorize(section+":", outputColor), color.Colorize(value, color.LightGray))
+		fmt.Fprintf(out, fmat, color.Colorize(section+":", outputColor), value)
 		return
 	}
 	fmt.Fprintf(out, fmat, section, value)

--- a/skins/transparent.yml
+++ b/skins/transparent.yml
@@ -4,19 +4,27 @@ k9s:
     bgColor: default
   promt:
     bgColor: default
+  info:
+    sectionColor: default
   dialog:
     bgColor: default
+    labelFgColor: default
+    fieldFgColor: default
   frame:
     crumbs:
       bgColor: default
     title:
       bgColor: default
+      counterColor: default
+    menu:
+      fgColor: default
   views:
     charts:
       bgColor: default
     table:
       bgColor: default
       header:
+        fgColor: default
         bgColor: default
     xray:
       bgColor: default
@@ -24,3 +32,6 @@ k9s:
       bgColor: default
       indicator:
         bgColor: default
+    yaml:
+      colonColor: default
+      valueColor: default


### PR DESCRIPTION
Hey :wave: 

Opening PR to address https://github.com/derailed/k9s/issues/1290

- Referencing the default k9s colors in [`styles.go`](https://github.com/derailed/k9s/blob/ca294732384a6d82d8eeb6ad1d99b69875f8ca1c/internal/config/styles.go#L266-L442), updated the `transparent.yml` skin to use the default terminal color if the k9s color, such as when `papayawhip` and `white`, would clash against a light terminal. Text in the info section and the table headers are readable in a light terminal:
![image](https://user-images.githubusercontent.com/15043193/199262302-eced3ea6-cbc3-4a79-adbc-4812f46831da.png)

- Updated `cmd` to not colorize the output by default with `color.LightGray` - instead using the default terminal text color. 
With `GNOME light` theme:
![image](https://user-images.githubusercontent.com/15043193/199261779-5a41392c-47be-4583-bbea-aa86a63b3bc3.png)
With `GNOME dark` theme:
![image](https://user-images.githubusercontent.com/15043193/199262803-08dbef60-4df3-4619-9e87-f9d601e31864.png)
  
Let me know of other related terminal readability items that could be good to look into for this.  

Cheers -