### PR TITLE
feat: allow override of plugins & hotkeys shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,8 +524,9 @@ In order to surface hotkeys globally please follow these steps:
           description: Xray Deployments
           command:     xray deploy
         # Hitting Ctrl-U view the resources in the namespace of your current selection
-        ctrl-u:
-          shortCut:    Ctrl-U
+        shift-s:
+          shortCut:    Shift-S
+          override:    true # => will override the default shortcut related action if set to true (default to false)
           description: Namespaced resources
           command:     "$RESOURCE_NAME $NAMESPACE"
           keepHistory: true # whether you can return to the previous view
@@ -669,6 +670,7 @@ plugins:
   # Defines a plugin to provide a `ctrl-l` shortcut to tail the logs while in pod view.
   fred:
     shortCut: Ctrl-L
+    override: false # => will override the default shortcut related action if set to true (default to false)
     confirm: false
     description: Pod logs
     scopes:

--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ K9s allows you to extend your command line and tooling by defining your very own
 A plugin is defined as follows:
 
 * Shortcut option represents the key combination a user would type to activate the plugin
+* Override option make that the default action related to the shortcut will be overrided by the plugin
 * Confirm option (when enabled) lets you see the command that is going to be executed and gives you an option to confirm or prevent execution
 * Description will be printed next to the shortcut in the k9s menu
 * Scopes defines a collection of resources names/short-names for the views associated with the plugin. You can specify `all` to provide this shortcut for all views.
@@ -670,7 +671,7 @@ plugins:
   # Defines a plugin to provide a `ctrl-l` shortcut to tail the logs while in pod view.
   fred:
     shortCut: Ctrl-L
-    override: false # => will override the default shortcut related action if set to true (default to false)
+    override: false
     confirm: false
     description: Pod logs
     scopes:

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ In order to surface hotkeys globally please follow these steps:
           shortCut:    Shift-2
           description: Xray Deployments
           command:     xray deploy
-        # Hitting Ctrl-U view the resources in the namespace of your current selection
+        # Hitting Shift-S view the resources in the namespace of your current selection
         shift-s:
           shortCut:    Shift-S
           override:    true # => will override the default shortcut related action if set to true (default to false)

--- a/internal/config/hotkey.go
+++ b/internal/config/hotkey.go
@@ -20,6 +20,7 @@ type HotKeys struct {
 // HotKey describes a K9s hotkey.
 type HotKey struct {
 	ShortCut    string `yaml:"shortCut"`
+	Override    bool   `yaml:"override"`
 	Description string `yaml:"description"`
 	Command     string `yaml:"command"`
 	KeepHistory bool   `yaml:"keepHistory"`

--- a/internal/config/json/schemas/hotkeys.json
+++ b/internal/config/json/schemas/hotkeys.json
@@ -10,6 +10,7 @@
         "type": "object",
         "properties": {
           "shortCut": {"type": "string"},
+          "override": { "type": "boolean" },
           "description": {"type": "string"},
           "command": {"type": "string"},
           "keepHistory": {"type": "boolean"}

--- a/internal/config/json/schemas/plugins.json
+++ b/internal/config/json/schemas/plugins.json
@@ -11,6 +11,7 @@
         "additionalProperties": false,
         "properties": {
           "shortCut": { "type": "string" },
+          "override": { "type": "boolean" },
           "description": { "type": "string" },
           "confirm": { "type": "boolean" },
           "scopes": {

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -29,6 +29,7 @@ type Plugin struct {
 	Scopes      []string `yaml:"scopes"`
 	Args        []string `yaml:"args"`
 	ShortCut    string   `yaml:"shortCut"`
+	Override    bool     `yaml:"override"`
 	Pipes       []string `yaml:"pipes"`
 	Description string   `yaml:"description"`
 	Command     string   `yaml:"command"`

--- a/internal/view/actions.go
+++ b/internal/view/actions.go
@@ -76,7 +76,7 @@ func hotKeyActions(r Runner, aa ui.KeyActions) error {
 			continue
 		}
 		_, ok := aa[key]
-		if ok {
+		if ok && !hk.Override {
 			errs = errors.Join(errs, fmt.Errorf("duplicated hotkeys found for %q in %q", hk.ShortCut, k))
 			continue
 		}
@@ -124,12 +124,13 @@ func pluginActions(r Runner, aa ui.KeyActions) error {
 			continue
 		}
 		key, err := asKey(plugin.ShortCut)
+
 		if err != nil {
 			errs = errors.Join(errs, err)
 			continue
 		}
 		_, ok := aa[key]
-		if ok {
+		if ok && !plugin.Override {
 			errs = errors.Join(errs, fmt.Errorf("duplicated plugin key found for %q in %q", plugin.ShortCut, k))
 			continue
 		}

--- a/internal/view/actions.go
+++ b/internal/view/actions.go
@@ -79,6 +79,8 @@ func hotKeyActions(r Runner, aa ui.KeyActions) error {
 		if ok && !hk.Override {
 			errs = errors.Join(errs, fmt.Errorf("duplicated hotkeys found for %q in %q", hk.ShortCut, k))
 			continue
+		} else if ok && hk.Override == true {
+			log.Info().Msgf("Action %q has been overrided by hotkey %q", hk.ShortCut, k)
 		}
 
 		command, err := r.EnvFn()().Substitute(hk.Command)
@@ -133,6 +135,8 @@ func pluginActions(r Runner, aa ui.KeyActions) error {
 		if ok && !plugin.Override {
 			errs = errors.Join(errs, fmt.Errorf("duplicated plugin key found for %q in %q", plugin.ShortCut, k))
 			continue
+		} else if ok && plugin.Override == true {
+			log.Info().Msgf("Action %q has been overrided by plugin in %q", plugin.ShortCut, k)
 		}
 		aa[key] = ui.NewKeyActionWithOpts(
 			plugin.Description,

--- a/internal/view/actions.go
+++ b/internal/view/actions.go
@@ -80,7 +80,7 @@ func hotKeyActions(r Runner, aa ui.KeyActions) error {
 			errs = errors.Join(errs, fmt.Errorf("duplicated hotkeys found for %q in %q", hk.ShortCut, k))
 			continue
 		} else if ok && hk.Override == true {
-			log.Info().Msgf("Action %q has been overrided by hotkey %q", hk.ShortCut, k)
+			log.Info().Msgf("Action %q has been overrided by hotkey in %q", hk.ShortCut, k)
 		}
 
 		command, err := r.EnvFn()().Substitute(hk.Command)


### PR DESCRIPTION
This PR make the possibility to override some default keys by a plugin shortcut or a hotkey.

It resolve this issue https://github.com/derailed/k9s/issues/1736

adding `override: true` in a plugin or hotkey definition makes the override possible.