### PR TITLE
Fix order of arguments for `CanI` function call

### DIFF
--- a/internal/dao/cronjob.go
+++ b/internal/dao/cronjob.go
@@ -112,7 +112,7 @@ func (c *CronJob) ScanSA(ctx context.Context, fqn string, wait bool) (Refs, erro
 // ToggleSuspend toggles suspend/resume on a CronJob.
 func (c *CronJob) ToggleSuspend(ctx context.Context, path string) error {
 	ns, n := client.Namespaced(path)
-	auth, err := c.Client().CanI(c.GVR(), ns, []string{client.GetVerb, client.UpdateVerb})
+	auth, err := c.Client().CanI(ns, c.GVR(), []string{client.GetVerb, client.UpdateVerb})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When checking permissions to (un)suspend cronjobs, a user will always be considered as unauthorized, because of the wrong arguments order when calling the `CanI` function.

For `CanI` definition, see:
https://github.com/derailed/k9s/blob/2f72441bac30337fc2211e5ce5d93d3e475c9657/internal/client/client.go#L138