### PR TITLE
Show the default container as the first entry

### DIFF
--- a/internal/dao/pod.go
+++ b/internal/dao/pod.go
@@ -33,9 +33,9 @@ var (
 )
 
 const (
-	logRetryCount                 = 20
-	logRetryWait                  = 1 * time.Second
-	defaultLogContainerAnnotation = "kubectl.kubernetes.io/default-logs-container"
+	logRetryCount              = 20
+	logRetryWait               = 1 * time.Second
+	defaultContainerAnnotation = "kubectl.kubernetes.io/default-container"
 )
 
 // Pod represents a pod resource.
@@ -197,7 +197,7 @@ func (p *Pod) TailLogs(ctx context.Context, opts *LogOptions) ([]LogChan, error)
 	}
 
 	outs := make([]LogChan, 0, coCounts)
-	if co, ok := GetDefaultLogContainer(po.ObjectMeta, po.Spec); ok && !opts.AllContainers {
+	if co, ok := GetDefaultContainer(po.ObjectMeta, po.Spec); ok && !opts.AllContainers {
 		opts.DefaultContainer = co
 		return append(outs, tailLogs(ctx, p, opts)), nil
 	}
@@ -486,16 +486,16 @@ func (p *Pod) isControlled(path string) (string, bool, error) {
 	return "", false, nil
 }
 
-// GetDefaultLogContainer returns a container name if specified in an annotation.
-func GetDefaultLogContainer(m metav1.ObjectMeta, spec v1.PodSpec) (string, bool) {
-	defaultContainer, ok := m.Annotations[defaultLogContainerAnnotation]
+// GetDefaultContainer returns a container name if specified in an annotation.
+func GetDefaultContainer(m metav1.ObjectMeta, spec v1.PodSpec) (string, bool) {
+	defaultContainer, ok := m.Annotations[defaultContainerAnnotation]
 	if ok {
 		for _, container := range spec.Containers {
 			if container.Name == defaultContainer {
 				return defaultContainer, true
 			}
 		}
-		log.Warn().Msg(defaultContainer + " container  not found. " + defaultLogContainerAnnotation + " annotation will be ignored")
+		log.Warn().Msg(defaultContainer + " container  not found. " + defaultContainerAnnotation + " annotation will be ignored")
 	}
 
 	return "", false

--- a/internal/dao/pod_test.go
+++ b/internal/dao/pod_test.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestGetDefaultLogContainer(t *testing.T) {
+func TestGetDefaultContainer(t *testing.T) {
 	uu := map[string]struct {
 		po            *v1.Pod
 		wantContainer string
@@ -26,7 +26,7 @@ func TestGetDefaultLogContainer(t *testing.T) {
 		"container_not_present": {
 			po: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"kubectl.kubernetes.io/default-logs-container": "container1"},
+					Annotations: map[string]string{"kubectl.kubernetes.io/default-container": "container1"},
 				},
 			},
 			wantContainer: "",
@@ -35,7 +35,7 @@ func TestGetDefaultLogContainer(t *testing.T) {
 		"container_found": {
 			po: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"kubectl.kubernetes.io/default-logs-container": "container1"},
+					Annotations: map[string]string{"kubectl.kubernetes.io/default-container": "container1"},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{Name: "container1"}},
@@ -48,7 +48,7 @@ func TestGetDefaultLogContainer(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			container, ok := GetDefaultLogContainer(u.po.ObjectMeta, u.po.Spec)
+			container, ok := GetDefaultContainer(u.po.ObjectMeta, u.po.Spec)
 			assert.Equal(t, u.wantContainer, container)
 			assert.Equal(t, u.wantOk, ok)
 		})

--- a/internal/view/dp.go
+++ b/internal/view/dp.go
@@ -59,7 +59,7 @@ func (d *Deploy) logOptions(prev bool) (*dao.LogOptions, error) {
 		co, dco string
 		allCos  bool
 	)
-	if c, ok := dao.GetDefaultLogContainer(sts.Spec.Template.ObjectMeta, sts.Spec.Template.Spec); ok {
+	if c, ok := dao.GetDefaultContainer(sts.Spec.Template.ObjectMeta, sts.Spec.Template.Spec); ok {
 		co, dco = c, c
 	} else if len(cc) == 1 {
 		co = cc[0].Name

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/rs/zerolog/log"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -95,7 +96,7 @@ func (p *Pod) logOptions(prev bool) (*dao.LogOptions, error) {
 		return nil, err
 	}
 
-	cc, cfg := fetchContainers(pod.Spec, true), p.App().Config.K9s.Logger
+	cc, cfg := fetchContainers(pod.ObjectMeta, pod.Spec, true), p.App().Config.K9s.Logger
 	opts := dao.LogOptions{
 		Path:            path,
 		Lines:           int64(cfg.TailCount),
@@ -261,7 +262,7 @@ func containerShellin(a *App, comp model.Component, path, co string) error {
 	if err != nil {
 		return err
 	}
-	cc := fetchContainers(pod.Spec, false)
+	cc := fetchContainers(pod.ObjectMeta, pod.Spec, false)
 	if len(cc) == 1 {
 		resumeShellIn(a, comp, path, cc[0])
 		return nil
@@ -305,7 +306,7 @@ func containerAttachIn(a *App, comp model.Component, path, co string) error {
 	if err != nil {
 		return err
 	}
-	cc := fetchContainers(pod.Spec, false)
+	cc := fetchContainers(pod.ObjectMeta, pod.Spec, false)
 	if len(cc) == 1 {
 		resumeAttachIn(a, comp, path, cc[0])
 		return nil
@@ -363,10 +364,19 @@ func buildShellArgs(cmd, path, co string, kcfg *string) []string {
 	return args
 }
 
-func fetchContainers(spec v1.PodSpec, allContainers bool) []string {
+func fetchContainers(meta metav1.ObjectMeta, spec v1.PodSpec, allContainers bool) []string {
 	nn := make([]string, 0, len(spec.Containers)+len(spec.InitContainers))
+
+	// put the default container as the first entry
+	defaultContainer, hasDefaultContainer := dao.GetDefaultContainer(meta, spec)
+	if hasDefaultContainer {
+		nn = append(nn, defaultContainer)
+	}
+
 	for _, c := range spec.Containers {
-		nn = append(nn, c.Name)
+		if !hasDefaultContainer || c.Name != defaultContainer {
+			nn = append(nn, c.Name)
+		}
 	}
 	if !allContainers {
 		return nn

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -104,7 +104,7 @@ func (p *Pod) logOptions(prev bool) (*dao.LogOptions, error) {
 		ShowTimestamp:   cfg.ShowTime,
 		Previous:        prev,
 	}
-	if c, ok := dao.GetDefaultLogContainer(pod.ObjectMeta, pod.Spec); ok {
+	if c, ok := dao.GetDefaultContainer(pod.ObjectMeta, pod.Spec); ok {
 		opts.Container, opts.DefaultContainer = c, c
 	} else if len(cc) == 1 {
 		opts.Container = cc[0]

--- a/internal/view/sts.go
+++ b/internal/view/sts.go
@@ -48,7 +48,7 @@ func (s *StatefulSet) logOptions(prev bool) (*dao.LogOptions, error) {
 		co, dco string
 		allCos  bool
 	)
-	if c, ok := dao.GetDefaultLogContainer(sts.Spec.Template.ObjectMeta, sts.Spec.Template.Spec); ok {
+	if c, ok := dao.GetDefaultContainer(sts.Spec.Template.ObjectMeta, sts.Spec.Template.Spec); ok {
 		co, dco = c, c
 	} else if len(cc) == 1 {
 		co = cc[0].Name


### PR DESCRIPTION
* In container selections show the default container as the first entry of the list.
   Allows one to quickly press s, enter to shell into the default container.
* Switch to the new kubectl.kubernetes.io/default-container pod annotation
   kubectl.kubernetes.io/default-logs-container has been deprecated and removed in kubectl, see https://github.com/kubernetes/kubernetes/commit/3a9c6f2a2f59cb05fc505f66afe2bd923a0d9f58