### PR TITLE
fix: Add missing help menu to gruvbox-dark skin

### DIFF
--- a/skins/gruvbox-dark.yml
+++ b/skins/gruvbox-dark.yml
@@ -23,6 +23,12 @@ k9s:
   info:
     fgColor: *magenta
     sectionColor: *foreground
+  help:
+    fgColor: *foreground
+    bgColor: *background
+    keyColor: *magenta
+    numKeyColor: *blue
+    sectionColor: *green
   dialog:
     fgColor: *foreground
     bgColor: *background


### PR DESCRIPTION
The values of almost everything in the skins gruvbox-light and gruvbox-dark are the same, but gruvbox-dark is missing the values of the help menu, which looks a bit broken.

This patch copies the values from gruvbox-light to gruvbox-dark so that it looks fine.