### PR TITLE
Only apply keyConv to mnemonic in menus

### DIFF
--- a/internal/ui/menu.go
+++ b/internal/ui/menu.go
@@ -148,7 +148,7 @@ func (m *Menu) buildMenuTable(hh model.MenuHints, table []model.MenuHints, colCo
 func (m *Menu) layout(table []model.MenuHints, mm []int, out [][]string) {
 	for r := range table {
 		for c := range table[r] {
-			out[r][c] = keyConv(m.formatMenu(table[r][c], mm[c]))
+			out[r][c] = m.formatMenu(table[r][c], mm[c])
 		}
 	}
 }


### PR DESCRIPTION
This fixes an issue where namespaces with "alt" in the name get replaced by "opt" when running on macOS.