### PR TITLE
Add Namespace viewer for OpenShift Projects in registrar

### DIFF
--- a/internal/view/registrar.go
+++ b/internal/view/registrar.go
@@ -14,6 +14,7 @@ func loadCustomViewers() MetaViewers {
 	batchViewers(m)
 	extViewers(m)
 	helmViewers(m)
+	openshiftViewers(m)
 
 	return m
 }
@@ -151,6 +152,12 @@ func batchViewers(vv MetaViewers) {
 func extViewers(vv MetaViewers) {
 	vv[client.NewGVR("apiextensions.k8s.io/v1/customresourcedefinitions")] = MetaViewer{
 		enterFn: showCRD,
+	}
+}
+
+func openshiftViewers(vv MetaViewers) {
+	vv[client.NewGVR("project.openshift.io/v1/projects")] = MetaViewer{
+		viewerFn: NewNamespace,
 	}
 }
 


### PR DESCRIPTION
Closes #2224 

Adding OpenShift Projects to the registrar, so that its view behaves like Namespaces. This great codebase made this easy, thanks for this great tool!