### PR TITLE
feat: add indicator to title if toast is toggled

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,7 @@ k9s:
       highlightColor: skyblue
       counterColor: slateblue
       filterColor: slategray
+      toastIcon: "󰚌",
   views:
     # TableView attributes.
     table:

--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ k9s:
       highlightColor: skyblue
       counterColor: slateblue
       filterColor: slategray
-      toastIcon: "󰚌",
+      toastIndicator: "!",
   views:
     # TableView attributes.
     table:

--- a/internal/config/styles.go
+++ b/internal/config/styles.go
@@ -23,6 +23,8 @@ type (
 	// Color represents a color.
 	Color string
 
+	Icon string
+
 	// Colors tracks multiple colors.
 	Colors []Color
 
@@ -141,6 +143,7 @@ type (
 		HighlightColor Color `yaml:"highlightColor"`
 		CounterColor   Color `yaml:"counterColor"`
 		FilterColor    Color `yaml:"filterColor"`
+		ToastIcon      Icon  `yaml:"toastIcon"`
 	}
 
 	// Info tracks info styles.
@@ -391,6 +394,7 @@ func newTitle() Title {
 		HighlightColor: "fuchsia",
 		CounterColor:   "papayawhip",
 		FilterColor:    "seagreen",
+		ToastIcon:      "󰚌",
 	}
 }
 

--- a/internal/config/styles.go
+++ b/internal/config/styles.go
@@ -23,7 +23,8 @@ type (
 	// Color represents a color.
 	Color string
 
-	Icon string
+	// Indicator represent a string or emoji.
+	Indicator string
 
 	// Colors tracks multiple colors.
 	Colors []Color
@@ -138,12 +139,12 @@ type (
 
 	// Title tracks title styles.
 	Title struct {
-		FgColor        Color `yaml:"fgColor"`
-		BgColor        Color `yaml:"bgColor"`
-		HighlightColor Color `yaml:"highlightColor"`
-		CounterColor   Color `yaml:"counterColor"`
-		FilterColor    Color `yaml:"filterColor"`
-		ToastIcon      Icon  `yaml:"toastIcon"`
+		FgColor        Color     `yaml:"fgColor"`
+		BgColor        Color     `yaml:"bgColor"`
+		HighlightColor Color     `yaml:"highlightColor"`
+		CounterColor   Color     `yaml:"counterColor"`
+		FilterColor    Color     `yaml:"filterColor"`
+		ToastIndicator Indicator `yaml:"toastIndicator"`
 	}
 
 	// Info tracks info styles.
@@ -394,7 +395,7 @@ func newTitle() Title {
 		HighlightColor: "fuchsia",
 		CounterColor:   "papayawhip",
 		FilterColor:    "seagreen",
-		ToastIcon:      "󰚌",
+		ToastIndicator: "!",
 	}
 }
 

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -440,16 +440,17 @@ func (t *Table) styleTitle() string {
 	if t.Extras != "" {
 		ns = t.Extras
 	}
+
+	toastIndicator := t.styles.K9s.Frame.Title.ToastIndicator
+	if t.toast && toastIndicator != "" {
+		base = fmt.Sprintf("%s%s", base, toastIndicator)
+	}
+
 	var title string
 	if ns == client.ClusterScope {
 		title = SkinTitle(fmt.Sprintf(TitleFmt, base, rc), t.styles.Frame())
 	} else {
 		title = SkinTitle(fmt.Sprintf(NSTitleFmt, base, ns, rc), t.styles.Frame())
-	}
-
-	toastIcon := t.styles.K9s.Frame.Title.ToastIcon
-	if t.toast && toastIcon != "" {
-		title = fmt.Sprintf(" %s%s", toastIcon, title)
 	}
 
 	buff := t.cmdBuff.GetText()

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -447,6 +447,11 @@ func (t *Table) styleTitle() string {
 		title = SkinTitle(fmt.Sprintf(NSTitleFmt, base, ns, rc), t.styles.Frame())
 	}
 
+	toastIcon := t.styles.K9s.Frame.Title.ToastIcon
+	if t.toast && toastIcon != "" {
+		title = fmt.Sprintf(" %s%s", toastIcon, title)
+	}
+
 	buff := t.cmdBuff.GetText()
 	if buff == "" {
 		return title

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -2,6 +2,7 @@ package ui_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,20 +57,20 @@ func TestTableSelection(t *testing.T) {
 	assert.Equal(t, 1, v.GetSelectedRowIndex())
 }
 
-func TestToggleToastWithIcon(t *testing.T) {
+func TestToggleToastWithIndicator(t *testing.T) {
 	v := ui.NewTable(client.NewGVR("fred"))
 	v.Init(makeContext())
 	v.SetModel(&mockModel{})
 
-	icon := "🐶"
-	iconType := config.Icon(icon)
-	v.Styles().K9s.Frame.Title.ToastIcon = iconType
+	indicator := "Indicator"
+	v.Styles().K9s.Frame.Title.ToastIndicator = config.Indicator(indicator)
 	v.Update(makeTableData(), false)
 
 	initTitle := v.GetTitle()
+	expectedTitle := strings.Replace(initTitle, "Fred", "Fred"+indicator, 1)
 
 	v.ToggleToast()
-	assert.Equal(t, " "+icon+initTitle, v.GetTitle())
+	assert.Equal(t, expectedTitle, v.GetTitle())
 	v.ToggleToast()
 	assert.Equal(t, initTitle, v.GetTitle())
 }

--- a/internal/ui/table_test.go
+++ b/internal/ui/table_test.go
@@ -56,6 +56,24 @@ func TestTableSelection(t *testing.T) {
 	assert.Equal(t, 1, v.GetSelectedRowIndex())
 }
 
+func TestToggleToastWithIcon(t *testing.T) {
+	v := ui.NewTable(client.NewGVR("fred"))
+	v.Init(makeContext())
+	v.SetModel(&mockModel{})
+
+	icon := "🐶"
+	iconType := config.Icon(icon)
+	v.Styles().K9s.Frame.Title.ToastIcon = iconType
+	v.Update(makeTableData(), false)
+
+	initTitle := v.GetTitle()
+
+	v.ToggleToast()
+	assert.Equal(t, " "+icon+initTitle, v.GetTitle())
+	v.ToggleToast()
+	assert.Equal(t, initTitle, v.GetTitle())
+}
+
 // ----------------------------------------------------------------------------
 // Helpers...
 


### PR DESCRIPTION
Closes [issues/2052](https://github.com/derailed/k9s/issues/2052)

Hi. should this be turn off or on by default? Also do I need to update skins with `toastIcon`? Thanks