### PR TITLE
fix: create user tmp directory before the app one

### DIFF
--- a/internal/config/files.go
+++ b/internal/config/files.go
@@ -282,7 +282,7 @@ func userTmpDir() (string, error) {
 		return "", err
 	}
 
-	dir := filepath.Join(os.TempDir(), AppName, u.Username)
+	dir := filepath.Join(os.TempDir(), u.Username, AppName)
 
 	return dir, nil
 }


### PR DESCRIPTION
Prefer `/tmp/<myuser>/k9s/` over `/tmp/k9s/<myuser>/`.

Otherwise on a shared machine, the `/tmp/k9s` directory will be owned by the first user to launch the `k9s` command. Others will get a "permission denied" error.