### PR TITLE
fix(#1359): add option to keep missing clusters in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,8 @@ K9s uses aliases to navigate most K8s resources.
     currentContext: minikube
     # Indicates the current kube cluster. Defaults to current context cluster
     currentCluster: minikube
+    # KeepMissingClusters will keep clusters in the config if they are missing from the current kubeconfig file. Default false
+    KeepMissingClusters: false
     # Persists per cluster preferences for favorite namespaces and view.
     clusters:
       coolio:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -296,6 +296,7 @@ var expectedConfig = `k9s:
     showTime: false
   currentContext: blee
   currentCluster: blee
+  keepMissingClusters: false
   clusters:
     blee:
       namespace:
@@ -395,6 +396,7 @@ var resetConfig = `k9s:
     showTime: false
   currentContext: blee
   currentCluster: blee
+  keepMissingClusters: false
   clusters:
     blee:
       namespace:

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -24,6 +24,7 @@ type K9s struct {
 	Logger              *Logger             `yaml:"logger"`
 	CurrentContext      string              `yaml:"currentContext"`
 	CurrentCluster      string              `yaml:"currentCluster"`
+	KeepMissingClusters bool                `yaml:"keepMissingClusters"`
 	Clusters            map[string]*Cluster `yaml:"clusters,omitempty"`
 	Thresholds          Threshold           `yaml:"thresholds"`
 	ScreenDumpDir       string              `yaml:"screenDumpDir"`
@@ -205,9 +206,17 @@ func (k *K9s) validateClusters(c client.Connection, ks KubeSettings) {
 	}
 	for key, cluster := range k.Clusters {
 		cluster.Validate(c, ks)
+		// if the cluster is defined in the $KUBECONFIG file, keep it in the k9s config file
 		if _, ok := cc[key]; ok {
 			continue
 		}
+
+		// if we asked to keep the clusters in the config file
+		if k.KeepMissingClusters {
+			continue
+		}
+
+		// else remove it from the k9s config file
 		if k.CurrentCluster == key {
 			k.CurrentCluster = ""
 		}


### PR DESCRIPTION
Hey !

First of all I love this project, thanks for maintaining it :) 

This PR adds an option to keep "missing" clusters in the k9s config, which is useful when the user is using multiple Kubeconfig files.
The default mechanism is still to remove clusters missing from the k9s config.

Link to issue : https://github.com/derailed/k9s/issues/1359 