### PR TITLE
Set build date on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@ OUTPUT_BIN ?= execs/${NAME}
 PACKAGE    := github.com/derailed/$(NAME)
 GIT_REV    ?= $(shell git rev-parse --short HEAD)
 SOURCE_DATE_EPOCH ?= $(shell date +%s)
+ifeq ($(shell uname), Darwin)
+DATE       ?= $(shell TZ=UTC date -j -f "%s" ${SOURCE_DATE_EPOCH} +"%Y-%m-%dT%H:%M:%SZ")
+else
 DATE       ?= $(shell date -u -d @${SOURCE_DATE_EPOCH} +"%Y-%m-%dT%H:%M:%SZ")
+endif
 VERSION    ?= v0.26.7
 IMG_NAME   := derailed/k9s
 IMAGE      := ${IMG_NAME}:${VERSION}


### PR DESCRIPTION
If I run the `make build` on master I get no build date:

``` 
❯ git rev-parse HEAD            
534c2791ca16ced6feb448b9b917849fbe2ea30e

❯ make build
date: illegal option -- d
usage: date [-jnRu] [-r seconds|file] [-v[+|-]val[ymwdHMS]]
            [-I[date | hours | minutes | seconds]]
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]

❯ ./execs/k9s version
 ____  __.________       
|    |/ _/   __   \______
|      < \____    /  ___/
|    |  \   /    /\___ \ 
|____|__ \ /____//____  >
        \/            \/ 

Version:    v0.26.7
Commit:     534c2791
Date:       
```

The `date` on macos doesn't support `-d` but you can get the same output with `-j`.

This adds a conditional to the makefile to set DATE differently when `uname` reports `"Darwin"`.

This change provides a date as expected:

```
❯ git rev-parse HEAD
9ad2899431da8f4da38203d2924db69c73d6e9eb

❯ make build

❯ ./execs/k9s version
 ____  __.________       
|    |/ _/   __   \______
|      < \____    /  ___/
|    |  \   /    /\___ \ 
|____|__ \ /____//____  >
        \/            \/ 

Version:    v0.26.7
Commit:     9ad28994
Date:       2022-11-09T01:54:52Z
```