### PR TITLE
fix reading benchmark from the wrong directory

### DIFF
--- a/internal/perf/benchmark.go
+++ b/internal/perf/benchmark.go
@@ -25,7 +25,6 @@ const (
 	k9sUA        = "k9s/"
 )
 
-
 var (
 	// K9sBenchDir directory to store K9s Benchmark files.
 	K9sBenchDir = filepath.Join(os.TempDir(), fmt.Sprintf("k9s-bench-%s", config.MustK9sUser()))
@@ -107,7 +106,7 @@ func (b *Benchmark) Canceled() bool {
 	return b.canceled
 }
 
-// Run starts a benchmark,.
+// Run starts a benchmark.
 func (b *Benchmark) Run(cluster string, done func()) {
 	log.Debug().Msgf("Running benchmark on cluster %s", cluster)
 	buff := new(bytes.Buffer)
@@ -115,7 +114,7 @@ func (b *Benchmark) Run(cluster string, done func()) {
 	// this call will block until the benchmark is complete or times out.
 	b.worker.Run()
 	b.worker.Stop()
-	if len(buff.Bytes()) > 0 {
+	if buff.Len() > 0 {
 		if err := b.save(cluster, buff); err != nil {
 			log.Error().Err(err).Msg("Saving Benchmark")
 		}
@@ -141,11 +140,7 @@ func (b *Benchmark) save(cluster string, r io.Reader) error {
 		}
 	}()
 
-	bb, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
-	if _, err := f.Write(bb); err != nil {
+	if _, err = io.Copy(f, r); err != nil {
 		return err
 	}
 

--- a/internal/view/benchmark.go
+++ b/internal/view/benchmark.go
@@ -65,7 +65,7 @@ func fileToSubject(path string) string {
 }
 
 func benchDir(cfg *config.Config) string {
-	return filepath.Join(perf.K9sBenchDir, cfg.K9s.CurrentContextDir())
+	return filepath.Join(perf.K9sBenchDir, cfg.K9s.CurrentCluster)
 }
 
 func readBenchFile(cfg *config.Config, n string) (string, error) {


### PR DESCRIPTION
this PR fixes https://github.com/derailed/k9s/issues/2063.

By the way, should we distinguish between canceled and failed benchmark?