### PR TITLE
Add namespace for rolebinding on a clusterrole

### DIFF
--- a/internal/dao/rbac_policy.go
+++ b/internal/dao/rbac_policy.go
@@ -175,26 +175,6 @@ func (p *Policy) fetchRoleBindingNamespaces(kind, name string) (map[string]strin
 	return ss, nil
 }
 
-func (p *Policy) fetchRoleBindingSubjects(kind, name string) ([]string, error) {
-	rbs, err := fetchRoleBindings(p.Factory)
-	if err != nil {
-		return nil, err
-	}
-
-	ns, n := client.Namespaced(name)
-	ss := make([]string, 0, len(rbs))
-	for _, rb := range rbs {
-		for _, s := range rb.Subjects {
-			s := s
-			if isSameSubject(kind, ns, n, &s) {
-				ss = append(ss, rb.RoleRef.Kind+":"+rb.RoleRef.Name)
-			}
-		}
-	}
-
-	return ss, nil
-}
-
 // isSameSubject verifies if the incoming type name and namespace match a subject from a
 // cluster/roleBinding. A ServiceAccount will always have a namespace and needs to be validated to ensure
 // we don't display permissions for a ServiceAccount with the same name in a different namespace

--- a/internal/dao/rbac_policy.go
+++ b/internal/dao/rbac_policy.go
@@ -88,21 +88,20 @@ func (p *Policy) loadClusterRoleBinding(kind, name string) (render.Policies, err
 }
 
 func (p *Policy) loadRoleBinding(kind, name string) (render.Policies, error) {
-	ss, err := p.fetchRoleBindingSubjects(kind, name)
+	rbsMap, err := p.fetchRoleBindingNamespaces(kind, name)
 	if err != nil {
 		return nil, err
 	}
-
 	crs, err := p.fetchClusterRoles()
 	if err != nil {
 		return nil, err
 	}
 	rows := make(render.Policies, 0, len(crs))
 	for _, cr := range crs {
-		if !inList(ss, "ClusterRole:"+cr.Name) {
-			continue
+		if rbNs, ok := rbsMap["ClusterRole:"+cr.Name]; ok {
+			log.Debug().Msgf("Loading rules for clusterrole %q:%q", rbNs, cr.Name)
+			rows = append(rows, parseRules(rbNs, "CR:"+cr.Name, cr.Rules)...)
 		}
-		rows = append(rows, parseRules("*", "CR:"+cr.Name, cr.Rules)...)
 	}
 
 	ros, err := p.fetchRoles()
@@ -110,7 +109,7 @@ func (p *Policy) loadRoleBinding(kind, name string) (render.Policies, error) {
 		return nil, err
 	}
 	for _, ro := range ros {
-		if !inList(ss, "Role:"+ro.Name) {
+		if _, ok := rbsMap["Role:"+ro.Name]; !ok {
 			continue
 		}
 		log.Debug().Msgf("Loading rules for role %q:%q", ro.Namespace, ro.Name)
@@ -154,6 +153,26 @@ func fetchRoleBindings(f Factory) ([]rbacv1.RoleBinding, error) {
 	}
 
 	return rbs, nil
+}
+
+func (p *Policy) fetchRoleBindingNamespaces(kind, name string) (map[string]string, error) {
+	rbs, err := fetchRoleBindings(p.Factory)
+	if err != nil {
+		return nil, err
+	}
+
+	ns, n := client.Namespaced(name)
+	ss := make(map[string]string, len(rbs))
+	for _, rb := range rbs {
+		for _, s := range rb.Subjects {
+			s := s
+			if isSameSubject(kind, ns, n, &s) {
+				ss[rb.RoleRef.Kind+":"+rb.RoleRef.Name] = rb.Namespace
+			}
+		}
+	}
+
+	return ss, nil
 }
 
 func (p *Policy) fetchRoleBindingSubjects(kind, name string) ([]string, error) {


### PR DESCRIPTION
A ClusterRole can be attached to a ServiceAccount via a RoleBinding, granting access only to a specific namespace. This PR adds the namespace name to the ServiceAccount Policy view, for ClusterRoles bound with a RoleBinding.

Fixes #2169

### Implementation

I modified the existing code, to keep a map of all the RoleBindings types mapped to namespace.