### PR TITLE
Add get-all plugin specific for namespace view

### DIFF
--- a/plugins/get-all.yml
+++ b/plugins/get-all.yml
@@ -1,6 +1,17 @@
 plugin:
   #get all resources in a namespace using the krew get-all plugin
-  get-all:
+  get-all-namespace:
+    shortCut: g
+    confirm: false
+    description: get-all
+    scopes:
+    - namespaces
+    command: sh
+    background: false
+    args:
+    - -c
+    - "kubectl get-all -n $NAME | less"
+  get-all-other:
     shortCut: g
     confirm: false
     description: get-all


### PR DESCRIPTION
This adds a second plugin configuration for get-all plugin. This enables to trigger get-all also from namespace view. Otherwise it won't work, as namespaces are a clusterwide resource and therefore $NAMESPACE is empty.