### PR TITLE
Fix to also clear the suggestion list (#2004)

### DIFF
--- a/internal/model/fish_buff.go
+++ b/internal/model/fish_buff.go
@@ -70,6 +70,7 @@ func (f *FishBuff) NextSuggestion() (string, bool) {
 
 // ClearSuggestions clear out all suggestions.
 func (f *FishBuff) ClearSuggestions() {
+	f.suggestions = f.suggestions[:0]
 	f.suggestionIndex = -1
 }
 


### PR DESCRIPTION
This clears the current list of suggestions in ClearSuggestions so that stale suggestions are not appended to the current term in the prompt.