### PR TITLE
docs: add plugin.yml JSON schema

### DIFF
--- a/plugins/schema.json
+++ b/plugins/schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Schema for k9s CLI plugin.yml file : https://k9scli.io/topics/plugins",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "plugin": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "shortCut": {
+            "description": "Define a mnemonic to invoke the plugin",
+            "type": "string"
+          },
+          "description": {
+            "description": "What will be shown on the K9s menu",
+            "type": "string"
+          },
+          "confirm": {
+            "description": "See the command that is going to be executed and gives you an option to confirm",
+            "type": "boolean"
+          },
+          "scopes": {
+            "type": "array",
+            "description": "Collections of views that support this shortcut. (You can use `all`)",
+            "items": {
+              "type": "string"
+            }
+          },
+          "command": {
+            "description": "The command to run upon invocation. Can use Krew plugins here too!",
+            "type": "string"
+          },
+          "background": {
+            "description": "Whether or not to run the command in background mode",
+            "type": "boolean"
+          },
+          "args": {
+            "description": "Defines the command arguments",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["shortCut", "description", "scopes", "command"]
+      },
+      "required": []
+    }
+  },
+  "required": ["plugin"]
+}


### PR DESCRIPTION
This adds a JSON schema for the `plugin.yml` file.

One can later reference it on [SchemaStore](https://www.schemastore.org/json/) so we can get documentation and validation right from any SchemaStore compatible editor :)