### PR TITLE
adding a default value for the AGE field

### DIFF
--- a/internal/render/generic.go
+++ b/internal/render/generic.go
@@ -101,7 +101,7 @@ func (g *Generic) Render(o interface{}, ns string, r *Row) error {
 		r.Fields = append(r.Fields, d)
 	} else if g.ageIndex > 0 {
 		log.Warn().Msgf("No Duration detected on age field")
-		r.Fields = append(r.Fields, "0")
+		r.Fields = append(r.Fields, NAValue)
 	}
 
 	return nil

--- a/internal/render/generic.go
+++ b/internal/render/generic.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/derailed/k9s/internal/client"
+	"github.com/rs/zerolog/log"
 
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 )
@@ -98,6 +99,9 @@ func (g *Generic) Render(o interface{}, ns string, r *Row) error {
 	}
 	if d, ok := duration.(string); ok {
 		r.Fields = append(r.Fields, d)
+	} else if g.ageIndex > 0 {
+		log.Warn().Msgf("No Duration detected on age field")
+		r.Fields = append(r.Fields, "0")
 	}
 
 	return nil

--- a/internal/render/helpers.go
+++ b/internal/render/helpers.go
@@ -4,6 +4,7 @@
 package render
 
 import (
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -47,6 +48,9 @@ func runesToNum(rr []rune) int64 {
 func durationToSeconds(duration string) int64 {
 	if len(duration) == 0 {
 		return 0
+	}
+	if duration == NAValue {
+		return math.MaxInt64
 	}
 
 	num := make([]rune, 0, 5)

--- a/internal/render/helpers_test.go
+++ b/internal/render/helpers_test.go
@@ -4,6 +4,7 @@
 package render
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -69,6 +70,7 @@ func TestDurationToSecond(t *testing.T) {
 		"day_hour_minute_seconds": {s: "2d22h3m50s", e: 252230},
 		"year":                    {s: "3y", e: 94608000},
 		"year_day":                {s: "1y2d", e: 31708800},
+		"n/a":                     {s: NAValue, e: math.MaxInt64},
 	}
 
 	for k := range uu {


### PR DESCRIPTION
this PR try fixes #2036.

It looks like it should be here, when the AGE column has an invalid value(not string), it will underpopulate a column of data, which will cause an out of bounds to occur here at https://github.com/derailed/k9s/blob/0c642c6786e18dbf6483106dce3930f938cc3421/internal/ui/table_helper.go#L176