### PR TITLE
feat: allow customization of log indicator toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,8 +866,13 @@ k9s:
       valueColor: royalblue
     # Logs styles.
     logs:
-      fgColor: white
+      fgColor: lightskyblue
       bgColor: black
+      indicator:
+        fgColor: dodgerblue
+        bgColor: black
+        toggleOnColor: limegreen
+        toggleOffColor: gray
 ```
 
 ---

--- a/internal/config/styles.go
+++ b/internal/config/styles.go
@@ -121,8 +121,10 @@ type (
 
 	// LogIndicator tracks log view indicator.
 	LogIndicator struct {
-		FgColor Color `yaml:"fgColor"`
-		BgColor Color `yaml:"bgColor"`
+		FgColor        Color `yaml:"fgColor"`
+		BgColor        Color `yaml:"bgColor"`
+		ToggleOnColor  Color `yaml:"toggleOnColor"`
+		ToggleOffColor Color `yaml:"toggleOffColor"`
 	}
 
 	// Yaml tracks yaml styles.
@@ -367,8 +369,10 @@ func newLog() Log {
 
 func newLogIndicator() LogIndicator {
 	return LogIndicator{
-		FgColor: "dodgerblue",
-		BgColor: "black",
+		FgColor:        "dodgerblue",
+		BgColor:        "black",
+		ToggleOnColor:  "limegreen",
+		ToggleOffColor: "gray",
 	}
 }
 

--- a/internal/view/log_indicator.go
+++ b/internal/view/log_indicator.go
@@ -1,6 +1,7 @@
 package view
 
 import (
+	"fmt"
 	"sync/atomic"
 
 	"github.com/derailed/k9s/internal/config"
@@ -47,6 +48,7 @@ func NewLogIndicator(cfg *config.Config, styles *config.Styles, allContainers bo
 func (l *LogIndicator) StylesChanged(styles *config.Styles) {
 	l.SetBackgroundColor(styles.K9s.Views.Log.Indicator.BgColor.Color())
 	l.SetTextColor(styles.K9s.Views.Log.Indicator.FgColor.Color())
+	l.Refresh()
 }
 
 // AutoScroll reports the current scrolling status.
@@ -111,36 +113,39 @@ func (l *LogIndicator) reset() {
 func (l *LogIndicator) Refresh() {
 	l.reset()
 
+	toggleOnFormat := "[::b]%s:[" + string(l.styles.K9s.Views.Log.Indicator.ToggleOnColor) + "::b]On[-::] %s"
+	toggleOffFormat := "[::b]%s:[" + string(l.styles.K9s.Views.Log.Indicator.ToggleOffColor) + "::d]Off[-::]%s"
+
 	if l.shouldDisplayAllContainers {
 		if l.allContainers {
-			l.indicator = append(l.indicator, "[::b]AllContainers:[limegreen::b]On[-::] "+spacer...)
+			l.indicator = append(l.indicator, fmt.Sprintf(toggleOnFormat, "AllContainers", spacer)...)
 		} else {
-			l.indicator = append(l.indicator, "[::b]AllContainers:[gray::d]Off[-::]"+spacer...)
+			l.indicator = append(l.indicator, fmt.Sprintf(toggleOffFormat, "AllContainers", spacer)...)
 		}
 	}
 
 	if l.AutoScroll() {
-		l.indicator = append(l.indicator, "[::b]Autoscroll:[limegreen::b]On[-::] "+spacer...)
+		l.indicator = append(l.indicator, fmt.Sprintf(toggleOnFormat, "Autoscroll", spacer)...)
 	} else {
-		l.indicator = append(l.indicator, "[::b]Autoscroll:[gray::d]Off[-::]"+spacer...)
+		l.indicator = append(l.indicator, fmt.Sprintf(toggleOffFormat, "Autoscroll", spacer)...)
 	}
 
 	if l.FullScreen() {
-		l.indicator = append(l.indicator, "[::b]FullScreen:[limegreen::b]On[-::] "+spacer...)
+		l.indicator = append(l.indicator, fmt.Sprintf(toggleOnFormat, "FullScreen", spacer)...)
 	} else {
-		l.indicator = append(l.indicator, "[::b]FullScreen:[gray::d]Off[-::]"+spacer...)
+		l.indicator = append(l.indicator, fmt.Sprintf(toggleOffFormat, "FullScreen", spacer)...)
 	}
 
 	if l.Timestamp() {
-		l.indicator = append(l.indicator, "[::b]Timestamps:[limegreen::b]On[-::] "+spacer...)
+		l.indicator = append(l.indicator, fmt.Sprintf(toggleOnFormat, "Timestamps", spacer)...)
 	} else {
-		l.indicator = append(l.indicator, "[::b]Timestamps:[gray::d]Off[-::]"+spacer...)
+		l.indicator = append(l.indicator, fmt.Sprintf(toggleOffFormat, "Timestamps", spacer)...)
 	}
 
 	if l.TextWrap() {
-		l.indicator = append(l.indicator, "[::b]Wrap:[limegreen::b]On[-::] "...)
+		l.indicator = append(l.indicator, fmt.Sprintf(toggleOnFormat, "Wrap", "")...)
 	} else {
-		l.indicator = append(l.indicator, "[::b]Wrap:[gray::d]Off[-::]"...)
+		l.indicator = append(l.indicator, fmt.Sprintf(toggleOffFormat, "Wrap", "")...)
 	}
 
 	_, _ = l.Write(l.indicator)


### PR DESCRIPTION
Demo of change:


https://user-images.githubusercontent.com/10135646/229672885-032436a1-620c-40ea-8a30-79ba77526bb2.mov


I noticed timestamps do not have the ability to customize as well. I see there is issue for customizing pod colors (https://github.com/derailed/k9s/issues/935) . I was thinking to add a note about timestamp do that issue as well.