### PR TITLE
Add plugin to remove finalizers

### DIFF
--- a/plugins/remove_finalizers.yml
+++ b/plugins/remove_finalizers.yml
@@ -1,14 +1,14 @@
-plugin:
+# Removes all finalizers from the selected resource. Finalizers are namespaced keys that tell Kubernetes to wait
+# until specific conditions are met before it fully deletes resources marked for deletion.
+# Before deleting an object you need to ensure that all finalizers has been removed. Usually this would be done
+# by the specific controller but under some circumstances it is possible to encounter a set of objects blocked
+# for deletion.
+# This plugins makes this task easier by providing a shortcut to directly removing them all.
+# Be careful when using this plugin as it may leave dangling resources or instantly deleting resources that were
+# blocked by the finalizers.
+# Author: github.com/jalvarezit
+plugins:
   remove_finalizers:
-    # Removes all finalizers from the selected resource. Finalizers are namespaced keys that tell Kubernetes to wait
-    # until specific conditions are met before it fully deletes resources marked for deletion.
-    # Before deleting an object you need to ensure that all finalizers has been removed. Usually this would be done
-    # by the specific controller but under some circumstances it is possible to encounter a set of objects blocked
-    # for deletion.
-    # This plugins makes this task easier by providing a shortcut to directly removing them all.
-    # Be careful when using this plugin as it may leave dangling resources or instantly deleting resources that were
-    # blocked by the finalizers.
-    # Author: github.com/jalvarezit
     shortCut: Ctrl-F
     confirm: true
     scopes:

--- a/plugins/remove_finalizers.yml
+++ b/plugins/remove_finalizers.yml
@@ -1,10 +1,21 @@
 plugin:
   remove_finalizers:
+    # Removes all finalizers from the selected resource. Finalizers are namespaced keys that tell Kubernetes to wait
+    # until specific conditions are met before it fully deletes resources marked for deletion.
+    # Before deleting an object you need to ensure that all finalizers has been removed. Usually this would be done
+    # by the specific controller but under some circumstances it is possible to encounter a set of objects blocked
+    # for deletion.
+    # This plugins makes this task easier by providing a shortcut to directly removing them all.
+    # Be careful when using this plugin as it may leave dangling resources or instantly deleting resources that were
+    # blocked by the finalizers.
+    # Author: github.com/jalvarezit
     shortCut: Ctrl-F
     confirm: true
     scopes:
       - all
-    description: Removes all finalizers from selected resource
+    description: |
+      Removes all finalizers from selected resource. Be careful when using it,
+      it may leave dangling resources or delete them 
     command: kubectl
     background: true
     args:

--- a/plugins/remove_finalizers.yml
+++ b/plugins/remove_finalizers.yml
@@ -1,0 +1,21 @@
+plugin:
+  remove_finalizers:
+    shortCut: Ctrl-F
+    confirm: true
+    scopes:
+      - all
+    description: Removes all finalizers from selected resource
+    command: kubectl
+    background: true
+    args:
+      - patch
+      - --context
+      - $CONTEXT
+      - --namespace
+      - $NAMESPACE
+      - $RESOURCE_NAME
+      - $NAME
+      - -p
+      - '{"metadata":{"finalizers":null}}'
+      - --type
+      - merge


### PR DESCRIPTION
# Add plugin to remove finalizers

From the [docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/#:~:text=Finalizers%20are%20namespaced%20keys%20that,resources%20the%20deleted%20object%20owned.).
> Finalizers are namespaced keys that tell Kubernetes to wait until specific conditions are met before it fully deletes resources marked for deletion. Finalizers alert [controllers](https://kubernetes.io/docs/concepts/architecture/controller/) to clean up resources the deleted object owned.

Before deleting an object you need to ensure that all finalizers has been removed. Usually this would be done by the specific controller but under some circumstances it is possible to encounter a set of objects blocked for deletion.

This plugins makes this task easier by providing a shortcut to directly removing them all.

Be careful when using this plugin as it may leave dangling resources or instantly deleting resources that were blocked by the finalizers.
