### PR TITLE
Preserve active namespace after accessing forbidden resource #1935

### DIFF
--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -133,6 +133,7 @@ func (b *Browser) SetInstance(path string) {
 func (b *Browser) Start() {
 	b.app.Config.ValidateFavorites()
 	ns := b.app.Config.ActiveNamespace()
+	b.setNamespace(ns)
 	if n := b.GetModel().GetNamespace(); !client.IsClusterScoped(n) {
 		ns = n
 	}


### PR DESCRIPTION
Resolves reported issue: https://github.com/derailed/k9s/issues/1935 so a selected namespace is preserved after hitting the forbidden resource to be able to return to access resources without k9s restart.
