### PR TITLE
Add labels configuration to Shell node pod

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -314,6 +314,7 @@ var expectedConfig = `k9s:
         limits:
           cpu: 100m
           memory: 100Mi
+        labels: {}
       portForwardAddress: localhost
     fred:
       namespace:
@@ -337,6 +338,7 @@ var expectedConfig = `k9s:
         limits:
           cpu: 100m
           memory: 100Mi
+        labels: {}
       portForwardAddress: localhost
     minikube:
       namespace:
@@ -360,6 +362,7 @@ var expectedConfig = `k9s:
         limits:
           cpu: 100m
           memory: 100Mi
+        labels: {}
       portForwardAddress: localhost
   thresholds:
     cpu:
@@ -409,6 +412,7 @@ var resetConfig = `k9s:
         limits:
           cpu: 100m
           memory: 100Mi
+        labels: {}
       portForwardAddress: localhost
   thresholds:
     cpu:

--- a/internal/config/shell_pod.go
+++ b/internal/config/shell_pod.go
@@ -12,11 +12,12 @@ type Limits map[v1.ResourceName]string
 
 // ShellPod represents k9s shell configuration.
 type ShellPod struct {
-	Image     string   `json:"image"`
-	Command   []string `json:"command,omitempty"`
-	Args      []string `json:"args,omitempty"`
-	Namespace string   `json:"namespace"`
-	Limits    Limits   `json:"resources,omitempty"`
+	Image     string            `json:"image"`
+	Command   []string          `json:"command,omitempty"`
+	Args      []string          `json:"args,omitempty"`
+	Namespace string            `json:"namespace"`
+	Limits    Limits            `json:"resources,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
 }
 
 // NewShellPod returns a new instance.

--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -331,6 +331,7 @@ func k9sShellPod(node string, cfg *config.ShellPod) v1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k9sShellPodName(),
 			Namespace: cfg.Namespace,
+			Labels:    cfg.Labels,
 		},
 		Spec: v1.PodSpec{
 			NodeName:                      node,


### PR DESCRIPTION
Hello!

Some environments often enforce labeling policies that doesn't allow to run workloads without certain mandatory labels.
This PR adds the ability to configure the Shell node Pod metadata labels from the configuration like this:

```yaml
# $XDG_CONFIG_HOME/k9s/config.yml
k9s:
  clusters:
    # Configures node shell on cluster blee
    blee:
      featureGates:
        # You must enable the nodeShell feature gate to enable shelling into nodes
        nodeShell: true
      # You can also further tune the shell pod specification
      shellPod:
        image: cool_kid_admin:42
        namespace: blee
        limits:
          cpu: 100m
          memory: 100Mi
        labels:
          app.kubernetes.io/instance: k9s-node-shell
          app.kubernetes.io/managed-by: Ruben
          app.kubernetes.io/name: k9s-node-shell
```
closes: #1856