### PR TITLE
Fix force deletion

### DIFF
--- a/internal/dao/generic.go
+++ b/internal/dao/generic.go
@@ -103,7 +103,7 @@ func (g *Generic) Delete(ctx context.Context, path string, propagation *metav1.D
 	}
 
 	if force {
-		var defaultKillGrace int64 = 1
+		var defaultKillGrace int64 = 0
 		opts.GracePeriodSeconds = &defaultKillGrace
 	}
 


### PR DESCRIPTION
To force a deletion the grace period has to be set to `0`, not `1`.

This fixes #1882.