### PR TITLE
supports referencing envs in hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ In order to surface hotkeys globally please follow these steps:
           shortCut:    Ctrl-U
           description: Namespaced resources
           command:     "$RESOURCE_NAME $NAMESPACE"
-          navigable:   true # whether you can return to the previous view
+          keepHistory: true # whether you can return to the previous view
       ```
 
  Not feeling so hot? Your custom hotkeys will be listed in the help view `?`.

--- a/README.md
+++ b/README.md
@@ -525,12 +525,20 @@ In order to surface hotkeys globally please follow these steps:
           shortCut:    Shift-2
           description: Xray Deployments
           command:     xray deploy
+        # Hitting Ctrl-U view the resources in the namespace of your current selection
+        ctrl-u:
+          shortCut:    Ctrl-U
+          description: Namespaced resources
+          command:     "$RESOURCE_NAME $NAMESPACE"
+          navigable:   true # whether you can return to the previous view
       ```
 
  Not feeling so hot? Your custom hotkeys will be listed in the help view `?`.
  Also your hotkeys file will be automatically reloaded so you can readily use your hotkeys as you define them.
 
  You can choose any keyboard shortcuts that make sense to you, provided they are not part of the standard K9s shortcuts list.
+
+ Similarly, referencing environment variables in hotkeys is also supported. The available environment variables can refer to the description in the [Plugins](#plugins) section.
 
 > NOTE: This feature/configuration might change in future releases!
 

--- a/internal/config/hotkey.go
+++ b/internal/config/hotkey.go
@@ -19,7 +19,7 @@ type HotKey struct {
 	ShortCut    string `yaml:"shortCut"`
 	Description string `yaml:"description"`
 	Command     string `yaml:"command"`
-	Navigable   bool   `yaml:"navigable"`
+	KeepHistory bool   `yaml:"keepHistory"`
 }
 
 // NewHotKeys returns a new plugin.

--- a/internal/config/hotkey.go
+++ b/internal/config/hotkey.go
@@ -19,6 +19,7 @@ type HotKey struct {
 	ShortCut    string `yaml:"shortCut"`
 	Description string `yaml:"description"`
 	Command     string `yaml:"command"`
+	Navigable   bool   `yaml:"navigable"`
 }
 
 // NewHotKeys returns a new plugin.

--- a/internal/config/hotkey_test.go
+++ b/internal/config/hotkey_test.go
@@ -21,5 +21,5 @@ func TestHotKeyLoad(t *testing.T) {
 	assert.Equal(t, "shift-0", k.ShortCut)
 	assert.Equal(t, "Launch pod view", k.Description)
 	assert.Equal(t, "pods", k.Command)
-	assert.Equal(t, true, k.Navigable)
+	assert.Equal(t, true, k.KeepHistory)
 }

--- a/internal/config/hotkey_test.go
+++ b/internal/config/hotkey_test.go
@@ -21,4 +21,5 @@ func TestHotKeyLoad(t *testing.T) {
 	assert.Equal(t, "shift-0", k.ShortCut)
 	assert.Equal(t, "Launch pod view", k.Description)
 	assert.Equal(t, "pods", k.Command)
+	assert.Equal(t, true, k.Navigable)
 }

--- a/internal/config/testdata/hotkeys.yaml
+++ b/internal/config/testdata/hotkeys.yaml
@@ -3,4 +3,4 @@ hotKeys:
     shortCut: shift-0
     description: Launch pod view
     command: pods
-    navigable: true
+    keepHistory: true

--- a/internal/config/testdata/hotkeys.yaml
+++ b/internal/config/testdata/hotkeys.yaml
@@ -3,3 +3,4 @@ hotKeys:
     shortCut: shift-0
     description: Launch pod view
     command: pods
+    navigable: true

--- a/internal/view/actions.go
+++ b/internal/view/actions.go
@@ -74,16 +74,23 @@ func hotKeyActions(r Runner, aa ui.KeyActions) {
 			log.Warn().Err(fmt.Errorf("HOT-KEY Doh! you are trying to override an existing command `%s", k)).Msg("Invalid shortcut")
 			continue
 		}
+
+		command, err := r.EnvFn()().Substitute(hk.Command)
+		if err != nil {
+			log.Warn().Err(err).Msg("Invalid shortcut command")
+			continue
+		}
+
 		aa[key] = ui.NewSharedKeyAction(
 			hk.Description,
-			gotoCmd(r, hk.Command, ""),
+			gotoCmd(r, command, "", !hk.Navigable),
 			false)
 	}
 }
 
-func gotoCmd(r Runner, cmd, path string) ui.ActionHandler {
+func gotoCmd(r Runner, cmd, path string, clearStack bool) ui.ActionHandler {
 	return func(evt *tcell.EventKey) *tcell.EventKey {
-		r.App().gotoResource(cmd, path, true)
+		r.App().gotoResource(cmd, path, clearStack)
 		return nil
 	}
 }

--- a/internal/view/actions.go
+++ b/internal/view/actions.go
@@ -83,7 +83,7 @@ func hotKeyActions(r Runner, aa ui.KeyActions) {
 
 		aa[key] = ui.NewSharedKeyAction(
 			hk.Description,
-			gotoCmd(r, command, "", !hk.Navigable),
+			gotoCmd(r, command, "", !hk.KeepHistory),
 			false)
 	}
 }


### PR DESCRIPTION
related issues: #2334.

This PR introduces a new setting to the hotkeys, allowing one to choose if the current view should be kept. for example:
```yaml
hotKeys:
  ctrl-u:
    shortCut:    Ctrl-U
    description: Namespaced resources
    command:     "$RESOURCE_NAME $NAMESPACE"
    navigable:   true
```