### PR TITLE
proper handling of help commands (fixes  #2154)

### DIFF
--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -122,6 +122,14 @@ func (p *Prompt) SendStrokes(s string) {
 	}
 }
 
+// Deactivate sets the prompt as inactive.
+func (p *Prompt) Deactivate() {
+	if p.model != nil {
+		p.model.ClearText(true)
+		p.model.SetActive(false)
+	}
+}
+
 // SetModel sets the prompt buffer model.
 func (p *Prompt) SetModel(m PromptModel) {
 	if p.model != nil {

--- a/internal/ui/prompt_test.go
+++ b/internal/ui/prompt_test.go
@@ -51,6 +51,19 @@ func TestCmdMode(t *testing.T) {
 	}
 }
 
+func TestPrompt_Deactivate(t *testing.T) {
+	model := model.NewFishBuff(':', model.CommandBuffer)
+	v := ui.NewPrompt(&ui.App{}, true, config.NewStyles())
+	v.SetModel(model)
+	model.AddListener(v)
+
+	model.SetActive(true)
+	if assert.True(t, v.InCmdMode()) {
+		v.Deactivate()
+		assert.False(t, v.InCmdMode())
+	}
+}
+
 // Tests that, when active, the prompt has the appropriate color
 func TestPromptColor(t *testing.T) {
 	styles := config.NewStyles()

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -641,12 +641,11 @@ func (a *App) dirCmd(path string) error {
 }
 
 func (a *App) helpCmd(evt *tcell.EventKey) *tcell.EventKey {
-	top := a.Content.Top()
-
-	if a.CmdBuff().InCmdMode() || (top != nil && top.InCmdMode()) {
+	if evt != nil && evt.Rune() == '?' && a.Prompt().InCmdMode() {
 		return evt
 	}
 
+	top := a.Content.Top()
 	if top != nil && top.Name() == "help" {
 		a.Content.Pop()
 		return nil
@@ -656,6 +655,7 @@ func (a *App) helpCmd(evt *tcell.EventKey) *tcell.EventKey {
 		a.Flash().Err(err)
 	}
 
+	a.Prompt().Deactivate()
 	return nil
 }
 


### PR DESCRIPTION
this PR fixes https://github.com/derailed/k9s/issues/2154.

Steps to reproduce the problem:
1. Type `:` or `/` to open prompt bar
2. Type `?`
3. Type `ESC` to close the help page

There is an extra prompt bar on the page and it cannot be closed by ESC.

This PR fixes the above problem, and also fixes the problem of unable to open the help page with the `help` or `h` commands.

Fixes #2154 
