### PR TITLE
shell autocomplete for k8s flags

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -71,7 +71,7 @@ func InitConnection(config *Config) (*APIClient, error) {
 	if err != nil {
 		log.Error().Err(err).Msgf("Fail to locate metrics-server")
 	}
-	if errors.Is(err, noMetricServerErr) || errors.Is(err, metricsUnsupportedErr) {
+	if err == nil || errors.Is(err, noMetricServerErr) || errors.Is(err, metricsUnsupportedErr) {
 		return &a, nil
 	}
 	a.connOK = false


### PR DESCRIPTION
This PR has resolved the following two issues:
1. panic should not occur when dealing with incorrect command line flags.
2. Introduce autocomplete functionality for flags context, cluster, user, and namespace.

fixes #2471.