### PR TITLE
Use current k9s NS if new context has no default NS

### DIFF
--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -94,6 +94,19 @@ func (c *Config) CurrentContextName() (string, error) {
 	return cfg.CurrentContext, nil
 }
 
+func (c *Config) CurrentContextNamespace() (string, error) {
+	name, err := c.CurrentContextName()
+	if err != nil {
+		return "", err
+	}
+	context, err := c.GetContext(name)
+	if err != nil {
+		return "", err
+	}
+
+	return context.Namespace, nil
+}
+
 // GetContext fetch a given context or error if it does not exists.
 func (c *Config) GetContext(n string) (*clientcmdapi.Context, error) {
 	cfg, err := c.RawConfig()
@@ -282,6 +295,13 @@ func (c *Config) CurrentUserName() (string, error) {
 // CurrentNamespaceName retrieves the active namespace.
 func (c *Config) CurrentNamespaceName() (string, error) {
 	ns, _, err := c.clientConfig().Namespace()
+
+	if ns == "default" {
+		ns, err = c.CurrentContextNamespace()
+		if ns == "" && err == nil {
+			return "", errors.New("No namespace specified in context")
+		}
+	}
 
 	return ns, err
 }

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -111,7 +111,7 @@ func TestConfigCurrentNamespace(t *testing.T) {
 	}{
 		"default": {
 			flags:     &genericclioptions.ConfigFlags{KubeConfig: &kubeConfig},
-			namespace: "default",
+			namespace: "",
 		},
 		"withContext": {
 			flags:     &genericclioptions.ConfigFlags{KubeConfig: &kubeConfig, Context: &bleeCTX},
@@ -128,7 +128,9 @@ func TestConfigCurrentNamespace(t *testing.T) {
 		t.Run(k, func(t *testing.T) {
 			cfg := client.NewConfig(u.flags)
 			ns, err := cfg.CurrentNamespaceName()
-			assert.Nil(t, err)
+			if ns != "" {
+				assert.Nil(t, err)
+			}
 			assert.Equal(t, u.namespace, ns)
 		})
 	}

--- a/internal/dao/testdata/config
+++ b/internal/dao/testdata/config
@@ -21,6 +21,7 @@ contexts:
   name: fred
 - context:
     cluster: blee
+    namespace: zorg
     user: blee
   name: blee
 - context:

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -402,10 +402,7 @@ func (a *App) switchContext(name string) error {
 	a.Halt()
 	defer a.Resume()
 	{
-		ns, err := a.Conn().Config().CurrentNamespaceName()
-		if err != nil {
-			log.Warn().Msg("No namespace specified in context. Using K9s config")
-		}
+		ns := a.Config.ActiveNamespace()
 		a.initFactory(ns)
 
 		if e := a.command.Reset(true); e != nil {

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -402,7 +402,11 @@ func (a *App) switchContext(name string) error {
 	a.Halt()
 	defer a.Resume()
 	{
-		ns := a.Config.ActiveNamespace()
+		ns, err := a.Conn().Config().CurrentNamespaceName()
+		if err != nil {
+			log.Warn().Msg("No namespace specified in context. Using K9s config")
+			ns = a.Config.ActiveNamespace()
+		}
 		a.initFactory(ns)
 
 		if e := a.command.Reset(true); e != nil {


### PR DESCRIPTION
closes #1461 

Switching context causes resetting active namespace for now and as a result `default` NS is always activated.