### PR TITLE
Add env var to disable node pod counts

### DIFF
--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -27,6 +27,7 @@ type K9s struct {
 	Clusters            map[string]*Cluster `yaml:"clusters,omitempty"`
 	Thresholds          Threshold           `yaml:"thresholds"`
 	ScreenDumpDir       string              `yaml:"screenDumpDir"`
+	DisablePodCounting  bool                `yaml:"disablePodCounting"`
 	manualRefreshRate   int
 	manualHeadless      *bool
 	manualLogoless      *bool

--- a/internal/dao/node.go
+++ b/internal/dao/node.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
@@ -146,7 +145,7 @@ func (n *Node) List(ctx context.Context, ns string) ([]runtime.Object, error) {
 		nmx, _ = client.DialMetrics(n.Client()).FetchNodesMetricsMap(ctx)
 	}
 
-	shouldCountPods := os.Getenv("K9S_DISABLE_POD_COUNTING") != "true"
+	shouldCountPods, _ := ctx.Value(internal.KeyPodCounting).(bool)
 
 	res := make([]runtime.Object, 0, len(oo))
 	for _, o := range oo {

--- a/internal/keys.go
+++ b/internal/keys.go
@@ -30,4 +30,5 @@ const (
 	KeyWithMetrics ContextKey = "withMetrics"
 	KeyViewConfig  ContextKey = "viewConfig"
 	KeyWait        ContextKey = "wait"
+	KeyPodCounting ContextKey = "podCounting"
 )

--- a/internal/view/node.go
+++ b/internal/view/node.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/dao"
 	"github.com/derailed/k9s/internal/ui"
@@ -26,8 +27,13 @@ func NewNode(gvr client.GVR) ResourceViewer {
 	}
 	n.AddBindKeysFn(n.bindKeys)
 	n.GetTable().SetEnterFn(n.showPods)
+	n.SetContextFn(n.aliasContext)
 
 	return &n
+}
+
+func (n *Node) aliasContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, internal.KeyPodCounting, !n.App().Config.K9s.DisablePodCounting)
 }
 
 func (n *Node) bindDangerousKeys(aa ui.KeyActions) {

--- a/internal/view/node.go
+++ b/internal/view/node.go
@@ -27,12 +27,12 @@ func NewNode(gvr client.GVR) ResourceViewer {
 	}
 	n.AddBindKeysFn(n.bindKeys)
 	n.GetTable().SetEnterFn(n.showPods)
-	n.SetContextFn(n.aliasContext)
+	n.SetContextFn(n.nodeContext)
 
 	return &n
 }
 
-func (n *Node) aliasContext(ctx context.Context) context.Context {
+func (n *Node) nodeContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, internal.KeyPodCounting, !n.App().Config.K9s.DisablePodCounting)
 }
 


### PR DESCRIPTION
Some of our clusters are really big with tens of thousands of pods running. The pod counting fetches them all which consumes multiple GB's of memory to do plus a significant load on the API side. This adds a simple env var to disable it.

I did have a quick look to see if it would be passable as a config option but couldn't figure out how!