### PR TITLE
Add missing help menu to one_dark skin

### DIFF
--- a/skins/one_dark.yml
+++ b/skins/one_dark.yml
@@ -23,6 +23,12 @@ k9s:
   info:
     fgColor: *grey
     sectionColor: *green
+  help:
+    fgColor: *foreground
+    bgColor: *background
+    keyColor: *yellow
+    numKeyColor: *blue
+    sectionColor: *purple
   dialog:
     fgColor: *black
     bgColor: *background


### PR DESCRIPTION
Missing color profile for the help menu, so matches the skin theme correctly.

Specifically related to: https://github.com/derailed/k9s/issues/1968