### PR TITLE
fix: (config) use active cluster instead of config namespace

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,7 +98,7 @@ func (c *Config) Refine(flags *genericclioptions.ConfigFlags, k9sFlags *Flags, c
 	} else if isSet(flags.Namespace) {
 		ns = *flags.Namespace
 	} else {
-		ns = context.Namespace
+		ns = c.K9s.ActiveCluster().Namespace.Active
 	}
 
 	if err := c.SetActiveNamespace(ns); err != nil {


### PR DESCRIPTION
Fixes #2033

We were loading the namespace from the kubeconfig rather than the current cluster on startup.