### PR TITLE
Added ln check for snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ faas
 demos
 /code
 kind
+*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: k9s
-base: core20 
+base: core20
 version: 'v0.27.4'
 summary: K9s is a CLI to view and manage your Kubernetes clusters.
 description: |
@@ -38,11 +38,9 @@ parts:
       make test
       make build
       install $SNAPCRAFT_PART_BUILD/execs/k9s -D $SNAPCRAFT_PART_INSTALL/bin/k9s
-    override-prime: |
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
-      ln -s $SNAPCRAFT_PART_INSTALL/bin/k9s $SNAPCRAFT_PART_INSTALL/bin/k9s
+      if [ ! -e $SNAPCRAFT_PART_INSTALL/bin/k9s ]; then
+        ln -s $SNAPCRAFT_PART_INSTALL/bin/k9s $SNAPCRAFT_PART_INSTALL/bin/k9s
+      fi
     build-packages:
       - build-essential
-
-prime:
-  - $build/bin/k9s

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: k9s
 base: core20
-version: 'v0.27.4'
+version: 'v0.29.1'
 summary: K9s is a CLI to view and manage your Kubernetes clusters.
 description: |
   K9s is a CLI to view and manage your Kubernetes clusters. By leveraging a terminal UI, you can easily traverse Kubernetes resources and view the state of your clusters in a single powerful session.


### PR DESCRIPTION
Realised that if you manually created (or already had) a ln it would cause the build to fail. So added in a check to see if it exists.
Moved commands out of prime-override as it didn't really add anything and made it harder to read

Additional small changes

- Updated version number 
- Added .snap to ignore