### PR TITLE
fix manual sorting not working when sortColumn is configured

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -86,6 +86,7 @@ func (t *Table) GVR() client.GVR { return t.gvr }
 
 // ViewSettingsChanged notifies listener the view configuration changed.
 func (t *Table) ViewSettingsChanged(settings config.ViewSetting) {
+	t.manualSort = false // make user changes to the sortColumn take effect
 	t.viewSetting = &settings
 	t.Refresh()
 }

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -46,6 +46,7 @@ type Table struct {
 	wide        bool
 	toast       bool
 	hasMetrics  bool
+	configSort  bool
 }
 
 // NewTable returns a new table view.
@@ -202,9 +203,11 @@ func (t *Table) doUpdate(data *render.TableData) {
 		cols = t.viewSetting.Columns
 	}
 	custData := data.Customize(cols, t.wide)
-	if t.viewSetting != nil && t.viewSetting.SortColumn != "" {
+	// The sortColumn settings in the configuration file can only be used once
+	if t.viewSetting != nil && t.viewSetting.SortColumn != "" && !t.configSort {
+		t.configSort = true
 		tokens := strings.Split(t.viewSetting.SortColumn, ":")
-		if custData.Header.IndexOf(tokens[0], false) >= 0 && custData.Header.IndexOf(t.sortCol.name, false) < 0 {
+		if custData.Header.IndexOf(tokens[0], false) >= 0 {
 			t.sortCol.name, t.sortCol.asc = tokens[0], true
 			if len(tokens) == 2 && tokens[1] == "desc" {
 				t.sortCol.asc = false

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -46,7 +46,7 @@ type Table struct {
 	wide        bool
 	toast       bool
 	hasMetrics  bool
-	configSort  bool
+	manualSort  bool
 }
 
 // NewTable returns a new table view.
@@ -203,9 +203,9 @@ func (t *Table) doUpdate(data *render.TableData) {
 		cols = t.viewSetting.Columns
 	}
 	custData := data.Customize(cols, t.wide)
-	// The sortColumn settings in the configuration file can only be used once
-	if t.viewSetting != nil && t.viewSetting.SortColumn != "" && !t.configSort {
-		t.configSort = true
+	// The sortColumn settings in the configuration file are only used
+	// if the sortCol has not been modified manually
+	if t.viewSetting != nil && t.viewSetting.SortColumn != "" && !t.manualSort {
 		tokens := strings.Split(t.viewSetting.SortColumn, ":")
 		if custData.Header.IndexOf(tokens[0], false) >= 0 {
 			t.sortCol.name, t.sortCol.asc = tokens[0], true
@@ -318,6 +318,7 @@ func (t *Table) SortColCmd(name string, asc bool) func(evt *tcell.EventKey) *tce
 			t.sortCol.asc = asc
 		}
 		t.sortCol.name = name
+		t.manualSort = true
 		t.Refresh()
 		return nil
 	}


### PR DESCRIPTION
this PR fixes https://github.com/derailed/k9s/issues/2194

Related PRs and Issues:
* https://github.com/derailed/k9s/issues/1421
* https://github.com/derailed/k9s/pull/1962

Please verify if it's actually fixed when you have time. I tested it according to the steps in Issue and it is correct. Example views.yml:
```yaml
k9s:
  views:
    v1/events:
      sortColumn: LAST SEEN:asc
    v1/pods:
      sortColumn: STATUS:desc
      columns:
        - NAMESPACE
        - NAME
        - READY
        - RESTARTS
        - STATUS
        - AGE
        - CPU
        - MEM
        - IP
        - QOS
```
The default sorting is correct and can be done manually with shift+[alpha].