### PR TITLE
fix: add missing shellpod config in schema

### DIFF
--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -55,7 +55,17 @@
               "additionalProperties": { "type": "string" },
               "required": []
             },
-            "tty": { "type": "boolean" }
+            "tty": { "type": "boolean" },
+            "imagePullPolicy": { "type": "string" },
+            "imagePullSecrets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" }
+                }
+              }
+            }
           },
           "required": ["image", "namespace", "limits"]
         },


### PR DESCRIPTION
Some fields were omitted in the config schema for the shellPod section. This PR adds them.