### PR TITLE
code cleaning and addition of missing schema

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,6 +207,9 @@ func (c *Config) Merge(c1 *Config) {
 func (c *Config) Load(path string) error {
 	bb, err := os.ReadFile(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 	if err := data.JSONValidator.Validate(json.K9sSchema, bb); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -537,7 +537,7 @@ func TestConfigLoad(t *testing.T) {
 func TestConfigLoadCrap(t *testing.T) {
 	cfg := mock.NewMockConfig()
 
-	assert.NotNil(t, cfg.Load("testdata/configs/k9s_not_there.yaml"))
+	assert.NoError(t, cfg.Load("testdata/configs/k9s_not_there.yaml"))
 }
 
 func TestConfigSaveFile(t *testing.T) {

--- a/internal/config/json/schemas/hotkeys.json
+++ b/internal/config/json/schemas/hotkeys.json
@@ -11,7 +11,8 @@
         "properties": {
           "shortCut": {"type": "string"},
           "description": {"type": "string"},
-          "command": {"type": "string"}
+          "command": {"type": "string"},
+          "keepHistory": {"type": "boolean"}
         }
       }
     }


### PR DESCRIPTION
When the configuration file does not exist or the configuration file validate is wrong it will panic and exit.