### PR TITLE
storageclasses view keeps the same output as kubectl get sc

### DIFF
--- a/internal/render/helpers.go
+++ b/internal/render/helpers.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/tview"
 	runewidth "github.com/mattn/go-runewidth"
 	"github.com/rs/zerolog/log"
@@ -14,6 +13,8 @@ import (
 	"golang.org/x/text/message"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
+
+	"github.com/derailed/k9s/internal/client"
 )
 
 func runesToNum(rr []rune) int64 {
@@ -296,6 +297,13 @@ func boolPtrToStr(b *bool) string {
 	}
 
 	return boolToStr(*b)
+}
+
+func strPtrToStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // Check if string is in a string list.

--- a/internal/render/helpers.go
+++ b/internal/render/helpers.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/tview"
 	runewidth "github.com/mattn/go-runewidth"
 	"github.com/rs/zerolog/log"
@@ -13,8 +14,6 @@ import (
 	"golang.org/x/text/message"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
-
-	"github.com/derailed/k9s/internal/client"
 )
 
 func runesToNum(rr []rune) int64 {

--- a/internal/render/sc.go
+++ b/internal/render/sc.go
@@ -3,13 +3,12 @@ package render
 import (
 	"fmt"
 
+	"github.com/derailed/k9s/internal/client"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubectl/pkg/util/storage"
-
-	"github.com/derailed/k9s/internal/client"
 )
 
 // StorageClass renders a K8s StorageClass to screen.
@@ -25,6 +24,8 @@ func (StorageClass) Header(ns string) Header {
 		HeaderColumn{Name: "RECLAIMPOLICY"},
 		HeaderColumn{Name: "VOLUMEBINDINGMODE"},
 		HeaderColumn{Name: "ALLOWVOLUMEEXPANSION"},
+		HeaderColumn{Name: "LABELS", Wide: true},
+		HeaderColumn{Name: "VALID", Wide: true},
 		HeaderColumn{Name: "AGE", Time: true},
 	}
 }
@@ -48,6 +49,8 @@ func (s StorageClass) Render(o interface{}, ns string, r *Row) error {
 		strPtrToStr((*string)(sc.ReclaimPolicy)),
 		strPtrToStr((*string)(sc.VolumeBindingMode)),
 		boolPtrToStr(sc.AllowVolumeExpansion),
+		mapToStr(sc.Labels),
+		"",
 		toAge(sc.GetCreationTimestamp()),
 	}
 

--- a/internal/render/sc_test.go
+++ b/internal/render/sc_test.go
@@ -3,9 +3,8 @@ package render_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/derailed/k9s/internal/render"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStorageClassRender(t *testing.T) {
@@ -14,5 +13,5 @@ func TestStorageClassRender(t *testing.T) {
 
 	assert.NoError(t, c.Render(load(t, "sc"), "", &r))
 	assert.Equal(t, "-/standard", r.ID)
-	assert.Equal(t, render.Fields{"standard (default)", "kubernetes.io/gce-pd"}, r.Fields[:2])
+	assert.Equal(t, render.Fields{"standard (default)", "kubernetes.io/gce-pd", "Delete", "Immediate", "true"}, r.Fields[:5])
 }

--- a/internal/render/sc_test.go
+++ b/internal/render/sc_test.go
@@ -3,8 +3,9 @@ package render_test
 import (
 	"testing"
 
-	"github.com/derailed/k9s/internal/render"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/derailed/k9s/internal/render"
 )
 
 func TestStorageClassRender(t *testing.T) {
@@ -13,5 +14,5 @@ func TestStorageClassRender(t *testing.T) {
 
 	assert.NoError(t, c.Render(load(t, "sc"), "", &r))
 	assert.Equal(t, "-/standard", r.ID)
-	assert.Equal(t, render.Fields{"standard", "kubernetes.io/gce-pd"}, r.Fields[:2])
+	assert.Equal(t, render.Fields{"standard (default)", "kubernetes.io/gce-pd"}, r.Fields[:2])
 }

--- a/internal/render/testdata/sc.json
+++ b/internal/render/testdata/sc.json
@@ -20,5 +20,6 @@
   },
   "provisioner": "kubernetes.io/gce-pd",
   "reclaimPolicy": "Delete",
-  "volumeBindingMode": "Immediate"
+  "volumeBindingMode": "Immediate",
+  "allowVolumeExpansion": true
 }


### PR DESCRIPTION
This adds the "default" marks to the name of the storageclasses, for ease of preview. Add same fields to the view to suggest some useful information(same as kubectl get sc output).