### PR TITLE
adding value, yaml and describe views to helm-history

### DIFF
--- a/internal/dao/helm_chart.go
+++ b/internal/dao/helm_chart.go
@@ -21,6 +21,7 @@ var (
 	_ Accessor  = (*HelmChart)(nil)
 	_ Nuker     = (*HelmChart)(nil)
 	_ Describer = (*HelmChart)(nil)
+	_ Valuer    = (*HelmChart)(nil)
 )
 
 // HelmChart represents a helm chart.

--- a/internal/dao/helm_history.go
+++ b/internal/dao/helm_history.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+	"helm.sh/helm/v3/pkg/action"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/render/helm"
-	"helm.sh/helm/v3/pkg/action"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var (
@@ -55,12 +58,24 @@ func (h *HelmHistory) List(ctx context.Context, _ string) ([]runtime.Object, err
 
 // Get returns a resource.
 func (h *HelmHistory) Get(_ context.Context, path string) (runtime.Object, error) {
-	ns, n := client.Namespaced(path)
+	fqn, rev, found := strings.Cut(path, ":")
+	if !found || len(rev) == 0 {
+		return nil, fmt.Errorf("invalid path %q", path)
+	}
+
+	ns, n := client.Namespaced(fqn)
 	cfg, err := ensureHelmConfig(h.Client(), ns)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := action.NewGet(cfg).Run(n)
+
+	getter := action.NewGet(cfg)
+	getter.Version, err = strconv.Atoi(rev)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := getter.Run(n)
 	if err != nil {
 		return nil, err
 	}
@@ -70,32 +85,50 @@ func (h *HelmHistory) Get(_ context.Context, path string) (runtime.Object, error
 
 // Describe returns the chart notes.
 func (h *HelmHistory) Describe(path string) (string, error) {
-	ns, n := client.Namespaced(path)
-	cfg, err := ensureHelmConfig(h.Client(), ns)
-	if err != nil {
-		return "", err
-	}
-	resp, err := action.NewGet(cfg).Run(n)
+	rel, err := h.Get(context.Background(), path)
 	if err != nil {
 		return "", err
 	}
 
-	return resp.Info.Notes, nil
+	resp, ok := rel.(helm.ReleaseRes)
+	if !ok {
+		return "", fmt.Errorf("expected helm.ReleaseRes, but got %T", rel)
+	}
+
+	return resp.Release.Info.Notes, nil
 }
 
 // ToYAML returns the chart manifest.
 func (h *HelmHistory) ToYAML(path string, showManaged bool) (string, error) {
-	ns, n := client.Namespaced(path)
-	cfg, err := ensureHelmConfig(h.Client(), ns)
-	if err != nil {
-		return "", err
-	}
-	resp, err := action.NewGet(cfg).Run(n)
+	rel, err := h.Get(context.Background(), path)
 	if err != nil {
 		return "", err
 	}
 
-	return resp.Manifest, nil
+	resp, ok := rel.(helm.ReleaseRes)
+	if !ok {
+		return "", fmt.Errorf("expected helm.ReleaseRes, but got %T", rel)
+	}
+
+	return resp.Release.Manifest, nil
+}
+
+// GetValues return the config for this chart.
+func (h *HelmHistory) GetValues(path string, allValues bool) ([]byte, error) {
+	rel, err := h.Get(context.Background(), path)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, ok := rel.(helm.ReleaseRes)
+	if !ok {
+		return nil, fmt.Errorf("expected helm.ReleaseRes, but got %T", rel)
+	}
+
+	if allValues {
+		return yaml.Marshal(resp.Release.Chart.Values)
+	}
+	return yaml.Marshal(resp.Release.Config)
 }
 
 func (h *HelmHistory) Rollback(_ context.Context, path, rev string) error {

--- a/internal/dao/helm_history.go
+++ b/internal/dao/helm_history.go
@@ -23,6 +23,7 @@ var (
 	_ Accessor  = (*HelmHistory)(nil)
 	_ Nuker     = (*HelmHistory)(nil)
 	_ Describer = (*HelmHistory)(nil)
+	_ Valuer    = (*HelmHistory)(nil)
 )
 
 // HelmHistory represents a helm chart.

--- a/internal/dao/registry.go
+++ b/internal/dao/registry.go
@@ -102,6 +102,7 @@ func AccessorFor(f Factory, gvr client.GVR) (Accessor, error) {
 		client.NewGVR("v1/namespaces"):          &Namespace{},
 		client.NewGVR("popeye"):                 &Popeye{},
 		client.NewGVR("helm"):                   &HelmChart{},
+		client.NewGVR("helm-history"):           &HelmHistory{},
 		client.NewGVR("dir"):                    &Dir{},
 	}
 

--- a/internal/dao/registry.go
+++ b/internal/dao/registry.go
@@ -315,7 +315,7 @@ func loadHelm(m ResourceMetas) {
 		Kind:       "History",
 		Namespaced: true,
 		Verbs:      []string{"delete"},
-		Categories: []string{k9sCat},
+		Categories: []string{helmCat},
 	}
 }
 

--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -170,3 +170,9 @@ type Sanitizer interface {
 	// Sanitize nukes all resources in unhappy state.
 	Sanitize(context.Context, string) (int, error)
 }
+
+// Valuer represents a resource with values.
+type Valuer interface {
+	// GetValues returns values for a resource.
+	GetValues(path string, allValues bool) ([]byte, error)
+}

--- a/internal/view/helm_chart.go
+++ b/internal/view/helm_chart.go
@@ -8,20 +8,16 @@ import (
 
 	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
-	"github.com/derailed/k9s/internal/model"
 	"github.com/derailed/k9s/internal/ui"
 	"github.com/derailed/tcell/v2"
-	"github.com/rs/zerolog/log"
 )
 
 // HelmChart represents a helm chart view.
 type HelmChart struct {
 	ResourceViewer
-
-	Values *model.Values
 }
 
-// NewHelm returns a new alias view.
+// NewHelmChart returns a new helm-chart view.
 func NewHelmChart(gvr client.GVR) ResourceViewer {
 	c := HelmChart{
 		ResourceViewer: NewBrowser(gvr),
@@ -84,26 +80,10 @@ func (c *HelmChart) getValsCmd() func(evt *tcell.EventKey) *tcell.EventKey {
 		if path == "" {
 			return evt
 		}
-		c.Values = model.NewValues(c.GVR(), path)
-		v := NewLiveView(c.App(), "Values", c.Values)
-		v.actions.Add(ui.KeyActions{
-			ui.KeyV: ui.NewKeyAction("Toggle All Values", c.toggleValuesCmd, true),
-		})
-		if err := v.app.inject(v, false); err != nil {
-			v.app.Flash().Err(err)
-		}
-		return nil
-	}
-}
 
-func (c *HelmChart) toggleValuesCmd(evt *tcell.EventKey) *tcell.EventKey {
-	c.Values.ToggleValues()
-	if err := c.Values.Refresh(c.defaultCtx()); err != nil {
-		log.Error().Err(err).Msgf("helm refresh failed")
+		showValues(c.defaultCtx(), c.App(), path, c.GVR())
 		return nil
 	}
-	c.App().Flash().Infof("Values toggled")
-	return nil
 }
 
 func (c *HelmChart) defaultCtx() context.Context {

--- a/internal/view/helm_chart.go
+++ b/internal/view/helm_chart.go
@@ -20,7 +20,7 @@ type HelmChart struct {
 // NewHelmChart returns a new helm-chart view.
 func NewHelmChart(gvr client.GVR) ResourceViewer {
 	c := HelmChart{
-		ResourceViewer: NewBrowser(gvr),
+		ResourceViewer: NewValueExtender(NewBrowser(gvr)),
 	}
 	c.GetTable().SetBorderFocusColor(tcell.ColorMediumSpringGreen)
 	c.GetTable().SetSelectedStyle(tcell.StyleDefault.
@@ -42,7 +42,6 @@ func (c *HelmChart) bindKeys(aa ui.KeyActions) {
 	aa.Add(ui.KeyActions{
 		ui.KeyR:      ui.NewKeyAction("Releases", c.historyCmd, true),
 		ui.KeyShiftS: ui.NewKeyAction("Sort Status", c.GetTable().SortColCmd(statusCol, true), false),
-		ui.KeyV:      ui.NewKeyAction("Values", c.getValsCmd(), true),
 	})
 }
 
@@ -72,20 +71,4 @@ func (c *HelmChart) helmContext(ctx context.Context) context.Context {
 	ctx = context.WithValue(ctx, internal.KeyFQN, path)
 
 	return context.WithValue(ctx, internal.KeyPath, path)
-}
-
-func (c *HelmChart) getValsCmd() func(evt *tcell.EventKey) *tcell.EventKey {
-	return func(evt *tcell.EventKey) *tcell.EventKey {
-		path := c.GetTable().GetSelectedItem()
-		if path == "" {
-			return evt
-		}
-
-		showValues(c.defaultCtx(), c.App(), path, c.GVR())
-		return nil
-	}
-}
-
-func (c *HelmChart) defaultCtx() context.Context {
-	return context.WithValue(context.Background(), internal.KeyFactory, c.App().factory)
 }

--- a/internal/view/helm_history.go
+++ b/internal/view/helm_history.go
@@ -31,6 +31,9 @@ func NewHistory(gvr client.GVR) ResourceViewer {
 	h.GetTable().SetSelectedStyle(tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorMediumSpringGreen).Attributes(tcell.AttrNone))
 	h.AddBindKeysFn(h.bindKeys)
 	h.SetContextFn(h.HistoryContext)
+	h.GetTable().SetSelectedFn(func(s string) string {
+		return s[:strings.Index(s, ":")]
+	})
 
 	return &h
 }

--- a/internal/view/helm_history.go
+++ b/internal/view/helm_history.go
@@ -8,10 +8,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/dao"
-	"github.com/derailed/k9s/internal/model"
 	"github.com/derailed/k9s/internal/render/helm"
 	"github.com/derailed/k9s/internal/ui"
 	"github.com/derailed/k9s/internal/ui/dialog"
@@ -26,14 +24,13 @@ type History struct {
 // NewHistory returns a new helm-history view.
 func NewHistory(gvr client.GVR) ResourceViewer {
 	h := History{
-		ResourceViewer: NewBrowser(gvr),
+		ResourceViewer: NewValueExtender(NewBrowser(gvr)),
 	}
 	h.GetTable().SetColorerFn(helm.History{}.ColorerFunc())
 	h.GetTable().SetBorderFocusColor(tcell.ColorMediumSpringGreen)
 	h.GetTable().SetSelectedStyle(tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorMediumSpringGreen).Attributes(tcell.AttrNone))
 	h.AddBindKeysFn(h.bindKeys)
 	h.SetContextFn(h.HistoryContext)
-	h.GetTable().SetEnterFn(h.enterFn)
 
 	return &h
 }
@@ -59,9 +56,6 @@ func (h *History) bindKeys(aa ui.KeyActions) {
 
 	aa.Delete(ui.KeyShiftA, ui.KeyShiftN, tcell.KeyCtrlS, tcell.KeyCtrlSpace, ui.KeySpace, tcell.KeyCtrlD)
 	aa.Add(ui.KeyActions{
-		ui.KeyY:      ui.NewKeyAction(yamlAction, h.yamlCmd, true),
-		ui.KeyD:      ui.NewKeyAction("Describe", h.describeCmd, true),
-		ui.KeyV:      ui.NewKeyAction("Values", h.valuesCmd, true),
 		ui.KeyShiftN: ui.NewKeyAction("Sort Revision", h.GetTable().SortColCmd("REVISION", true), false),
 		ui.KeyShiftS: ui.NewKeyAction("Sort Status", h.GetTable().SortColCmd("STATUS", true), false),
 		ui.KeyShiftA: ui.NewKeyAction("Sort Age", h.GetTable().SortColCmd("AGE", true), false),
@@ -103,43 +97,6 @@ func (h *History) rollbackCmd(evt *tcell.EventKey) *tcell.EventKey {
 	return nil
 }
 
-func (h *History) yamlCmd(evt *tcell.EventKey) *tcell.EventKey {
-	path := h.GetTable().GetSelectedItem()
-	if path == "" {
-		return evt
-	}
-
-	v := NewLiveView(h.App(), yamlAction, model.NewYAML(h.GVR(), path))
-	if err := v.app.inject(v, false); err != nil {
-		v.app.Flash().Err(err)
-	}
-	return nil
-}
-
-func (h *History) describeCmd(evt *tcell.EventKey) *tcell.EventKey {
-	path := h.GetTable().GetSelectedItem()
-	if path == "" {
-		return evt
-	}
-
-	describeResource(h.App(), h.GetTable().GetModel(), h.GVR().String(), path)
-	return nil
-}
-
-func (h *History) valuesCmd(evt *tcell.EventKey) *tcell.EventKey {
-	path := h.GetTable().GetSelectedItem()
-	if path == "" {
-		return evt
-	}
-
-	showValues(h.defaultCtx(), h.App(), path, h.GVR())
-	return nil
-}
-
-func (h *History) enterFn(app *App, _ ui.Tabular, gvr, path string) {
-	h.valuesCmd(nil)
-}
-
 func (h *History) rollback(ctx context.Context, path, rev string) error {
 	var hm dao.HelmHistory
 	hm.Init(h.App().factory, h.GVR())
@@ -149,8 +106,4 @@ func (h *History) rollback(ctx context.Context, path, rev string) error {
 	h.Refresh()
 
 	return nil
-}
-
-func (h *History) defaultCtx() context.Context {
-	return context.WithValue(context.Background(), internal.KeyFactory, h.App().factory)
 }

--- a/internal/view/helpers.go
+++ b/internal/view/helpers.go
@@ -261,34 +261,3 @@ func linesWithRegions(lines []string, matches fuzzy.Matches) []string {
 	}
 	return ll
 }
-
-func showValues(ctx context.Context, app *App, path string, gvr client.GVR) {
-	vm := model.NewValues(gvr, path)
-	if err := vm.Init(app.factory); err != nil {
-		app.Flash().Errf("Initializing the values model failed: %s", err)
-	}
-
-	toggleValuesCmd := func(evt *tcell.EventKey) *tcell.EventKey {
-		if err := vm.ToggleValues(); err != nil {
-			app.Flash().Errf("Values toggle failed: %s", err)
-			return nil
-		}
-
-		if err := vm.Refresh(ctx); err != nil {
-			log.Error().Err(err).Msgf("values refresh failed")
-			return nil
-		}
-
-		app.Flash().Infof("Values toggled")
-		return nil
-	}
-
-	v := NewLiveView(app, "Values", vm)
-	v.actions.Add(ui.KeyActions{
-		ui.KeyV: ui.NewKeyAction("Toggle All Values", toggleValuesCmd, true),
-	})
-
-	if err := v.app.inject(v, false); err != nil {
-		v.app.Flash().Err(err)
-	}
-}

--- a/internal/view/value_extender.go
+++ b/internal/view/value_extender.go
@@ -1,0 +1,44 @@
+package view
+
+import (
+	"context"
+	"github.com/derailed/k9s/internal"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/tcell/v2"
+)
+
+// ValueExtender adds values actions to a given viewer.
+type ValueExtender struct {
+	ResourceViewer
+}
+
+// NewValueExtender returns a new extender.
+func NewValueExtender(r ResourceViewer) ResourceViewer {
+	p := ValueExtender{ResourceViewer: r}
+	p.AddBindKeysFn(p.bindKeys)
+	p.GetTable().SetEnterFn(func(app *App, model ui.Tabular, gvr, path string) {
+		p.valuesCmd(nil)
+	})
+
+	return &p
+}
+
+func (v *ValueExtender) bindKeys(aa ui.KeyActions) {
+	aa.Add(ui.KeyActions{
+		ui.KeyV: ui.NewKeyAction("Values", v.valuesCmd, true),
+	})
+}
+
+func (v *ValueExtender) valuesCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := v.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	showValues(v.defaultCtx(), v.App(), path, v.GVR())
+	return nil
+}
+
+func (v *ValueExtender) defaultCtx() context.Context {
+	return context.WithValue(context.Background(), internal.KeyFactory, v.App().factory)
+}


### PR DESCRIPTION
This PR adds the `d` command (to show a description) and `y` command (to show the YAML manifest) to helm-history, and modifies the default `enter` key to view values.

this PR also fixes https://github.com/derailed/k9s/issues/2332.