### PR TITLE
Resources are rendered using skin.yaml colors

### DIFF
--- a/internal/config/styles.go
+++ b/internal/config/styles.go
@@ -61,13 +61,16 @@ type (
 
 	// Body tracks body styles.
 	Body struct {
-		FgColor        Color `yaml:"fgColor"`
-		BgColor        Color `yaml:"bgColor"`
-		LogoColor      Color `yaml:"logoColor"`
-		LogoColorMsg   Color `yaml:"logoColorMsg"`
-		LogoColorInfo  Color `yaml:"logoColorInfo"`
-		LogoColorWarn  Color `yaml:"logoColorWarn"`
-		LogoColorError Color `yaml:"logoColorError"`
+		FgColor         Color `yaml:"fgColor"`
+		BgColor         Color `yaml:"bgColor"`
+		LogoColor       Color `yaml:"logoColor"`
+		LogoColorMsg    Color `yaml:"logoColorMsg"`
+		LogoColorInfo   Color `yaml:"logoColorInfo"`
+		LogoColorWarn   Color `yaml:"logoColorWarn"`
+		LogoColorError  Color `yaml:"logoColorError"`
+		FlashColorOk    Color `yaml:"flashColorOk"`
+		FlashColorWarn  Color `yaml:"flashColorWarn"`
+		FlashColorError Color `yaml:"flashColorError"`
 	}
 
 	// Dialog tracks dialog styles.
@@ -80,6 +83,7 @@ type (
 		ButtonFocusBgColor Color `yaml:"buttonFocusBgColor"`
 		LabelFgColor       Color `yaml:"labelFgColor"`
 		FieldFgColor       Color `yaml:"fieldFgColor"`
+		ErrorColor         Color `yaml:"errorColor"`
 	}
 
 	// Frame tracks frame styles.
@@ -279,6 +283,7 @@ func newDialog() Dialog {
 		ButtonFocusFgColor: "black",
 		LabelFgColor:       "white",
 		FieldFgColor:       "white",
+		ErrorColor:         "orangered",
 	}
 }
 
@@ -336,13 +341,16 @@ func newHelp() Help {
 
 func newBody() Body {
 	return Body{
-		FgColor:        "cadetblue",
-		BgColor:        "black",
-		LogoColor:      "orange",
-		LogoColorMsg:   "white",
-		LogoColorInfo:  "green",
-		LogoColorWarn:  "mediumvioletred",
-		LogoColorError: "red",
+		FgColor:         "cadetblue",
+		BgColor:         "black",
+		LogoColor:       "orange",
+		LogoColorMsg:    "white",
+		LogoColorInfo:   "green",
+		LogoColorWarn:   "mediumvioletred",
+		LogoColorError:  "red",
+		FlashColorOk:    "green",
+		FlashColorWarn:  "yellow",
+		FlashColorError: "red",
 	}
 }
 
@@ -478,6 +486,21 @@ func (s *Styles) FgColor() tcell.Color {
 // BgColor returns the background color.
 func (s *Styles) BgColor() tcell.Color {
 	return s.Body().BgColor.Color()
+}
+
+// FlashColorOk returns the color in combination with happy emoji.
+func (s *Styles) FlashColorOk() tcell.Color {
+	return s.Body().FlashColorOk.Color()
+}
+
+// FlashColorWarn returns the color in combination with warn emoji.
+func (s *Styles) FlashColorWarn() tcell.Color {
+	return s.Body().FlashColorWarn.Color()
+}
+
+// FlashColorWarn returns the color in combination with angry emoji.
+func (s *Styles) FlashColorError() tcell.Color {
+	return s.Body().FlashColorError.Color()
 }
 
 // AddListener registers a new listener.

--- a/internal/render/benchmark.go
+++ b/internal/render/benchmark.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/derailed/k9s/internal/client"
-	"github.com/derailed/tcell/v2"
 	"github.com/derailed/tview"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,12 +29,7 @@ type Benchmark struct {
 
 // ColorerFunc colors a resource row.
 func (b Benchmark) ColorerFunc() ColorerFunc {
-	return func(ns string, h Header, re RowEvent) tcell.Color {
-		if !Happy(ns, h, re.Row) {
-			return ErrColor
-		}
-		return tcell.ColorPaleGreen
-	}
+	return DefaultColorer
 }
 
 // Header returns a header row.

--- a/internal/render/dir.go
+++ b/internal/render/dir.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/derailed/tcell/v2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -19,9 +18,7 @@ func (Dir) IsGeneric() bool {
 
 // ColorerFunc colors a resource row.
 func (Dir) ColorerFunc() ColorerFunc {
-	return func(ns string, _ Header, re RowEvent) tcell.Color {
-		return tcell.ColorCadetBlue
-	}
+	return DefaultColorer
 }
 
 // Header returns a header row.

--- a/internal/render/helm.go
+++ b/internal/render/helm.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/derailed/k9s/internal/client"
-	"github.com/derailed/tcell/v2"
 	"helm.sh/helm/v3/pkg/release"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,13 +21,7 @@ func (Helm) IsGeneric() bool {
 
 // ColorerFunc colors a resource row.
 func (Helm) ColorerFunc() ColorerFunc {
-	return func(ns string, h Header, re RowEvent) tcell.Color {
-		if !Happy(ns, h, re.Row) {
-			return ErrColor
-		}
-
-		return tcell.ColorMediumSpringGreen
-	}
+	return DefaultColorer
 }
 
 // Header returns a header row.

--- a/internal/render/policy.go
+++ b/internal/render/policy.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/derailed/k9s/internal/client"
-	"github.com/derailed/tcell/v2"
 	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,9 +30,7 @@ type Policy struct {
 
 // ColorerFunc colors a resource row.
 func (Policy) ColorerFunc() ColorerFunc {
-	return func(ns string, _ Header, re RowEvent) tcell.Color {
-		return tcell.ColorMediumSpringGreen
-	}
+	return DefaultColorer
 }
 
 // Header returns a header row.

--- a/internal/render/portforward.go
+++ b/internal/render/portforward.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/derailed/k9s/internal/client"
-	"github.com/derailed/tcell/v2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -35,9 +34,7 @@ type PortForward struct {
 
 // ColorerFunc colors a resource row.
 func (PortForward) ColorerFunc() ColorerFunc {
-	return func(ns string, _ Header, re RowEvent) tcell.Color {
-		return tcell.ColorSkyblue
-	}
+	return DefaultColorer
 }
 
 // Header returns a header row.

--- a/internal/render/reference.go
+++ b/internal/render/reference.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/derailed/k9s/internal/client"
-	"github.com/derailed/tcell/v2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -16,9 +15,7 @@ type Reference struct {
 
 // ColorerFunc colors a resource row.
 func (Reference) ColorerFunc() ColorerFunc {
-	return func(ns string, _ Header, re RowEvent) tcell.Color {
-		return tcell.ColorCadetBlue
-	}
+	return DefaultColorer
 }
 
 // Header returns a header row.

--- a/internal/render/screen_dump.go
+++ b/internal/render/screen_dump.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/derailed/tcell/v2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -18,9 +17,7 @@ type ScreenDump struct {
 
 // ColorerFunc colors a resource row.
 func (ScreenDump) ColorerFunc() ColorerFunc {
-	return func(ns string, _ Header, re RowEvent) tcell.Color {
-		return tcell.ColorNavajoWhite
-	}
+	return DefaultColorer
 }
 
 // Header returns a header row.

--- a/internal/render/subject.go
+++ b/internal/render/subject.go
@@ -3,7 +3,6 @@ package render
 import (
 	"fmt"
 
-	"github.com/derailed/tcell/v2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -15,9 +14,7 @@ type Subject struct {
 
 // ColorerFunc colors a resource row.
 func (Subject) ColorerFunc() ColorerFunc {
-	return func(ns string, _ Header, re RowEvent) tcell.Color {
-		return tcell.ColorMediumSpringGreen
-	}
+	return DefaultColorer
 }
 
 // Header returns a header row.

--- a/internal/ui/dialog/error.go
+++ b/internal/ui/dialog/error.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/ui"
-	"github.com/derailed/tcell/v2"
 	"github.com/derailed/tview"
 )
 
@@ -18,7 +17,7 @@ func ShowError(styles config.Dialog, pages *ui.Pages, msg string) {
 		SetButtonBackgroundColor(styles.ButtonBgColor.Color()).
 		SetButtonTextColor(styles.ButtonFgColor.Color()).
 		SetLabelColor(styles.LabelFgColor.Color()).
-		SetFieldTextColor(tcell.ColorIndianRed)
+		SetFieldTextColor(styles.FieldFgColor.Color())
 	f.AddButton("Dismiss", func() {
 		dismiss(pages)
 	})
@@ -29,7 +28,7 @@ func ShowError(styles config.Dialog, pages *ui.Pages, msg string) {
 	f.SetFocus(0)
 	modal := tview.NewModalForm("<error>", f)
 	modal.SetText(cowTalk(msg))
-	modal.SetTextColor(tcell.ColorOrangeRed)
+	modal.SetTextColor(styles.ErrorColor.Color())
 	modal.SetDoneFunc(func(int, string) {
 		dismiss(pages)
 	})

--- a/internal/ui/flash.go
+++ b/internal/ui/flash.go
@@ -30,7 +30,7 @@ func NewFlash(app *App) *Flash {
 		app:      app,
 		TextView: tview.NewTextView(),
 	}
-	f.SetTextColor(tcell.ColorAqua)
+
 	f.SetDynamicColors(true)
 	f.SetTextAlign(tview.AlignCenter)
 	f.SetBorderPadding(0, 0, 1, 1)
@@ -70,7 +70,7 @@ func (f *Flash) SetMessage(m model.LevelMessage) {
 			f.Clear()
 			return
 		}
-		f.SetTextColor(flashColor(m.Level))
+		f.SetTextColor(f.flashColor(m.Level))
 		f.SetText(f.flashEmoji(m.Level) + " " + m.Text)
 	}
 
@@ -98,14 +98,16 @@ func (f *Flash) flashEmoji(l model.FlashLevel) string {
 
 // Helpers...
 
-func flashColor(l model.FlashLevel) tcell.Color {
+func (f *Flash) flashColor(l model.FlashLevel) tcell.Color {
+	styles := f.app.Styles
+
 	// nolint:exhaustive
 	switch l {
 	case model.FlashWarn:
-		return tcell.ColorOrange
+		return styles.FlashColorWarn()
 	case model.FlashErr:
-		return tcell.ColorOrangeRed
+		return styles.FlashColorError()
 	default:
-		return tcell.ColorNavajoWhite
+		return styles.FlashColorOk()
 	}
 }

--- a/internal/ui/indicator.go
+++ b/internal/ui/indicator.go
@@ -8,7 +8,6 @@ import (
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/model"
 	"github.com/derailed/k9s/internal/render"
-	"github.com/derailed/tcell/v2"
 	"github.com/derailed/tview"
 )
 
@@ -30,7 +29,7 @@ func NewStatusIndicator(app *App, styles *config.Styles) *StatusIndicator {
 		styles:   styles,
 	}
 	s.SetTextAlign(tview.AlignCenter)
-	s.SetTextColor(tcell.ColorWhite)
+	s.SetTextColor(styles.FgColor())
 	s.SetBackgroundColor(styles.BgColor())
 	s.SetDynamicColors(true)
 	styles.AddListener(&s)

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -71,7 +71,6 @@ func (t *Table) Init(ctx context.Context) {
 	t.SetBorderPadding(0, 0, 1, 1)
 	t.SetSelectable(true, false)
 	t.SetSelectionChangedFunc(t.selectionChanged)
-	t.SetBackgroundColor(tcell.ColorDefault)
 	t.Select(1, 0)
 	if cfg, ok := ctx.Value(internal.KeyViewConfig).(*config.CustomView); ok && cfg != nil {
 		cfg.AddListener(t.GVR().String(), t)

--- a/internal/ui/tree.go
+++ b/internal/ui/tree.go
@@ -40,7 +40,6 @@ func (t *Tree) Init(ctx context.Context) error {
 	t.SetBorderAttributes(tcell.AttrBold)
 	t.SetBorderPadding(0, 0, 1, 1)
 	t.SetGraphics(true)
-	t.SetGraphicsColor(tcell.ColorCadetBlue)
 	t.SetInputCapture(t.keyboard)
 
 	return nil

--- a/internal/view/alias.go
+++ b/internal/view/alias.go
@@ -22,8 +22,6 @@ func NewAlias(gvr client.GVR) ResourceViewer {
 	a := Alias{
 		ResourceViewer: NewBrowser(gvr),
 	}
-	a.GetTable().SetBorderFocusColor(tcell.ColorAliceBlue)
-	a.GetTable().SetSelectedStyle(tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorAliceBlue).Attributes(tcell.AttrNone))
 	a.AddBindKeysFn(a.bindKeys)
 	a.SetContextFn(a.aliasContext)
 

--- a/internal/view/benchmark.go
+++ b/internal/view/benchmark.go
@@ -11,7 +11,6 @@ import (
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/perf"
 	"github.com/derailed/k9s/internal/ui"
-	"github.com/derailed/tcell/v2"
 )
 
 // Benchmark represents a service benchmark results view.
@@ -24,8 +23,6 @@ func NewBenchmark(gvr client.GVR) ResourceViewer {
 	b := Benchmark{
 		ResourceViewer: NewBrowser(gvr),
 	}
-	b.GetTable().SetBorderFocusColor(tcell.ColorSeaGreen)
-	b.GetTable().SetSelectedStyle(tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorSeaGreen).Attributes(tcell.AttrNone))
 	b.GetTable().SetSortCol(ageCol, true)
 	b.SetContextFn(b.benchContext)
 	b.GetTable().SetEnterFn(b.viewBench)

--- a/internal/view/context.go
+++ b/internal/view/context.go
@@ -78,22 +78,26 @@ func (c *Context) showRenameModal(a *App, name string, ok func(form *tview.Form,
 			p.RemovePage(renamePage)
 		})
 	m := tview.NewModalForm("<Rename>", f)
+
 	m.SetText(fmt.Sprintf("Rename context %q?", name))
 	m.SetDoneFunc(func(int, string) {
 		p.RemovePage(renamePage)
 	})
+
 	p.AddPage(renamePage, m, false, false)
 	p.ShowPage(renamePage)
 }
 
 func (c *Context) makeStyledForm() *tview.Form {
 	f := tview.NewForm()
+	styles := c.App().Styles.Dialog()
+
 	f.SetItemPadding(0)
 	f.SetButtonsAlign(tview.AlignCenter).
-		SetButtonBackgroundColor(tview.Styles.PrimitiveBackgroundColor).
-		SetButtonTextColor(tview.Styles.PrimaryTextColor).
-		SetLabelColor(tcell.ColorAqua).
-		SetFieldTextColor(tcell.ColorOrange)
+		SetButtonBackgroundColor(styles.ButtonBgColor.Color()).
+		SetButtonTextColor(styles.ButtonFgColor.Color()).
+		SetLabelColor(styles.LabelFgColor.Color()).
+		SetFieldTextColor(styles.FieldFgColor.Color())
 
 	return f
 }
@@ -124,6 +128,6 @@ func useContext(app *App, name string) error {
 		log.Error().Err(err).Msgf("Context switch failed")
 		return err
 	}
-	
+
 	return app.switchContext(name)
 }

--- a/internal/view/cow.go
+++ b/internal/view/cow.go
@@ -36,8 +36,6 @@ func (c *Cow) Init(_ context.Context) error {
 	c.SetBorder(true)
 	c.SetScrollable(true).SetWrap(true).SetRegions(true)
 	c.SetDynamicColors(true)
-	c.SetHighlightColor(tcell.ColorOrange)
-	c.SetTitleColor(tcell.ColorAqua)
 	c.SetInputCapture(c.keyboard)
 	c.SetBorderPadding(0, 0, 1, 1)
 	c.updateTitle()

--- a/internal/view/details.go
+++ b/internal/view/details.go
@@ -54,10 +54,9 @@ func (d *Details) Init(_ context.Context) error {
 	if d.title != "" {
 		d.SetBorder(true)
 	}
+
 	d.text.SetScrollable(true).SetWrap(true).SetRegions(true)
 	d.text.SetDynamicColors(true)
-	d.text.SetHighlightColor(tcell.ColorOrange)
-	d.SetTitleColor(tcell.ColorAqua)
 	d.SetInputCapture(d.keyboard)
 	d.SetBorderPadding(0, 0, 1, 1)
 	d.updateTitle()

--- a/internal/view/dir.go
+++ b/internal/view/dir.go
@@ -37,8 +37,7 @@ func NewDir(path string) ResourceViewer {
 		ResourceViewer: NewBrowser(client.NewGVR("dir")),
 		path:           path,
 	}
-	d.GetTable().SetBorderFocusColor(tcell.ColorAliceBlue)
-	d.GetTable().SetSelectedStyle(tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorAliceBlue).Attributes(tcell.AttrNone))
+
 	d.AddBindKeysFn(d.bindKeys)
 	d.SetContextFn(d.dirContext)
 
@@ -229,23 +228,13 @@ func (d *Dir) delCmd(evt *tcell.EventKey) *tcell.EventKey {
 		return evt
 	}
 
-	opts := []string{"-f"}
-	msgRessource := "manifest"
-	if containsDir(sel) {
-		opts = append(opts, "-R")
-	}
-	if isKustomized(sel) {
-		opts = []string{"-k"}
-		msgRessource = "kustomization"
-	}
-
 	d.Stop()
 	defer d.Start()
-	msg := fmt.Sprintf("Delete resource(s) in %s %s", msgRessource, sel)
+	msg := fmt.Sprintf("Delete resource(s) in manifest %s", sel)
 	dialog.ShowConfirm(d.App().Styles.Dialog(), d.App().Content.Pages, "Confirm Delete", msg, func() {
 		args := make([]string, 0, 10)
 		args = append(args, "delete")
-		args = append(args, opts...)
+		args = append(args, "-f")
 		args = append(args, sel)
 		res, err := runKu(d.App(), shellOpts{clear: false, args: args})
 		if err != nil {

--- a/internal/view/helm.go
+++ b/internal/view/helm.go
@@ -23,8 +23,7 @@ func NewHelm(gvr client.GVR) ResourceViewer {
 	c := Helm{
 		ResourceViewer: NewBrowser(gvr),
 	}
-	c.GetTable().SetBorderFocusColor(tcell.ColorMediumSpringGreen)
-	c.GetTable().SetSelectedStyle(tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorMediumSpringGreen).Attributes(tcell.AttrNone))
+
 	c.AddBindKeysFn(c.bindKeys)
 	c.SetContextFn(c.chartContext)
 

--- a/internal/view/image_extender.go
+++ b/internal/view/image_extender.go
@@ -94,7 +94,7 @@ func (s *ImageExtender) showImageDialog(path string) error {
 }
 
 func (s *ImageExtender) makeSetImageForm(sel string) (*tview.Form, error) {
-	f := s.makeStyledForm()
+	f := tview.NewForm()
 	podSpec, err := s.getPodSpec(sel)
 	if err != nil {
 		return nil, err
@@ -134,22 +134,29 @@ func (s *ImageExtender) makeSetImageForm(sel string) (*tview.Form, error) {
 		s.dismissDialog()
 	})
 
+	styles := s.App().Styles.Dialog()
+
+	f.SetItemPadding(0)
+	f.SetButtonsAlign(tview.AlignCenter).
+		SetButtonBackgroundColor(styles.ButtonBgColor.Color()).
+		SetButtonTextColor(styles.ButtonFgColor.Color()).
+		SetLabelColor(styles.LabelFgColor.Color()).
+		SetFieldTextColor(styles.FieldFgColor.Color())
+
+	for i := 0; i < 2; i++ {
+		b := f.GetButton(i)
+		if b == nil {
+			continue
+		}
+		b.SetBackgroundColorActivated(styles.ButtonFocusBgColor.Color())
+		b.SetLabelColorActivated(styles.ButtonFocusFgColor.Color())
+	}
+
 	return f, nil
 }
 
 func (s *ImageExtender) dismissDialog() {
 	s.App().Content.RemovePage(imageKey)
-}
-
-func (s *ImageExtender) makeStyledForm() *tview.Form {
-	f := tview.NewForm()
-	f.SetItemPadding(0)
-	f.SetButtonsAlign(tview.AlignCenter).
-		SetButtonBackgroundColor(tview.Styles.PrimitiveBackgroundColor).
-		SetButtonTextColor(tview.Styles.PrimaryTextColor).
-		SetLabelColor(tcell.ColorAqua).
-		SetFieldTextColor(tcell.ColorOrange)
-	return f
 }
 
 func (s *ImageExtender) getPodSpec(path string) (*corev1.PodSpec, error) {

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -59,10 +59,9 @@ func (v *LiveView) Init(_ context.Context) error {
 	if v.title != "" {
 		v.SetBorder(true)
 	}
+
 	v.text.SetScrollable(true).SetWrap(true).SetRegions(true)
 	v.text.SetDynamicColors(true)
-	v.text.SetHighlightColor(tcell.ColorOrange)
-	v.SetTitleColor(tcell.ColorAqua)
 	v.SetInputCapture(v.keyboard)
 	v.SetBorderPadding(0, 0, 1, 1)
 	v.updateTitle()

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -173,8 +173,7 @@ func (l *Log) BufferActive(state bool, k model.BufferKind) {
 // StylesChanged reports skin changes.
 func (l *Log) StylesChanged(s *config.Styles) {
 	l.SetBackgroundColor(s.Views().Log.BgColor.Color())
-	l.logs.SetTextColor(s.Views().Log.FgColor.Color())
-	l.logs.SetBackgroundColor(s.Views().Log.BgColor.Color())
+	l.logs.StylesChanged(s)
 }
 
 // GetModel returns the log model.

--- a/internal/view/logger.go
+++ b/internal/view/logger.go
@@ -37,8 +37,6 @@ func (l *Logger) Init(_ context.Context) error {
 	}
 	l.SetScrollable(true).SetWrap(true)
 	l.SetDynamicColors(true)
-	l.SetHighlightColor(tcell.ColorOrange)
-	l.SetTitleColor(tcell.ColorAqua)
 	l.SetInputCapture(l.keyboard)
 	l.SetBorderPadding(0, 0, 1, 1)
 
@@ -85,9 +83,9 @@ func (l *Logger) keyboard(evt *tcell.EventKey) *tcell.EventKey {
 
 // StylesChanged notifies the skin changed.
 func (l *Logger) StylesChanged(s *config.Styles) {
-	l.SetBackgroundColor(l.app.Styles.BgColor())
-	l.SetTextColor(l.app.Styles.FgColor())
-	l.SetBorderFocusColor(l.app.Styles.Frame().Border.FocusColor.Color())
+	l.SetBackgroundColor(s.Views().Log.BgColor.Color())
+	l.SetTextColor(s.Views().Log.FgColor.Color())
+	l.SetBackgroundColor(s.Views().Log.BgColor.Color())
 }
 
 // SetSubject updates the subject.

--- a/internal/view/popeye.go
+++ b/internal/view/popeye.go
@@ -23,8 +23,6 @@ func NewPopeye(gvr client.GVR) ResourceViewer {
 	p := Popeye{
 		ResourceViewer: NewBrowser(gvr),
 	}
-	p.GetTable().SetBorderFocusColor(tcell.ColorMediumSpringGreen)
-	p.GetTable().SetSelectedStyle(tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorMediumSpringGreen).Attributes(tcell.AttrNone))
 	p.GetTable().SetSortCol("SCORE%", true)
 	p.GetTable().SetDecorateFn(p.decorateRows)
 	p.AddBindKeysFn(p.bindKeys)

--- a/internal/view/reference.go
+++ b/internal/view/reference.go
@@ -18,8 +18,7 @@ func NewReference(gvr client.GVR) ResourceViewer {
 	r := Reference{
 		ResourceViewer: NewBrowser(gvr),
 	}
-	r.GetTable().SetBorderFocusColor(tcell.ColorMediumSpringGreen)
-	r.GetTable().SetSelectedStyle(tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorMediumSpringGreen).Attributes(tcell.AttrNone))
+
 	r.AddBindKeysFn(r.bindKeys)
 
 	return &r

--- a/internal/view/rs.go
+++ b/internal/view/rs.go
@@ -81,7 +81,7 @@ func (r *ReplicaSet) showModal(msg string, done func(int, string)) {
 	confirm := tview.NewModal().
 		AddButtons([]string{"Cancel", "OK"}).
 		SetButtonBackgroundColor(styles.ButtonBgColor.Color()).
-		SetTextColor(tcell.ColorFuchsia).
+		SetTextColor(styles.ButtonFgColor.Color()).
 		SetText(msg).
 		SetDoneFunc(done)
 	r.App().Content.AddPage("confirm", confirm, false, false)

--- a/internal/view/scale_extender.go
+++ b/internal/view/scale_extender.go
@@ -59,6 +59,7 @@ func (s *ScaleExtender) showScaleDialog(paths []string) {
 	if len(paths) > 1 {
 		msg = fmt.Sprintf("Scale [%d] %s?", len(paths), s.GVR().R())
 	}
+
 	confirm.SetText(msg)
 	confirm.SetDoneFunc(func(int, string) {
 		s.dismissDialog()
@@ -76,7 +77,15 @@ func (s *ScaleExtender) valueOf(col string) (string, error) {
 }
 
 func (s *ScaleExtender) makeScaleForm(sels []string) (*tview.Form, error) {
-	f := s.makeStyledForm()
+	f := tview.NewForm()
+	styles := s.App().Styles.Dialog()
+
+	f.SetItemPadding(0)
+	f.SetButtonsAlign(tview.AlignCenter).
+		SetButtonBackgroundColor(styles.ButtonBgColor.Color()).
+		SetButtonTextColor(styles.ButtonFgColor.Color()).
+		SetLabelColor(styles.LabelFgColor.Color()).
+		SetFieldTextColor(styles.FieldFgColor.Color())
 
 	factor := "0"
 	if len(sels) == 1 {
@@ -124,23 +133,20 @@ func (s *ScaleExtender) makeScaleForm(sels []string) (*tview.Form, error) {
 		s.dismissDialog()
 	})
 
+	for i := 0; i < f.GetButtonCount(); i++ {
+		b := f.GetButton(i)
+		if b == nil {
+			continue
+		}
+		b.SetBackgroundColorActivated(styles.ButtonFocusBgColor.Color())
+		b.SetLabelColorActivated(styles.ButtonFocusFgColor.Color())
+	}
+
 	return f, nil
 }
 
 func (s *ScaleExtender) dismissDialog() {
 	s.App().Content.RemovePage(scaleDialogKey)
-}
-
-func (s *ScaleExtender) makeStyledForm() *tview.Form {
-	f := tview.NewForm()
-	f.SetItemPadding(0)
-	f.SetButtonsAlign(tview.AlignCenter).
-		SetButtonBackgroundColor(tview.Styles.PrimitiveBackgroundColor).
-		SetButtonTextColor(tview.Styles.PrimaryTextColor).
-		SetLabelColor(tcell.ColorAqua).
-		SetFieldTextColor(tcell.ColorOrange)
-
-	return f
 }
 
 func (s *ScaleExtender) scale(ctx context.Context, path string, replicas int) error {

--- a/internal/view/screen_dump.go
+++ b/internal/view/screen_dump.go
@@ -9,7 +9,6 @@ import (
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/ui"
-	"github.com/derailed/tcell/v2"
 	"github.com/rs/zerolog/log"
 )
 
@@ -23,8 +22,6 @@ func NewScreenDump(gvr client.GVR) ResourceViewer {
 	s := ScreenDump{
 		ResourceViewer: NewBrowser(gvr),
 	}
-	s.GetTable().SetBorderFocusColor(tcell.ColorSteelBlue)
-	s.GetTable().SetSelectedStyle(tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorRoyalBlue).Attributes(tcell.AttrNone))
 	s.GetTable().SetSortCol(ageCol, true)
 	s.GetTable().SelectRow(1, true)
 	s.GetTable().SetEnterFn(s.edit)


### PR DESCRIPTION
Attempts to fix part of #1951 by removing the hardcoded colours and setting them to the appropriate values from `skin.yml` file.

The purpose was to remove places where colours were hardcoded. There are still forms of hardcoding the colours as these:
- [happy case](https://github.com/derailed/k9s/blob/master/internal/view/picker.go#L40), where there is still access to the `Style` struct
- [unhappy case](https://github.com/derailed/k9s/blob/v0.27.4/internal/render/rbac.go#L99), where the `Style` struct is not accessible

The PR becomes quite large so I just wanted an opinion if it's meaningful or not continue replacing hardcoded colours even further.