### PR TITLE
Remove unsupported key binding on users view

### DIFF
--- a/internal/view/user.go
+++ b/internal/view/user.go
@@ -3,10 +3,11 @@ package view
 import (
 	"context"
 
+	"github.com/derailed/tcell/v2"
+
 	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/ui"
-	"github.com/derailed/tcell/v2"
 )
 
 // User presents a user viewer.
@@ -24,7 +25,7 @@ func NewUser(gvr client.GVR) ResourceViewer {
 }
 
 func (u *User) bindKeys(aa ui.KeyActions) {
-	aa.Delete(ui.KeyShiftA, ui.KeyShiftP, tcell.KeyCtrlSpace, ui.KeySpace)
+	aa.Delete(ui.KeyShiftA, ui.KeyShiftP, tcell.KeyCtrlSpace, ui.KeySpace, tcell.KeyCtrlD, ui.KeyE)
 	aa.Add(ui.KeyActions{
 		tcell.KeyEnter: ui.NewKeyAction("Rules", u.policyCmd, true),
 		ui.KeyShiftK:   ui.NewKeyAction("Sort Kind", u.GetTable().SortColCmd("KIND", true), false),


### PR DESCRIPTION
Avoid pressing e and ctrl-d on the users view causing screen flickering problems.