### PR TITLE
fix: (views) use saved context view when switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,8 @@ K9s uses aliases to navigate most K8s resources.
 | Fuzzy find a resource given a filter                           | `/`-f filter⏎                 |                                                                        |
 | Bails out of view/command/filter mode                          | `<esc>`                       |                                                                        |
 | Key mapping to describe, view, edit, view logs,...             | `d`,`v`, `e`, `l`,...         |                                                                        |
-| To view and switch to another Kubernetes context               | `:`ctx⏎                       |                                                                        |
-| To view and switch to another Kubernetes context               | `:`ctx context-name⏎          |                                                                        |
+| To view and switch to another Kubernetes context (Pod view)    | `:`ctx⏎                       |                                                                        |
+| To view and switch directl to another Kubernetes context (Last used view) | `:`ctx context-name⏎          |                                                                        |
 | To view and switch to another Kubernetes namespace             | `:`ns⏎                        |                                                                        |
 | To view all saved resources                                    | `:`screendump or sd⏎          |                                                                        |
 | To delete a resource (TAB and ENTER to confirm)                | `ctrl-d`                      |                                                                        |

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -398,7 +398,7 @@ func (a *App) isValidNS(ns string) (bool, error) {
 	return true, nil
 }
 
-func (a *App) switchContext(name string, loadPods bool) error {
+func (a *App) switchContext(name string) error {
 	log.Debug().Msgf("--> Switching Context %q--%q", name, a.Config.ActiveView())
 	a.Halt()
 	defer a.Resume()
@@ -413,7 +413,7 @@ func (a *App) switchContext(name string, loadPods bool) error {
 			return e
 		}
 		v := a.Config.ActiveView()
-		if v == "" || isContextCmd(v) || loadPods {
+		if v == "" || isContextCmd(v) {
 			v = "pod"
 			a.Config.SetActiveView(v)
 		}
@@ -433,7 +433,7 @@ func (a *App) switchContext(name string, loadPods bool) error {
 
 		a.Flash().Infof("Switching context to %s", name)
 		a.ReloadStyles(name)
-		a.gotoResource(v, "", true)
+		a.gotoResource(a.Config.ActiveView(), "", true)
 		a.clusterModel.Reset(a.factory)
 	}
 

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -412,10 +412,8 @@ func (a *App) switchContext(name string) error {
 		if e := a.command.Reset(true); e != nil {
 			return e
 		}
-		v := a.Config.ActiveView()
-		if v == "" || isContextCmd(v) {
-			v = "pod"
-			a.Config.SetActiveView(v)
+		if a.Config.ActiveView() == "" || isContextCmd(a.Config.ActiveView()) {
+			a.Config.SetActiveView("pod")
 		}
 		a.Config.Reset()
 		a.Config.K9s.CurrentContext = name

--- a/internal/view/context.go
+++ b/internal/view/context.go
@@ -119,6 +119,6 @@ func useContext(app *App, name string) error {
 		log.Error().Err(err).Msgf("Context switch failed")
 		return err
 	}
-
-	return app.switchContext(name, true)
+	
+	return app.switchContext(name)
 }


### PR DESCRIPTION
Related: #1481 (may not close)

In this PR, we adjust switching contexts to default to pods if empty or if using the context view, however if a specific context is specified (`ctx my-cluster`), it will switch to that cluster in the previous view.