### PR TITLE
feat: add imagePullSecrets and imagePullPolicy configuration for shellpod

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ K9s uses aliases to navigate most K8s resources.
           namespace: fred
           # imagePullPolicy defaults to Always
           imagePullPolicy: Always
-          # imagePullSecrets defaults to no secret, remove the option if you don't need it.
+          # imagePullSecrets defaults to no secret
           imagePullSecrets:
           - name: my-regcred
           # The resource limit to set on the shell pod.
@@ -436,7 +436,7 @@ k9s:
         namespace: blee
         # imagePullPolicy defaults to Always
         imagePullPolicy: Always
-        # imagePullSecrets defaults to no secret, remove the option if you don't need it.
+        # imagePullSecrets defaults to no secret
         imagePullSecrets:
         - name: my-regcred
         # The resource limit to

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ K9s uses aliases to navigate most K8s resources.
           namespace: fred
           # imagePullPolicy defaults to Always
           imagePullPolicy: Always
-          # imagePullSecrets defaults to no secrets
+          # imagePullSecrets defaults to no secret, remove the option if you don't need it.
           imagePullSecrets:
           - name: my-regcred
           # The resource limit to set on the shell pod.

--- a/README.md
+++ b/README.md
@@ -388,8 +388,8 @@ K9s uses aliases to navigate most K8s resources.
           # imagePullPolicy defaults to Always
           imagePullPolicy: Always
           # imagePullSecrets defaults to no secrets
-          # imagePullSecrets:
-          # - name: my-regcred
+          imagePullSecrets:
+          - name: my-regcred
           # The resource limit to set on the shell pod.
           limits:
             cpu: 100m
@@ -436,9 +436,9 @@ k9s:
         namespace: blee
         # imagePullPolicy defaults to Always
         imagePullPolicy: Always
-        # imagePullSecrets defaults to no secrets
-        # imagePullSecrets:
-        # - name: my-regcred
+        # imagePullSecrets defaults to no secret, remove the option if you don't need it.
+        imagePullSecrets:
+        - name: my-regcred
         # The resource limit to
         limits:
           cpu: 100m

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ k9s:
         # imagePullSecrets defaults to no secret
         imagePullSecrets:
         - name: my-regcred
-        # The resource limit to
+        # The resource limit to set on the shell pod.
         limits:
           cpu: 100m
           memory: 100Mi

--- a/README.md
+++ b/README.md
@@ -385,6 +385,11 @@ K9s uses aliases to navigate most K8s resources.
           image: killerAdmin
           # The namespace to launch to shell pod into.
           namespace: fred
+          # imagePullPolicy defaults to Always
+          imagePullPolicy: Always
+          # imagePullSecrets defaults to no secrets
+          # imagePullSecrets:
+          # - name: my-regcred
           # The resource limit to set on the shell pod.
           limits:
             cpu: 100m
@@ -429,6 +434,12 @@ k9s:
       shellPod:
         image: cool_kid_admin:42
         namespace: blee
+        # imagePullPolicy defaults to Always
+        imagePullPolicy: Always
+        # imagePullSecrets defaults to no secrets
+        # imagePullSecrets:
+        # - name: my-regcred
+        # The resource limit to
         limits:
           cpu: 100m
           memory: 100Mi

--- a/internal/config/shell_pod.go
+++ b/internal/config/shell_pod.go
@@ -14,7 +14,7 @@ type Limits map[v1.ResourceName]string
 type ShellPod struct {
 	Image            string                    `json:"image"`
 	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty" yaml:"imagePullSecrets,omitempty"`
-	ImagePullPolicy  string                    `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
+	ImagePullPolicy  v1.PullPolicy             `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
 	Command          []string                  `json:"command,omitempty"`
 	Args             []string                  `json:"args,omitempty"`
 	Namespace        string                    `json:"namespace"`
@@ -38,9 +38,6 @@ func (s *ShellPod) Validate(client.Connection, KubeSettings) {
 	}
 	if len(s.Limits) == 0 {
 		s.Limits = defaultLimits()
-	}
-	if len(s.ImagePullSecrets) == 0 {
-		s.ImagePullSecrets = []v1.LocalObjectReference{}
 	}
 }
 

--- a/internal/config/shell_pod.go
+++ b/internal/config/shell_pod.go
@@ -12,12 +12,14 @@ type Limits map[v1.ResourceName]string
 
 // ShellPod represents k9s shell configuration.
 type ShellPod struct {
-	Image     string            `json:"image"`
-	Command   []string          `json:"command,omitempty"`
-	Args      []string          `json:"args,omitempty"`
-	Namespace string            `json:"namespace"`
-	Limits    Limits            `json:"resources,omitempty"`
-	Labels    map[string]string `json:"labels,omitempty"`
+	Image            string                    `json:"image"`
+	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty" yaml:"imagePullSecrets,omitempty"`
+	ImagePullPolicy  string                    `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
+	Command          []string                  `json:"command,omitempty"`
+	Args             []string                  `json:"args,omitempty"`
+	Namespace        string                    `json:"namespace"`
+	Limits           Limits                    `json:"resources,omitempty"`
+	Labels           map[string]string         `json:"labels,omitempty"`
 }
 
 // NewShellPod returns a new instance.
@@ -36,6 +38,9 @@ func (s *ShellPod) Validate(client.Connection, KubeSettings) {
 	}
 	if len(s.Limits) == 0 {
 		s.Limits = defaultLimits()
+	}
+	if len(s.ImagePullSecrets) == 0 {
+		s.ImagePullSecrets = []v1.LocalObjectReference{}
 	}
 }
 

--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -378,9 +378,6 @@ func k9sShellPod(node string, cfg *config.ShellPod) *v1.Pod {
 	if len(cfg.Args) > 0 {
 		c.Args = cfg.Args
 	}
-	if len(cfg.ImagePullPolicy) > 0 {
-		c.ImagePullPolicy = v1.PullPolicy(cfg.ImagePullPolicy)
-	}
 
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -378,6 +378,9 @@ func k9sShellPod(node string, cfg *config.ShellPod) *v1.Pod {
 	if len(cfg.Args) > 0 {
 		c.Args = cfg.Args
 	}
+	if len(cfg.ImagePullPolicy) > 0 {
+		c.ImagePullPolicy = v1.PullPolicy(cfg.ImagePullPolicy)
+	}
 
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -390,6 +393,7 @@ func k9sShellPod(node string, cfg *config.ShellPod) *v1.Pod {
 			RestartPolicy:                 v1.RestartPolicyNever,
 			HostPID:                       true,
 			HostNetwork:                   true,
+			ImagePullSecrets:              cfg.ImagePullSecrets,
 			TerminationGracePeriodSeconds: &grace,
 			Volumes: []v1.Volume{
 				{

--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -357,8 +357,9 @@ func k9sShellPod(node string, cfg *config.ShellPod) *v1.Pod {
 
 	log.Debug().Msgf("Shell Config %#v", cfg)
 	c := v1.Container{
-		Name:  k9sShell,
-		Image: cfg.Image,
+		Name:            k9sShell,
+		Image:           cfg.Image,
+		ImagePullPolicy: cfg.ImagePullPolicy,
 		VolumeMounts: []v1.VolumeMount{
 			{
 				Name:      "root-vol",


### PR DESCRIPTION
See #2300 

This is to be able to use internal registries  and set imagePullPolicy 

This doesn't change the default configuration of k9s, but enables the use of shellpod when public registries are off-limit due to company policies.

