### PR TITLE
Do not mark triggered jobs to block deletion of owner cronjobs

### DIFF
--- a/internal/dao/cronjob.go
+++ b/internal/dao/cronjob.go
@@ -60,7 +60,6 @@ func (c *CronJob) Run(path string) error {
 	if len(cj.Name) >= maxJobNameSize {
 		jobName = cj.Name[0:maxJobNameSize]
 	}
-	true := true
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        jobName + "-manual-" + rand.String(3),
@@ -71,7 +70,6 @@ func (c *CronJob) Run(path string) error {
 				{
 					APIVersion:         c.gvr.GV().String(),
 					Kind:               "CronJob",
-					BlockOwnerDeletion: &true,
 					Name:               cj.Name,
 					UID:                cj.UID,
 				},


### PR DESCRIPTION
EDIT :pencil2: 
Only jobs triggered through oc DO NOT set `BlockOwnerDeletion` to true. Jobs triggered through kubectl sets  `BlockOwnerDeletion` to true.

Closing Pull Request.

Original description below:

------
Jobs triggered through kubectl (like the example command below) do not set `BlockOwnerDeletion` to true.
```
kubectl create job --from=cronjob/my-cronjob my-manually-triggered-job-01
```

Closes #1865

Tests are green but not sure if I need to remove this line https://github.com/derailed/k9s/blob/master/internal/render/testdata/job.json#L15

Thanks!


