### PR TITLE
feat: allow to customize logs dir through environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,22 @@ tail -f /Users/fernand/.local/data/k9s/k9s.log
 k9s -l debug
 ```
 
+### Customize logs destination
+
+You can override the default log file destination either with the `--logFile` argument:
+
+```shell
+k9s --logFile /tmp/k9s.log
+less /tmp/k9s.log
+```
+
+Or through the `K9S_LOGS_DIR` environment variable:
+
+```shell
+K9S_LOGS_DIR=/var/log k9s
+less /var/log/k9s.log
+```
+
 ## Key Bindings
 
 K9s uses aliases to navigate most K8s resources.

--- a/internal/config/files.go
+++ b/internal/config/files.go
@@ -19,6 +19,9 @@ const (
 	// K9sConfigDir represents k9s configuration dir env var.
 	K9sConfigDir = "K9S_CONFIG_DIR"
 
+	// K9sLogsDir represents k9s logs dir env var.
+	K9sLogsDir = "K9S_LOGS_DIR"
+
 	// AppName tracks k9s app name.
 	AppName = "k9s"
 
@@ -80,11 +83,20 @@ var (
 
 // InitLogsLoc initializes K9s logs location.
 func InitLogLoc() error {
-	tmpDir, err := userTmpDir()
-	if err != nil {
+	var appLogDir string
+	if envDir := os.Getenv(K9sLogsDir); envDir != "" {
+		appLogDir = envDir
+	} else {
+		tmpDir, err := userTmpDir()
+		if err != nil {
+			return err
+		}
+		appLogDir = tmpDir
+	}
+	if err := data.EnsureFullPath(appLogDir, data.DefaultDirMod); err != nil {
 		return err
 	}
-	AppLogFile = filepath.Join(tmpDir, K9sLogsFile)
+	AppLogFile = filepath.Join(appLogDir, K9sLogsFile)
 
 	return nil
 }
@@ -271,9 +283,6 @@ func userTmpDir() (string, error) {
 	}
 
 	dir := filepath.Join(os.TempDir(), AppName, u.Username)
-	if err := data.EnsureFullPath(dir, data.DefaultDirMod); err != nil {
-		return "", err
-	}
 
 	return dir, nil
 }


### PR DESCRIPTION
Allow to customize log directory through `K9S_LOGS_DIR` environment variable.
If not set, fallsback on default tmp directory.

Fixes #2394