### PR TITLE
K9s/release v0.30.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ DATE       ?= $(shell TZ=UTC date -j -f "%s" ${SOURCE_DATE_EPOCH} +"%Y-%m-%dT%H:
 else
 DATE       ?= $(shell date -u -d @${SOURCE_DATE_EPOCH} +"%Y-%m-%dT%H:%M:%SZ")
 endif
-VERSION    ?= v0.30.1
+VERSION    ?= v0.30.2
 IMG_NAME   := derailed/k9s
 IMAGE      := ${IMG_NAME}:${VERSION}
 

--- a/README.md
+++ b/README.md
@@ -898,7 +898,7 @@ k9s:
       memory: 100Mi
   imageScans:
     enable: false
-    blackList:
+    exclusions:
       namespaces: []
       labels: {}
   logger:

--- a/change_logs/release_v0.30.0.md
+++ b/change_logs/release_v0.30.0.md
@@ -116,8 +116,8 @@ k9s:
   # ImageScan config changed from v0.29.0!
   imageScans:
     enable: false
-    # Now figures exclusions ie blacklist namespaces or specific workload labels
-    blackList:
+    # Now figures exclusions ie excludes certain namespaces or specific workload labels
+    exclusions:
       # Exclude the following namespaces for image vulscans!
       namespaces:
         - kube-system
@@ -236,13 +236,13 @@ This is a feature reported by many of you and its (finally!) here. As of this dr
 
 ---
 
-# The Black List...
+# Vulnerability Scan Exclusions...
 
 As it seems customary with all k9s new features, folks want to turn them off ;(
 The `Vulscan` feature did not get out unscaped ;(
 As it was rightfully so pointed out, you may want to opted out scans for images that you do not control.
 Tho I think it might be a good idea to run wide open once in a while to see if your cluster has any holes??
-For this reason, we've opted to intro a blacklist section under the image scan configuration to exclude certain images from the scans.
+For this reason, we've opted to intro an exclusion section under the image scan configuration to exclude certain images from the scans.
 
 Here is a sample configuration:
 
@@ -258,7 +258,7 @@ k9s:
     noIcons: false
   imageScans:
     enable: true
-    blackList:
+    exclusions:
       # Skip scans on these namespaces
       namespaces:
         - ns-1

--- a/change_logs/release_v0.30.1.md
+++ b/change_logs/release_v0.30.1.md
@@ -19,7 +19,7 @@ On Slack? Please join us [K9slackers](https://join.slack.com/t/k9sers/shared_inv
 
 ## 🎄 Maintenance Release! 🎄
 
-🎵 `On The twentyfouth day of Christmas my true love gave to me... Bugs!!` 🎵
+🎵 `On The eleventh day of Christmas my true love gave to me... Bugs!!` 🎵
 
 Got to love the aftermath... Thank you all for pitch'in in and help flesh out bugs!! The gift that keeps on... giving?
 
@@ -41,8 +41,8 @@ Please dial [K9s Channel](https://www.youtube.com/channel/UC897uwPygni4QIjkPCpgj
 * [#2368](https://github.com/derailed/k9s/issues/2368) Pod CPU and MEM columns are empty in 0.30.0
 * [#2367](https://github.com/derailed/k9s/issues/2367) k9s 0.30.0 issue loading plugins
 * [#2366](https://github.com/derailed/k9s/issues/2366) List pods of deployment is now impossible
-* [#2264](https://github.com/derailed/k9s/issues/2264) k9s 0.30.0 fields and values missed in action in the "namespace view"
-* [#2263](https://github.com/derailed/k9s/issues/2263) Default 0.30.0 default skin on macOS is no good
+* [#2364](https://github.com/derailed/k9s/issues/2364) k9s 0.30.0 fields and values missed in action in the "namespace view"
+* [#2363](https://github.com/derailed/k9s/issues/2363) Default 0.30.0 default skin on macOS is no good
 
 ---
 

--- a/change_logs/release_v0.30.2.md
+++ b/change_logs/release_v0.30.2.md
@@ -1,0 +1,96 @@
+<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/k9s-xmas.png" align="center" width="800" height="auto"/>
+
+# Release v0.30.2
+
+## Notes
+
+Thank you to all that contributed with flushing out issues and enhancements for K9s!
+I'll try to mark some of these issues as fixed. But if you don't mind grab the latest rev
+and see if we're happier with some of the fixes!
+If you've filed an issue please help me verify and close.
+
+Your support, kindness and awesome suggestions to make K9s better are, as ever, very much noted and appreciated!
+Also big thanks to all that have allocated their own time to help others on both slack and on this repo!!
+
+As you may know, K9s is not pimped out by corps with deep pockets, thus if you feel K9s is helping your Kubernetes journey,
+please consider joining our [sponsorship program](https://github.com/sponsors/derailed) and/or make some noise on social! [@kitesurfer](https://twitter.com/kitesurfer)
+
+On Slack? Please join us [K9slackers](https://join.slack.com/t/k9sers/shared_invite/enQtOTA5MDEyNzI5MTU0LWQ1ZGI3MzliYzZhZWEyNzYxYzA3NjE0YTk1YmFmNzViZjIyNzhkZGI0MmJjYzhlNjdlMGJhYzE2ZGU1NjkyNTM)
+
+## 🎄 Maintenance Release! 🎄
+
+🎵 `On The eleventh day of Christmas my true love gave to me... More Bugs!!` 🎵
+
+Thank you all for pitching in and help flesh out bugs!!
+
+---
+
+## [!!FEATURE NAME CHANGED!!] Vulnerability Scan Exclusions...
+
+As it seems customary with all k9s new features, folks want to turn them off ;(
+The `Vulscan` feature did not get out unscaped ;(
+As it was rightfully so pointed out, you may want to opted out scans for images that you do not control.
+Tho I think it might be a good idea to run wide open once in a while to see if your cluster has any holes??
+For this reason, we've opted to intro an exclusion section under the image scan configuration to exclude certain images from the scans.
+
+Here is a sample configuration:
+
+```yaml
+k9s:
+  liveViewAutoRefresh: false
+  refreshRate: 2
+  ui:
+    enableMouse: false
+    headless: false
+    logoless: false
+    crumbsless: false
+    noIcons: false
+  imageScans:
+    enable: true
+    # MOTE!! Field Name changed!!
+    exclusions:
+      # Skip scans on these namespaces
+      namespaces:
+        - ns-1
+        - ns-2
+      # Skip scans for pods matching these labels
+      labels:
+        - app:
+          - fred
+          - blee
+          - duh
+        - env:
+          - dev
+```
+
+---
+
+## Videos Are In The Can!
+
+Please dial [K9s Channel](https://www.youtube.com/channel/UC897uwPygni4QIjkPCpgjmw) for up coming content...
+
+* [K9s v0.30.0 Sneak peek](https://youtu.be/mVBc1XneRJ4)
+* [Vulnerability Scans](https://youtu.be/ULkl0MsaidU)
+
+---
+
+## Resolved Issues
+
+* [#2374](https://github.com/derailed/k9s/issues/2374) The headless parameter does not function properly (v0.30.1)
+* [#2372](https://github.com/derailed/k9s/issues/2372) Unable to set default resource to load (v0.30.1)
+* [#2371](https://github.com/derailed/k9s/issues/2371) --write cli option does not work (0.30.X)
+* [#2370](https://github.com/derailed/k9s/issues/2370) Wrong list of pods on node (0.30.X)
+* [#2362](https://github.com/derailed/k9s/issues/2362) blackList: Use inclusive language alternatives
+
+---
+
+## Contributed PRs
+
+Please be sure to give `Big Thanks!` and `ATTA Girls/Boys!` to all the fine contributors for making K9s better for all of us!!
+
+* [#2375](https://github.com/derailed/k9s/pull/2375) get node filtering params from matching context values
+* [#2373](https://github.com/derailed/k9s/pull/2373) fix command line flags not working
+
+---
+
+<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/imhotep_logo.png" width="32" height="auto"/> © 2023 Imhotep Software LLC. All materials licensed under [Apache v2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -170,7 +170,7 @@ var expectedConfig = `k9s:
       memory: 100Mi
   imageScans:
     enable: false
-    blackList:
+    exclusions:
       namespaces: []
       labels: {}
   logger:
@@ -212,7 +212,7 @@ var resetConfig = `k9s:
       memory: 100Mi
   imageScans:
     enable: false
-    blackList:
+    exclusions:
       namespaces: []
       labels: {}
   logger:

--- a/internal/config/scans.go
+++ b/internal/config/scans.go
@@ -21,19 +21,19 @@ func (l Labels) exclude(k, val string) bool {
 	return false
 }
 
-// Blacklist tracks vul scan exclusions.
-type BlackList struct {
+// ScanExcludes tracks vul scan exclusions.
+type ScanExcludes struct {
 	Namespaces []string `yaml:"namespaces"`
 	Labels     Labels   `yaml:"labels"`
 }
 
-func newBlackList() BlackList {
-	return BlackList{
+func newScanExcludes() ScanExcludes {
+	return ScanExcludes{
 		Labels: make(Labels),
 	}
 }
 
-func (b BlackList) exclude(ns string, ll map[string]string) bool {
+func (b ScanExcludes) exclude(ns string, ll map[string]string) bool {
 	for _, nss := range b.Namespaces {
 		if nss == ns {
 			return true
@@ -50,14 +50,14 @@ func (b BlackList) exclude(ns string, ll map[string]string) bool {
 
 // ImageScans tracks vul scans options.
 type ImageScans struct {
-	Enable    bool      `yaml:"enable"`
-	BlackList BlackList `yaml:"blackList"`
+	Enable     bool         `yaml:"enable"`
+	Exclusions ScanExcludes `yaml:"exclusions"`
 }
 
 // NewImageScans returns a new instance.
 func NewImageScans() *ImageScans {
 	return &ImageScans{
-		BlackList: newBlackList(),
+		Exclusions: newScanExcludes(),
 	}
 }
 
@@ -67,5 +67,5 @@ func (i *ImageScans) ShouldExclude(ns string, ll map[string]string) bool {
 		return false
 	}
 
-	return i.BlackList.exclude(ns, ll)
+	return i.Exclusions.exclude(ns, ll)
 }

--- a/internal/dao/pod.go
+++ b/internal/dao/pod.go
@@ -98,7 +98,7 @@ func (p *Pod) List(ctx context.Context, ns string) ([]runtime.Object, error) {
 	if withMx, ok := ctx.Value(internal.KeyWithMetrics).(bool); ok && withMx {
 		pmx, _ = client.DialMetrics(p.Client()).FetchPodsMetricsMap(ctx, ns)
 	}
-	sel, _ := ctx.Value(internal.KeyLabels).(string)
+	sel, _ := ctx.Value(internal.KeyFields).(string)
 	fsel, err := labels.ConvertSelectorToLabelsMap(sel)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
---

## [!!FEATURE NAME CHANGED!!] Vulnerability Scan Exclusions...

As it seems customary with all k9s new features, folks want to turn them off ;(
The `Vulscan` feature did not get out unscaped ;(
As it was rightfully so pointed out, you may want to opted out scans for images that you do not control.
Tho I think it might be a good idea to run wide open once in a while to see if your cluster has any holes??
For this reason, we've opted to intro an exclusion section under the image scan configuration to exclude certain images from the scans.

Here is a sample configuration:

```yaml
k9s:
  liveViewAutoRefresh: false
  refreshRate: 2
  ui:
    enableMouse: false
    headless: false
    logoless: false
    crumbsless: false
    noIcons: false
  imageScans:
    enable: true
    # MOTE!! Field Name changed!!
    exclusions:
      # Skip scans on these namespaces
      namespaces:
        - ns-1
        - ns-2
      # Skip scans for pods matching these labels
      labels:
        - app:
          - fred
          - blee
          - duh
        - env:
          - dev
```

---

## Resolved Issues

* [#2374](https://github.com/derailed/k9s/issues/2374) The headless parameter does not function properly (v0.30.1)
* [#2372](https://github.com/derailed/k9s/issues/2372) Unable to set default resource to load (v0.30.1)
* [#2371](https://github.com/derailed/k9s/issues/2371) --write cli option does not work (0.30.X)
* [#2370](https://github.com/derailed/k9s/issues/2370) Wrong list of pods on node (0.30.X)
* [#2362](https://github.com/derailed/k9s/issues/2362) blackList: Use inclusive language alternatives

---

## Contributed PRs

Please be sure to give `Big Thanks!` and `ATTA Girls/Boys!` to all the fine contributors for making K9s better for all of us!!

* [#2375](https://github.com/derailed/k9s/pull/2375) get node filtering params from matching context values
* [#2373](https://github.com/derailed/k9s/pull/2373) fix command line flags not working
