### PR TITLE
Container debug command

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,8 @@ K9s uses aliases to navigate most K8s resources.
           active: dp
     # The path to screen dump. Default: '%temp_dir%/k9s-screens-%username%' (k9s info)
     screenDumpDir: /tmp
+    # The image to use when launching the container debug action
+    debugImage: busybox:1.35.0
   ```
 
 ---

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -369,6 +369,7 @@ var expectedConfig = `k9s:
       critical: 90
       warn: 70
   screenDumpDir: /tmp
+  debugImage: busybox:1.35.0
 `
 
 var resetConfig = `k9s:
@@ -418,4 +419,5 @@ var resetConfig = `k9s:
       critical: 90
       warn: 70
   screenDumpDir: /tmp
+  debugImage: busybox:1.35.0
 `

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -7,6 +7,7 @@ import (
 const (
 	defaultRefreshRate  = 2
 	defaultMaxConnRetry = 5
+	defaultDebugImage   = "busybox:1.35.0"
 )
 
 // K9s tracks K9s configuration options.
@@ -41,6 +42,7 @@ func NewK9s() *K9s {
 	return &K9s{
 		RefreshRate:   defaultRefreshRate,
 		MaxConnRetry:  defaultMaxConnRetry,
+		DebugImage:    defaultDebugImage,
 		Logger:        NewLogger(),
 		Clusters:      make(map[string]*Cluster),
 		Thresholds:    NewThreshold(),

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -26,6 +26,7 @@ type K9s struct {
 	Clusters            map[string]*Cluster `yaml:"clusters,omitempty"`
 	Thresholds          Threshold           `yaml:"thresholds"`
 	ScreenDumpDir       string              `yaml:"screenDumpDir"`
+	DebugImage          string              `yaml:"debugImage"`
 	manualRefreshRate   int
 	manualHeadless      *bool
 	manualLogoless      *bool

--- a/internal/config/testdata/k9s.yml
+++ b/internal/config/testdata/k9s.yml
@@ -30,3 +30,4 @@ k9s:
       view:
         active: po
   screenDumpDir: /tmp
+  debugImage: busybox:1.35.0

--- a/internal/view/container.go
+++ b/internal/view/container.go
@@ -55,8 +55,9 @@ func (c *Container) Name() string { return containerTitle }
 
 func (c *Container) bindDangerousKeys(aa ui.KeyActions) {
 	aa.Add(ui.KeyActions{
-		ui.KeyS: ui.NewKeyAction("Shell", c.shellCmd, true),
-		ui.KeyA: ui.NewKeyAction("Attach", c.attachCmd, true),
+		ui.KeyS:      ui.NewKeyAction("Shell", c.shellCmd, true),
+		ui.KeyA:      ui.NewKeyAction("Attach", c.attachCmd, true),
+		ui.KeyShiftD: ui.NewKeyAction("Debug", c.debugCmd, true),
 	})
 }
 
@@ -146,6 +147,19 @@ func (c *Container) shellCmd(evt *tcell.EventKey) *tcell.EventKey {
 	c.Stop()
 	defer c.Start()
 	shellIn(c.App(), c.GetTable().Path, path)
+
+	return nil
+}
+
+func (c *Container) debugCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := c.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	c.Stop()
+	defer c.Start()
+	debugIn(c.App(), c.GetTable().Path, path)
 
 	return nil
 }

--- a/internal/view/container_test.go
+++ b/internal/view/container_test.go
@@ -13,5 +13,5 @@ func TestContainerNew(t *testing.T) {
 
 	assert.Nil(t, c.Init(makeCtx()))
 	assert.Equal(t, "Containers", c.Name())
-	assert.Equal(t, 18, len(c.Hints()))
+	assert.Equal(t, 19, len(c.Hints()))
 }

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -303,12 +303,9 @@ func debugIn(a *App, fqn, co string) {
 	}
 
 	image := defaultDebugImage
-	log.Info().Str("default", image).Msg("Defaulted image")
 	if a.Config.K9s.DebugImage != "" {
-		log.Info().Str("configured", a.Config.K9s.DebugImage).Msg("Resolving configured image")
 		image = a.Config.K9s.DebugImage
 	}
-	log.Info().Str("image", image).Msg("Resolved image")
 	args := computeDebugArgs(fqn, co, a.Conn().Config().Flags().KubeConfig, os, image)
 
 	c := color.New(color.BgGreen).Add(color.FgBlack).Add(color.Bold)

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -21,11 +21,10 @@ import (
 )
 
 const (
-	windowsOS         = "windows"
-	powerShell        = "powershell"
-	osBetaSelector    = "beta.kubernetes.io/os"
-	osSelector        = "kubernetes.io/os"
-	defaultDebugImage = "busybox:1.35.0"
+	windowsOS      = "windows"
+	powerShell     = "powershell"
+	osBetaSelector = "beta.kubernetes.io/os"
+	osSelector     = "kubernetes.io/os"
 )
 
 // Pod represents a pod viewer.

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -370,7 +370,7 @@ func computeDebugArgs(path, co string, kcfg *string, os string, image string) []
 	}
 
 	args = append(args, "--target", co)
-	args = append(args, fmt.Sprintf("--image=%s", image))
+	args = append(args, "--image", image)
 
 	return args
 }

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -363,7 +363,6 @@ func computeDebugArgs(path, co string, kcfg *string, os string) []string {
 		args = append(args, "--kubeconfig", *kcfg)
 	}
 
-	args = append(args, po)
 	args = append(args, "--target", co)
 	args = append(args, "--image=alpine")
 

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -296,12 +296,7 @@ func shellIn(a *App, fqn, co string) {
 }
 
 func debugIn(a *App, fqn, co string) {
-	os, err := getPodOS(a.factory, fqn)
-	if err != nil {
-		log.Warn().Err(err).Msgf("os detect failed")
-	}
-
-	args := computeDebugArgs(fqn, co, a.Conn().Config().Flags().KubeConfig, os, a.Config.K9s.DebugImage)
+	args := computeDebugArgs(fqn, co, a.Conn().Config().Flags().KubeConfig, a.Config.K9s.DebugImage)
 
 	c := color.New(color.BgGreen).Add(color.FgBlack).Add(color.Bold)
 	if !runK(a, shellOpts{clear: true, banner: c.Sprintf(bannerFmt, fqn, co), args: args}) {
@@ -351,7 +346,7 @@ func attachIn(a *App, path, co string) {
 	}
 }
 
-func computeDebugArgs(path, co string, kcfg *string, os string, image string) []string {
+func computeDebugArgs(path, co string, kcfg *string, image string) []string {
 	args := make([]string, 0, 15)
 	args = append(args, "debug", "-it")
 

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -302,11 +302,7 @@ func debugIn(a *App, fqn, co string) {
 		log.Warn().Err(err).Msgf("os detect failed")
 	}
 
-	image := defaultDebugImage
-	if a.Config.K9s.DebugImage != "" {
-		image = a.Config.K9s.DebugImage
-	}
-	args := computeDebugArgs(fqn, co, a.Conn().Config().Flags().KubeConfig, os, image)
+	args := computeDebugArgs(fqn, co, a.Conn().Config().Flags().KubeConfig, os, a.Config.K9s.DebugImage)
 
 	c := color.New(color.BgGreen).Add(color.FgBlack).Add(color.Bold)
 	if !runK(a, shellOpts{clear: true, banner: c.Sprintf(bannerFmt, fqn, co), args: args}) {


### PR DESCRIPTION
Fixes https://github.com/derailed/k9s/issues/1692

Hit shift+d on the container screen to attach an image. You can override the used image by setting `debugImage` in your config.

Demo: [![asciicast](https://asciinema.org/a/IV26UrpI1Ti36a1Ocy42ioMOc.svg)](https://asciinema.org/a/IV26UrpI1Ti36a1Ocy42ioMOc)

