### PR TITLE
Add VIM-like quit force option.

### DIFF
--- a/internal/config/alias.go
+++ b/internal/config/alias.go
@@ -143,7 +143,7 @@ func (a *Aliases) loadDefaultAliases() {
 	a.Alias["np"] = "networking.k8s.io/v1/networkpolicies"
 
 	a.declare("help", "h", "?")
-	a.declare("quit", "q", "Q")
+	a.declare("quit", "q", "q!", "Q")
 	a.declare("aliases", "alias", "a")
 	a.declare("popeye", "pop")
 	a.declare("helm", "charts", "chart", "hm")

--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -178,7 +178,7 @@ func (c *Command) specialCmd(cmd, path string) bool {
 	case "cow":
 		c.app.cowCmd(path)
 		return true
-	case "q", "Q", "quit":
+	case "q", "q!", "Q", "quit":
 		c.app.BailOut()
 		return true
 	case "?", "h", "help":


### PR DESCRIPTION
I you are a VIM user like me, you are so used to writing q! when you exit VIM, that you do the same when exiting k9s, only to get a cowsay error. This PR should fix that, and make k9s even more lovable for VIM users.

Signed-off-by: Audun Nes <audun.nes@gmail.com>