### PR TITLE
Focus command bar if active on startup

### DIFF
--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -466,6 +466,10 @@ func (a *App) Run() error {
 		<-time.After(splashDelay)
 		a.QueueUpdateDraw(func() {
 			a.Main.SwitchToPage("main")
+			// if command bar is already active, focus it
+			if a.CmdBuff().IsActive() {
+				a.SetFocus(a.Prompt())
+			}
 		})
 	}()
 


### PR DESCRIPTION
If the command bar was activated with `:` before or during the splash delay, the main page would steal focus from it, breaking the UI.

This patch re-focuses the command bar if its active after switching focus to the main page.

Fixes issue #2178