### PR TITLE
fix: Show meaningful error message when kubectl exec fails

### DIFF
--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -41,6 +41,10 @@ type shellOpts struct {
 
 func runK(a *App, opts shellOpts) bool {
 	bin, err := exec.LookPath("kubectl")
+	if errors.Is(err, exec.ErrDot) {
+		log.Error().Err(err).Msgf("kubectl command must not be in the current working directory")
+		return false
+	}
 	if err != nil {
 		log.Error().Err(err).Msgf("kubectl command is not in your path")
 		return false
@@ -137,6 +141,10 @@ func execute(opts shellOpts) error {
 
 func runKu(a *App, opts shellOpts) (string, error) {
 	bin, err := exec.LookPath("kubectl")
+	if errors.Is(err, exec.ErrDot) {
+		log.Error().Err(err).Msgf("kubectl command must not be in the current working directory")
+		return "", err
+	}
 	if err != nil {
 		log.Error().Err(err).Msgf("kubectl command is not in your path")
 		return "", err


### PR DESCRIPTION
`exec.LookPath()` and `exec.Command()` aren't supposed to work with
binaries that are located in the current working directory:

https://cs.opensource.google/go/go/+/fd208c8850cdfe84469d3e4ef9bd55e2e0cece70:src/os/exec/exec.go

If `kubectl` is found in the current working directory, `LookPath()`
will return `ErrDot` even if it is also found in any other directory in
the `PATH`.

This patch detects this condition and shows a meaningful error message
in the log so that the user knows the reason why `kubectl` couldn't be
executed.

Related: https://github.com/derailed/k9s/issues/1787