### PR TITLE
fix: honor defaults from drain dialog in request

### DIFF
--- a/internal/view/drain_dialog.go
+++ b/internal/view/drain_dialog.go
@@ -15,7 +15,7 @@ const drainKey = "drain"
 type DrainFunc func(v ResourceViewer, path string, opts dao.DrainOptions)
 
 // ShowDrain pops a node drain dialog.
-func ShowDrain(view ResourceViewer, path string, defaults dao.DrainOptions, okFn DrainFunc) {
+func ShowDrain(view ResourceViewer, path string, opts dao.DrainOptions, okFn DrainFunc) {
 	styles := view.App().Styles
 
 	f := tview.NewForm()
@@ -26,13 +26,6 @@ func ShowDrain(view ResourceViewer, path string, defaults dao.DrainOptions, okFn
 		SetLabelColor(styles.K9s.Info.FgColor.Color()).
 		SetFieldTextColor(styles.K9s.Info.SectionColor.Color())
 
-	opts := dao.DrainOptions{
-		GracePeriodSeconds:  defaults.GracePeriodSeconds,
-		Timeout:             defaults.Timeout,
-		IgnoreAllDaemonSets: defaults.IgnoreAllDaemonSets,
-		DeleteEmptyDirData:  defaults.DeleteEmptyDirData,
-		Force:               defaults.Force,
-	}
 	f.AddInputField("GracePeriod:", strconv.Itoa(defaults.GracePeriodSeconds), 0, nil, func(v string) {
 		a, err := asIntOpt(v)
 		if err != nil {

--- a/internal/view/drain_dialog.go
+++ b/internal/view/drain_dialog.go
@@ -26,7 +26,13 @@ func ShowDrain(view ResourceViewer, path string, defaults dao.DrainOptions, okFn
 		SetLabelColor(styles.K9s.Info.FgColor.Color()).
 		SetFieldTextColor(styles.K9s.Info.SectionColor.Color())
 
-	var opts dao.DrainOptions
+	opts := dao.DrainOptions{
+		GracePeriodSeconds:  defaults.GracePeriodSeconds,
+		Timeout:             defaults.Timeout,
+		IgnoreAllDaemonSets: defaults.IgnoreAllDaemonSets,
+		DeleteEmptyDirData:  defaults.DeleteEmptyDirData,
+		Force:               defaults.Force,
+	}
 	f.AddInputField("GracePeriod:", strconv.Itoa(defaults.GracePeriodSeconds), 0, nil, func(v string) {
 		a, err := asIntOpt(v)
 		if err != nil {

--- a/internal/view/drain_dialog.go
+++ b/internal/view/drain_dialog.go
@@ -26,7 +26,7 @@ func ShowDrain(view ResourceViewer, path string, opts dao.DrainOptions, okFn Dra
 		SetLabelColor(styles.K9s.Info.FgColor.Color()).
 		SetFieldTextColor(styles.K9s.Info.SectionColor.Color())
 
-	f.AddInputField("GracePeriod:", strconv.Itoa(defaults.GracePeriodSeconds), 0, nil, func(v string) {
+	f.AddInputField("GracePeriod:", strconv.Itoa(opts.GracePeriodSeconds), 0, nil, func(v string) {
 		a, err := asIntOpt(v)
 		if err != nil {
 			view.App().Flash().Err(err)
@@ -35,7 +35,7 @@ func ShowDrain(view ResourceViewer, path string, opts dao.DrainOptions, okFn Dra
 		view.App().Flash().Clear()
 		opts.GracePeriodSeconds = a
 	})
-	f.AddInputField("Timeout:", defaults.Timeout.String(), 0, nil, func(v string) {
+	f.AddInputField("Timeout:", opts.Timeout.String(), 0, nil, func(v string) {
 		a, err := asDurOpt(v)
 		if err != nil {
 			view.App().Flash().Err(err)
@@ -44,13 +44,13 @@ func ShowDrain(view ResourceViewer, path string, opts dao.DrainOptions, okFn Dra
 		view.App().Flash().Clear()
 		opts.Timeout = a
 	})
-	f.AddCheckbox("Ignore DaemonSets:", defaults.IgnoreAllDaemonSets, func(_ string, v bool) {
+	f.AddCheckbox("Ignore DaemonSets:", opts.IgnoreAllDaemonSets, func(_ string, v bool) {
 		opts.IgnoreAllDaemonSets = v
 	})
-	f.AddCheckbox("Delete Local Data:", defaults.DeleteEmptyDirData, func(_ string, v bool) {
+	f.AddCheckbox("Delete Local Data:", opts.DeleteEmptyDirData, func(_ string, v bool) {
 		opts.DeleteEmptyDirData = v
 	})
-	f.AddCheckbox("Force:", defaults.Force, func(_ string, v bool) {
+	f.AddCheckbox("Force:", opts.Force, func(_ string, v bool) {
 		opts.Force = v
 	})
 


### PR DESCRIPTION
**Describe the bug**

Draining a node doesn't honor default values shown in the dialog. In particular drain happens with grace period of 0s instead of the default of -1

**How to Reproduce**

When draining a node, we noticed that when you do not modify the default gracePeriod of -1 from the UI, based on the API logs it is sending `gracePeriod: 0`, which it's pretty similar to a force non-graceful termination which doesn't let the termination flow go.

![image](https://github.com/derailed/k9s/assets/55707366/bd3996b5-cebf-498b-be61-51adcac6304a)

If we update the default to a different value, that other value is the one that is sent as expected

If you delete the default gracePeriod of -1 from the dialog, and type again -1, this time it works and do not sends a gracePeriod, so I wonder if our issue is related to this same issue

![image](https://github.com/derailed/k9s/assets/55707366/9d1d6dd4-181f-4e6e-9abc-54feef51f41f)

**Expected behavior**
Drain operation should honor default values shown in the dialog

Possible related to issue https://github.com/derailed/k9s/issues/2129