### PR TITLE
Alias `qa` to quit.

### DIFF
--- a/internal/config/alias.go
+++ b/internal/config/alias.go
@@ -143,7 +143,7 @@ func (a *Aliases) loadDefaultAliases() {
 	a.Alias["np"] = "networking.k8s.io/v1/networkpolicies"
 
 	a.declare("help", "h", "?")
-	a.declare("quit", "q", "q!", "Q")
+	a.declare("quit", "q", "q!", "qa", "Q")
 	a.declare("aliases", "alias", "a")
 	a.declare("popeye", "pop")
 	a.declare("helm", "charts", "chart", "hm")

--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -180,7 +180,7 @@ func (c *Command) specialCmd(cmd, path string) bool {
 	case "cow":
 		c.app.cowCmd(path)
 		return true
-	case "q", "q!", "Q", "quit":
+	case "q", "q!", "qa", "Q", "quit":
 		c.app.BailOut()
 		return true
 	case "?", "h", "help":


### PR DESCRIPTION
This adds an additional alias for "quit". `qa` is muscle memory for vimmers, and fits in well alongside `q` and `q!`.

Resolves #856