### PR TITLE
Add support for using custom kubeconfig with log_full plugin

### DIFF
--- a/plugins/log_full.yml
+++ b/plugins/log_full.yml
@@ -15,6 +15,8 @@ plugin:
     - $NAMESPACE
     - --context
     - $CONTEXT
+    - --kubeconfig
+    - $KUBECONFIG
   log-less:
     shortCut: Shift-L
     description: "logs|less"
@@ -33,6 +35,8 @@ plugin:
     - $NAMESPACE
     - --context
     - $CONTEXT
+    - --kubeconfig
+    - $KUBECONFIG
   log-less-container:
     shortCut: Shift-L
     description: "logs|less"
@@ -53,3 +57,5 @@ plugin:
     - $NAMESPACE
     - --context
     - $CONTEXT
+    - --kubeconfig
+    - $KUBECONFIG


### PR DESCRIPTION
Support for using the log_full plugin (added in #2002) if starting k9s with a custom kubeconfig file (the `--kubeconfig` flag)