### PR TITLE
Switch install instructions to use the core homebrew formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ K9s is available on Linux, macOS and Windows platforms.
 * Via [Homebrew](https://brew.sh/) for macOS or Linux
 
    ```shell
-   brew install derailed/k9s/k9s
+   brew install k9s
    ```
 
 * Via [MacPorts](https://www.macports.org)


### PR DESCRIPTION
`k9s` has been bundled via the core Homebrew tap [for a while](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/k/k9s.rb). 

There is some confusion around using the homebrew formula vs `derailed/k9s/k9s`. I personally prefer the `homebrew-core` tap - is there a specific reason the documentation specifies to use the `derailed/k9s/k9s` tap?