### PR TITLE
#1873 add symlink into snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ base: core20
 version: 'v0.27.4'
 summary: K9s is a CLI to view and manage your Kubernetes clusters.
 description: |
-  K9s is a CLI to view and manage your Kubernetes clusters. By leveraging a terminal UI, you can easily traverse Kubernetes resources and view the state of you clusters in a single powerful session.
+  K9s is a CLI to view and manage your Kubernetes clusters. By leveraging a terminal UI, you can easily traverse Kubernetes resources and view the state of your clusters in a single powerful session.
 
 grade: stable
 confinement: classic
@@ -38,5 +38,11 @@ parts:
       make test
       make build
       install $SNAPCRAFT_PART_BUILD/execs/k9s -D $SNAPCRAFT_PART_INSTALL/bin/k9s
+    override-prime: |
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+      ln -s $SNAPCRAFT_PART_INSTALL/bin/k9s $SNAPCRAFT_PART_INSTALL/bin/k9s
     build-packages:
       - build-essential
+
+prime:
+  - $build/bin/k9s


### PR DESCRIPTION
K9s snap is missing a symlink when installing on Ubuntu 22.04.3 LTS

This creates the link alongside the rest of the snap.