### PR TITLE
fix: multiple matches in a single line in YAML view filter

### DIFF
--- a/internal/model/yaml.go
+++ b/internal/model/yaml.go
@@ -84,11 +84,11 @@ func (*YAML) rxFilter(q string, lines []string) fuzzy.Matches {
 	}
 	matches := make(fuzzy.Matches, 0, len(lines))
 	for i, l := range lines {
-		if loc := rx.FindStringIndex(l); len(loc) == 2 {
+		locs := rx.FindAllStringIndex(l, -1)
+		for _, loc := range locs {
 			matches = append(matches, fuzzy.Match{Str: q, Index: i, MatchedIndexes: loc})
 		}
 	}
-
 	return matches
 }
 

--- a/internal/model/yaml_test.go
+++ b/internal/model/yaml_test.go
@@ -1,0 +1,65 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/sahilm/fuzzy"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestYAML_rxFilter(t *testing.T) {
+	uu := map[string]struct {
+		q     string
+		lines []string
+		e     fuzzy.Matches
+	}{
+		"empty-lines": {
+			q: "foo",
+			e: fuzzy.Matches{},
+		},
+		"no-match": {
+			q:     "foo",
+			lines: []string{"bar"},
+			e:     fuzzy.Matches{},
+		},
+		"single-match": {
+			q:     "foo",
+			lines: []string{"foo", "bar", "baz"},
+			e: fuzzy.Matches{
+				{
+					Str:            "foo",
+					Index:          0,
+					MatchedIndexes: []int{0, 3},
+				},
+			},
+		},
+		"multiple-matches": {
+			q:     "foo",
+			lines: []string{"foo", "bar", "foo bar foo", "baz"},
+			e: fuzzy.Matches{
+				{
+					Str:            "foo",
+					Index:          0,
+					MatchedIndexes: []int{0, 3},
+				},
+				{
+					Str:            "foo",
+					Index:          2,
+					MatchedIndexes: []int{0, 3},
+				},
+				{
+					Str:            "foo",
+					Index:          2,
+					MatchedIndexes: []int{8, 11},
+				},
+			},
+		},
+	}
+	var y YAML
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, y.rxFilter(u.q, u.lines))
+		})
+	}
+}

--- a/internal/view/live_view_test.go
+++ b/internal/view/live_view_test.go
@@ -1,0 +1,64 @@
+package view
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/sahilm/fuzzy"
+	"github.com/stretchr/testify/assert"
+)
+
+func matchTag(i int, s string) string {
+	return `<<<"search_` + strconv.Itoa(i) + `">>>` + s + `<<<"">>>`
+}
+
+func TestLiveView_linesWithRegions(t *testing.T) {
+	uu := map[string]struct {
+		lines   []string
+		matches fuzzy.Matches
+		e       []string
+	}{
+		"empty-lines": {
+			e: []string{},
+		},
+		"no-match": {
+			lines: []string{"bar"},
+			e:     []string{"bar"},
+		},
+		"single-match": {
+			lines: []string{"foo", "bar", "baz"},
+			matches: fuzzy.Matches{
+				{Index: 1, MatchedIndexes: []int{0, 3}},
+			},
+			e: []string{"foo", matchTag(0, "bar"), "baz"},
+		},
+		"multiple-matches": {
+			lines: []string{"foo", "bar", "baz"},
+			matches: fuzzy.Matches{
+				{Index: 1, MatchedIndexes: []int{0, 3}},
+				{Index: 2, MatchedIndexes: []int{0, 3}},
+			},
+			e: []string{"foo", matchTag(0, "bar"), matchTag(1, "baz")},
+		},
+		"multiple-matches-same-line": {
+			lines: []string{"foosfoo baz", "dfbarfoos bar"},
+			matches: fuzzy.Matches{
+				{Index: 0, MatchedIndexes: []int{0, 3}},
+				{Index: 0, MatchedIndexes: []int{4, 7}},
+				{Index: 1, MatchedIndexes: []int{5, 8}},
+			},
+			e: []string{
+				matchTag(0, "foo") + "s" + matchTag(1, "foo") + " baz",
+				"dfbar" + matchTag(2, "foo") + "s bar",
+			},
+		},
+	}
+	var v LiveView
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, u.e, v.linesWithRegions(u.lines, u.matches))
+		})
+	}
+}


### PR DESCRIPTION
# Changes
- Correctly handle multiple matches in a single line when filtering in the YAML view
- Add a unit test for rxFilter

# Demonstration
<img width="2112" alt="Screenshot 2022-11-26 at 19 53 38" src="https://user-images.githubusercontent.com/8296549/204105125-ec74b122-0866-44c0-833c-a1808bf13941.png">
As you can see in the screenshot above (right), the 8 matches of "bar" are correctly detected and can be navigated through, whereas, on the current rev (left), only 2 matches are detected (one per line).

closes #1727 