### PR TITLE
Add policy view to serviceAccounts

### DIFF
--- a/internal/dao/rbac_policy.go
+++ b/internal/dao/rbac_policy.go
@@ -61,10 +61,12 @@ func (p *Policy) loadClusterRoleBinding(kind, name string) (render.Policies, err
 		return nil, err
 	}
 
+	ns, n := client.Namespaced(name)
 	var nn []string
 	for _, crb := range crbs {
 		for _, s := range crb.Subjects {
-			if s.Kind == kind && s.Name == name {
+			s := s
+			if isSameSubject(kind, ns, n, &s) {
 				nn = append(nn, crb.RoleRef.Name)
 			}
 		}
@@ -159,16 +161,33 @@ func (p *Policy) fetchRoleBindingSubjects(kind, name string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	ns, n := client.Namespaced(name)
 	ss := make([]string, 0, len(rbs))
 	for _, rb := range rbs {
 		for _, s := range rb.Subjects {
-			if s.Kind == kind && s.Name == name {
-				ss = append(ss, rb.RoleRef.Kind+":"+rb.Name)
+			s := s
+			if isSameSubject(kind, ns, n, &s) {
+				ss = append(ss, rb.RoleRef.Kind+":"+rb.RoleRef.Name)
 			}
 		}
 	}
 
 	return ss, nil
+}
+
+// isSameSubject verifies if the incoming type name and namespace match a subject from a
+// cluster/roleBinding. A ServiceAccount will always have a namespace and needs to be validated to ensure
+// we don't display permissions for a ServiceAccount with the same name in a different namespace
+func isSameSubject(kind, namespace, name string, subject *rbacv1.Subject) bool {
+	if subject.Kind != kind || subject.Name != name {
+		return false
+	}
+	if kind == rbacv1.ServiceAccountKind {
+		// Kind and name were checked above, check the namespace
+		return subject.Namespace == namespace
+	}
+	return true
 }
 
 func (p *Policy) fetchClusterRoles() ([]rbacv1.ClusterRole, error) {

--- a/internal/dao/rbac_policy_test.go
+++ b/internal/dao/rbac_policy_test.go
@@ -1,0 +1,76 @@
+package dao
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestIsSameSubject(t *testing.T) {
+	uu := map[string]struct {
+		kind      string
+		namespace string
+		name      string
+		subject   rbacv1.Subject
+		want      bool
+	}{
+		"kind-name-match": {
+			kind: rbacv1.UserKind,
+			name: "foo",
+			subject: rbacv1.Subject{
+				Kind: rbacv1.UserKind,
+				Name: "foo",
+			},
+			want: true,
+		},
+		"name-does-not-match": {
+			kind: rbacv1.UserKind,
+			name: "foo",
+			subject: rbacv1.Subject{
+				Kind: rbacv1.UserKind,
+				Name: "bar",
+			},
+			want: false,
+		},
+		"kind-does-not-match": {
+			kind: rbacv1.GroupKind,
+			name: "foo",
+			subject: rbacv1.Subject{
+				Kind: rbacv1.UserKind,
+				Name: "foo",
+			},
+			want: false,
+		},
+		"serviceAccount-all-match": {
+			kind:      rbacv1.ServiceAccountKind,
+			name:      "foo",
+			namespace: "bar",
+			subject: rbacv1.Subject{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			want: true,
+		},
+		"serviceAccount-namespace-no-match": {
+			kind:      rbacv1.ServiceAccountKind,
+			name:      "foo",
+			namespace: "bar",
+			subject: rbacv1.Subject{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "foo",
+				Namespace: "bazz",
+			},
+			want: false,
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			same := isSameSubject(u.kind, u.namespace, u.name, &u.subject)
+			assert.Equal(t, u.want, same)
+		})
+	}
+}


### PR DESCRIPTION
Add the same policy view to ServiceAccounts as users/groups. This also works under the xray view. 
This commit also fixes the issue with role/rolebindings not having the same name not showing up in Policy view.

fixes https://github.com/derailed/k9s/issues/1838
closes https://github.com/derailed/k9s/issues/1839

The screenshot below shows the fix for the role/rolebinding naming issue:
![Screen Shot 2022-11-01 at 5 24 52 PM](https://user-images.githubusercontent.com/13897607/199360653-f3f9b04d-8766-46f6-a9b7-0d9e09814ad7.png)

Example SA with a policy view:
![Screen Shot 2022-11-01 at 5 25 51 PM](https://user-images.githubusercontent.com/13897607/199360748-260dbe6b-7be5-409f-9752-784a4d2604f7.png)

