### PR TITLE
feat: Added support for arm in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ ARG KUBECTL_VERSION="v1.25.2"
 COPY --from=build /k9s/execs/k9s /bin/k9s
 RUN apk add --update ca-certificates \
   && apk add --update -t deps curl vim \
-  && arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
-  && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl -o /usr/local/bin/kubectl \
+  && TARGET_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
+  && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${TARGET_ARCH}/kubectl -o /usr/local/bin/kubectl \
   && chmod +x /usr/local/bin/kubectl \
   && apk del --purge deps \
   && rm /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ ARG KUBECTL_VERSION="v1.25.2"
 COPY --from=build /k9s/execs/k9s /bin/k9s
 RUN apk add --update ca-certificates \
   && apk add --update -t deps curl vim \
-  && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+  && arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
+  && echo $arch && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl -o /usr/local/bin/kubectl \
   && chmod +x /usr/local/bin/kubectl \
   && apk del --purge deps \
   && rm /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY --from=build /k9s/execs/k9s /bin/k9s
 RUN apk add --update ca-certificates \
   && apk add --update -t deps curl vim \
   && arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
-  && echo $arch && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl -o /usr/local/bin/kubectl \
+  && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl -o /usr/local/bin/kubectl \
   && chmod +x /usr/local/bin/kubectl \
   && apk del --purge deps \
   && rm /var/cache/apk/*


### PR DESCRIPTION
Running k9s containerized has errors while running on ARM based host because kubectl is being downloaded for AMD only. Hence attach terminal etc. doesn't work

This PR resolves that issue when we build muti-arch images from same dockerfile

I have already tested this on my own multiple multi-arch k8s clusters