### PR TITLE
feat: add noLatestRevCheck config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ K9s uses aliases to navigate most K8s resources.
     noExitOnCtrlC: false
     # Toggles icons display as not all terminal support these chars.
     noIcons: false
+    # Toggles whether k9s should check for the latest revision from the Github repository releases. Default is false.
+    noLatestRevCheck: false
     # Logs configuration
     logger:
       # Defines the number of lines to return. Default 100

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ K9s uses aliases to navigate most K8s resources.
     # Toggles icons display as not all terminal support these chars.
     noIcons: false
     # Toggles whether k9s should check for the latest revision from the Github repository releases. Default is false.
-    noLatestRevCheck: false
+    skipLatestRevCheck: false
     # Logs configuration
     logger:
       # Defines the number of lines to return. Default 100

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -286,7 +286,7 @@ var expectedConfig = `k9s:
   readOnly: true
   noExitOnCtrlC: false
   noIcons: false
-  noLatestRevCheck: false
+  skipLatestRevCheck: false
   logger:
     tail: 500
     buffer: 800
@@ -382,7 +382,7 @@ var resetConfig = `k9s:
   readOnly: false
   noExitOnCtrlC: false
   noIcons: false
-  noLatestRevCheck: false
+  skipLatestRevCheck: false
   logger:
     tail: 200
     buffer: 2000

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -286,6 +286,7 @@ var expectedConfig = `k9s:
   readOnly: true
   noExitOnCtrlC: false
   noIcons: false
+  noLatestRevCheck: false
   logger:
     tail: 500
     buffer: 800
@@ -381,6 +382,7 @@ var resetConfig = `k9s:
   readOnly: false
   noExitOnCtrlC: false
   noIcons: false
+  noLatestRevCheck: false
   logger:
     tail: 200
     buffer: 2000

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -20,6 +20,7 @@ type K9s struct {
 	ReadOnly            bool                `yaml:"readOnly"`
 	NoExitOnCtrlC       bool                `yaml:"noExitOnCtrlC"`
 	NoIcons             bool                `yaml:"noIcons"`
+	NoLatestRevCheck    bool                `yaml:"noLatestRevCheck"`
 	Logger              *Logger             `yaml:"logger"`
 	CurrentContext      string              `yaml:"currentContext"`
 	CurrentCluster      string              `yaml:"currentCluster"`

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -20,7 +20,7 @@ type K9s struct {
 	ReadOnly            bool                `yaml:"readOnly"`
 	NoExitOnCtrlC       bool                `yaml:"noExitOnCtrlC"`
 	NoIcons             bool                `yaml:"noIcons"`
-	NoLatestRevCheck    bool                `yaml:"noLatestRevCheck"`
+	SkipLatestRevCheck  bool                `yaml:"skipLatestRevCheck"`
 	Logger              *Logger             `yaml:"logger"`
 	CurrentContext      string              `yaml:"currentContext"`
 	CurrentCluster      string              `yaml:"currentCluster"`

--- a/internal/model/cluster_info.go
+++ b/internal/model/cluster_info.go
@@ -69,22 +69,24 @@ func (c ClusterMeta) Deltas(n ClusterMeta) bool {
 
 // ClusterInfo models cluster metadata.
 type ClusterInfo struct {
-	cluster   *Cluster
-	factory   dao.Factory
-	data      ClusterMeta
-	version   string
-	listeners []ClusterInfoListener
-	cache     *cache.LRUExpireCache
+	cluster          *Cluster
+	factory          dao.Factory
+	data             ClusterMeta
+	version          string
+	noLatestRevCheck bool
+	listeners        []ClusterInfoListener
+	cache            *cache.LRUExpireCache
 }
 
 // NewClusterInfo returns a new instance.
-func NewClusterInfo(f dao.Factory, v string) *ClusterInfo {
+func NewClusterInfo(f dao.Factory, v string, noLatestRevCheck bool) *ClusterInfo {
 	c := ClusterInfo{
-		factory: f,
-		cluster: NewCluster(f),
-		data:    NewClusterMeta(),
-		version: v,
-		cache:   cache.NewLRUExpireCache(cacheSize),
+		factory:          f,
+		cluster:          NewCluster(f),
+		data:             NewClusterMeta(),
+		version:          v,
+		noLatestRevCheck: noLatestRevCheck,
+		cache:            cache.NewLRUExpireCache(cacheSize),
 	}
 
 	return &c
@@ -130,7 +132,14 @@ func (c *ClusterInfo) Refresh() {
 		}
 	}
 	data.K9sVer = c.version
-	v1, v2 := NewSemVer(data.K9sVer), NewSemVer(c.fetchK9sLatestRev())
+	v1 := NewSemVer(data.K9sVer)
+
+	var latestRev string
+	if !c.noLatestRevCheck {
+		latestRev = c.fetchK9sLatestRev()
+	}
+	v2 := NewSemVer(latestRev)
+
 	data.K9sVer, data.K9sLatest = v1.String(), v2.String()
 	if v1.IsCurrent(v2) {
 		data.K9sLatest = ""

--- a/internal/model/cluster_info.go
+++ b/internal/model/cluster_info.go
@@ -69,24 +69,24 @@ func (c ClusterMeta) Deltas(n ClusterMeta) bool {
 
 // ClusterInfo models cluster metadata.
 type ClusterInfo struct {
-	cluster          *Cluster
-	factory          dao.Factory
-	data             ClusterMeta
-	version          string
-	noLatestRevCheck bool
-	listeners        []ClusterInfoListener
-	cache            *cache.LRUExpireCache
+	cluster            *Cluster
+	factory            dao.Factory
+	data               ClusterMeta
+	version            string
+	skipLatestRevCheck bool
+	listeners          []ClusterInfoListener
+	cache              *cache.LRUExpireCache
 }
 
 // NewClusterInfo returns a new instance.
-func NewClusterInfo(f dao.Factory, v string, noLatestRevCheck bool) *ClusterInfo {
+func NewClusterInfo(f dao.Factory, v string, skipLatestRevCheck bool) *ClusterInfo {
 	c := ClusterInfo{
-		factory:          f,
-		cluster:          NewCluster(f),
-		data:             NewClusterMeta(),
-		version:          v,
-		noLatestRevCheck: noLatestRevCheck,
-		cache:            cache.NewLRUExpireCache(cacheSize),
+		factory:            f,
+		cluster:            NewCluster(f),
+		data:               NewClusterMeta(),
+		version:            v,
+		skipLatestRevCheck: skipLatestRevCheck,
+		cache:              cache.NewLRUExpireCache(cacheSize),
 	}
 
 	return &c
@@ -135,7 +135,7 @@ func (c *ClusterInfo) Refresh() {
 	v1 := NewSemVer(data.K9sVer)
 
 	var latestRev string
-	if !c.noLatestRevCheck {
+	if !c.skipLatestRevCheck {
 		latestRev = c.fetchK9sLatestRev()
 	}
 	v2 := NewSemVer(latestRev)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -151,7 +151,7 @@ func (a *App) bindKeys() {
 	}
 }
 
-// BailOut exists the application.
+// BailOut exits the application.
 func (a *App) BailOut() {
 	a.Stop()
 	os.Exit(0)

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -100,7 +100,7 @@ func (a *App) Init(version string, rate int) error {
 	}
 	a.initFactory(ns)
 
-	a.clusterModel = model.NewClusterInfo(a.factory, a.version, a.Config.K9s.NoLatestRevCheck)
+	a.clusterModel = model.NewClusterInfo(a.factory, a.version, a.Config.K9s.SkipLatestRevCheck)
 	a.clusterModel.AddListener(a.clusterInfo())
 	a.clusterModel.AddListener(a.statusIndicator())
 	if a.Conn().ConnectionOK() {

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -100,7 +100,7 @@ func (a *App) Init(version string, rate int) error {
 	}
 	a.initFactory(ns)
 
-	a.clusterModel = model.NewClusterInfo(a.factory, a.version)
+	a.clusterModel = model.NewClusterInfo(a.factory, a.version, a.Config.K9s.NoLatestRevCheck)
 	a.clusterModel.AddListener(a.clusterInfo())
 	a.clusterModel.AddListener(a.statusIndicator())
 	if a.Conn().ConnectionOK() {


### PR DESCRIPTION
# Changes
- Add the ability to configure whether k9s should check for the latest rev from the GitHub repo through a `noLatestRevCheck` boolean config entry

closes #1833