### PR TITLE
fix brew command in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ K9s is available on Linux, macOS and Windows platforms.
 * Via [Homebrew](https://brew.sh/) for macOS or Linux
 
    ```shell
-   brew install derailed/k9s/k9s
+   brew install k9s
    ```
 
 * Via [MacPorts](https://www.macports.org)


### PR DESCRIPTION
Works: brew info k9s
Doesn't work: brew info derailed/k9s/k9s