### PR TITLE
fix: (config) only respect the --command flag once

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -191,6 +191,10 @@ func (c *Config) ActiveView() string {
 	cmd := cl.View.Active
 	if c.K9s.manualCommand != nil && *c.K9s.manualCommand != "" {
 		cmd = *c.K9s.manualCommand
+		// We reset the manualCommand property because
+		// the command-line switch should only be considered once,
+		// on startup.
+		*c.K9s.manualCommand = ""
 	}
 
 	return cmd


### PR DESCRIPTION
We want to switch to the command specified by the flag, but only at startup.

Afterwards, we should be interactive and favor the user's command choices over the startup commandline switch.

**Sidenote**: I'm not very familiar with `k9s`'s codebase, so I didn't see any `.Lock()` I should be calling when updating the `*Config` object or if updating via pointer is not advised. Give me a hint and I'll run from there 😎

Bug introduced in #2045
Fixes #2085

cc: @kinoute (thank you for reporting this!)