### PR TITLE
Update pod status contstants to account for Evicted and ContainerStatusUnknown and leverage them in sanitize

### DIFF
--- a/internal/dao/pod.go
+++ b/internal/dao/pod.go
@@ -544,6 +544,10 @@ func (p *Pod) Sanitize(ctx context.Context, ns string) (int, error) {
 			fallthrough
 		case render.PhaseImagePullBackOff:
 			fallthrough
+		case render.PhaseContainerStatusUnknown:
+			fallthrough
+		case render.PhaseEvicted:
+			fallthrough
 		case render.PhaseOOMKilled:
 			// !!BOZO!! Might need to bump timeout otherwise rev limit if too many??
 			log.Debug().Msgf("Sanitizing %s:%s", pod.Namespace, pod.Name)

--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -28,19 +28,21 @@ const (
 )
 
 const (
-	PhaseTerminating       = "Terminating"
-	PhaseInitialized       = "Initialized"
-	PhaseRunning           = "Running"
-	PhaseNotReady          = "NoReady"
-	PhaseCompleted         = "Completed"
-	PhaseContainerCreating = "ContainerCreating"
-	PhasePodInitializing   = "PodInitializing"
-	PhaseUnknown           = "Unknown"
-	PhaseCrashLoop         = "CrashLoopBackOff"
-	PhaseError             = "Error"
-	PhaseImagePullBackOff  = "ImagePullBackOff"
-	PhaseOOMKilled         = "OOMKilled"
-	PhasePending           = "Pending"
+	PhaseTerminating            = "Terminating"
+	PhaseInitialized            = "Initialized"
+	PhaseRunning                = "Running"
+	PhaseNotReady               = "NoReady"
+	PhaseCompleted              = "Completed"
+	PhaseContainerCreating      = "ContainerCreating"
+	PhasePodInitializing        = "PodInitializing"
+	PhaseUnknown                = "Unknown"
+	PhaseCrashLoop              = "CrashLoopBackOff"
+	PhaseError                  = "Error"
+	PhaseImagePullBackOff       = "ImagePullBackOff"
+	PhaseOOMKilled              = "OOMKilled"
+	PhasePending                = "Pending"
+	PhaseContainerStatusUnknown = "ContainerStatusUnknown"
+	PhaseEvicted                = "Evicted"
 )
 
 // Pod renders a K8s Pod to screen.


### PR DESCRIPTION
I had a cluster that was blowing up with pods that were being Evicted and others that had ContainerStatusUnknown... figured I would try the new sanitize function, but noticed that it wasn't clearing them out.  Updated accordingly.

I did notice some weird behavior in that the sanitize function didn't completely clear out everything in one run... (I had roughly 800-1000 failing pods 😱).  I had to run it about 3 times to fully get everything.  Is that expected? 

I've said it before, but this tool is such a game changer.  Thanks very much for all the hard work!