### PR TITLE
adding the f command to pf extender view

### DIFF
--- a/internal/view/dp_test.go
+++ b/internal/view/dp_test.go
@@ -16,5 +16,5 @@ func TestDeploy(t *testing.T) {
 
 	assert.Nil(t, v.Init(makeCtx()))
 	assert.Equal(t, "Deployments", v.Name())
-	assert.Equal(t, 14, len(v.Hints()))
+	assert.Equal(t, 15, len(v.Hints()))
 }

--- a/internal/view/ds_test.go
+++ b/internal/view/ds_test.go
@@ -16,5 +16,5 @@ func TestDaemonSet(t *testing.T) {
 
 	assert.Nil(t, v.Init(makeCtx()))
 	assert.Equal(t, "DaemonSets", v.Name())
-	assert.Equal(t, 15, len(v.Hints()))
+	assert.Equal(t, 16, len(v.Hints()))
 }

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -117,7 +117,6 @@ func (p *Pod) bindKeys(aa ui.KeyActions) {
 
 	aa.Add(ui.KeyActions{
 		ui.KeyN:      ui.NewKeyAction("Show Node", p.showNode, true),
-		ui.KeyF:      ui.NewKeyAction("Show PortForward", p.showPFCmd, true),
 		ui.KeyShiftR: ui.NewKeyAction("Sort Ready", p.GetTable().SortColCmd(readyCol, true), false),
 		ui.KeyShiftT: ui.NewKeyAction("Sort Restart", p.GetTable().SortColCmd("RESTARTS", false), false),
 		ui.KeyShiftS: ui.NewKeyAction("Sort Status", p.GetTable().SortColCmd(statusCol, true), false),
@@ -194,33 +193,6 @@ func (p *Pod) showNode(evt *tcell.EventKey) *tcell.EventKey {
 	}
 
 	return nil
-}
-
-func (p *Pod) showPFCmd(evt *tcell.EventKey) *tcell.EventKey {
-	path := p.GetTable().GetSelectedItem()
-	if path == "" {
-		return evt
-	}
-
-	if !p.App().factory.Forwarders().IsPodForwarded(path) {
-		p.App().Flash().Errf("no port-forward defined")
-		return nil
-	}
-	pf := NewPortForward(client.NewGVR("portforwards"))
-	pf.SetContextFn(p.portForwardContext)
-	if err := p.App().inject(pf, false); err != nil {
-		p.App().Flash().Err(err)
-	}
-
-	return nil
-}
-
-func (p *Pod) portForwardContext(ctx context.Context) context.Context {
-	if bc := p.App().BenchFile; bc != "" {
-		ctx = context.WithValue(ctx, internal.KeyBenchCfg, p.App().BenchFile)
-	}
-
-	return context.WithValue(ctx, internal.KeyPath, p.GetTable().GetSelectedItem())
 }
 
 func (p *Pod) killCmd(evt *tcell.EventKey) *tcell.EventKey {

--- a/internal/view/sts_test.go
+++ b/internal/view/sts_test.go
@@ -16,5 +16,5 @@ func TestStatefulSetNew(t *testing.T) {
 
 	assert.Nil(t, s.Init(makeCtx()))
 	assert.Equal(t, "StatefulSets", s.Name())
-	assert.Equal(t, 12, len(s.Hints()))
+	assert.Equal(t, 13, len(s.Hints()))
 }

--- a/internal/view/svc_test.go
+++ b/internal/view/svc_test.go
@@ -173,5 +173,5 @@ func TestServiceNew(t *testing.T) {
 
 	assert.Nil(t, s.Init(makeCtx()))
 	assert.Equal(t, "Services", s.Name())
-	assert.Equal(t, 10, len(s.Hints()))
+	assert.Equal(t, 11, len(s.Hints()))
 }


### PR DESCRIPTION
In practice, I may be creating port-forward in svc or dp view, but I found that I can't view the enabled forwarding via f command in these views, I have to switch to po view to see it.

So this PR inlines the f command directly in pf_extender, what do you think about this approach?