### PR TITLE
feat: add openshift community plugin

### DIFF
--- a/plugins/openshift.yaml
+++ b/plugins/openshift.yaml
@@ -1,0 +1,36 @@
+plugins:
+  # openshift community plugin (no official support by Red Hat)
+  # Requires the oc command-line tool in PATH
+  # Install using https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html
+  openshift-shell:
+    shortCut: Shift-X
+    description: Debug Node
+    scopes:
+      - nodes
+    command: oc
+    background: false
+    args:
+      - debug
+      - node/$NAME
+      - -n
+      - $NAMESPACE
+      - -q
+  openshift-root-shell:
+    shortCut: Ctrl-X
+    description: Debug Node (Root)
+    scopes:
+      - nodes
+    command: oc
+    background: false
+    args:
+      - debug
+      - node/$NAME
+      - -n
+      - $NAMESPACE
+      - --as-user=0
+      - --as-root=true
+      - -q
+      - -t
+      - --
+      - chroot
+      - /host


### PR DESCRIPTION
This adds a community plugin for openshift which includes 2 commands for debugging into a node via shell as root or non-root.

On node view one can now easily open up a shell into the node for debugging RHCOS within Openshift.

Other commands can be added at will, this is not maintained by Red Hat but just a nice addition I really love to use together with k9s.