### PR TITLE
Added plugin to download full container logs

### DIFF
--- a/plugins/log_full.yml
+++ b/plugins/log_full.yml
@@ -53,3 +53,13 @@ plugin:
     - $NAMESPACE
     - --context
     - $CONTEXT
+  download-container-logs:
+    shortCut: Ctrl-D
+    description: "download full log"
+    scopes:
+    - containers
+    command: bash
+    background: true
+    args:
+    - -c 
+    - "kubectl logs -n $NAMESPACE $POD -c $NAME --context $CONTEXT > $POD.log"


### PR DESCRIPTION
Added a new plugin command to download full container logs to local, it is useful when logs are very large after downloading can check the logs easily on local.

Command shortcut:- **Ctrl-D**
