### PR TITLE
Added defaultsToFullScreen flag for Live/Details view,logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,16 +385,27 @@ K9s uses aliases to navigate most K8s resources.
     refreshRate: 2
     # Number of retries once the connection to the api-server is lost. Default 15.
     maxConnRetry: 5
-    # Enable mouse support. Default false
-    enableMouse: true
-    # Set to true to hide K9s header. Default false
-    headless: false
-    # Set to true to hide K9s crumbs. Default false
-    crumbsless: false
     # Indicates whether modification commands like delete/kill/edit are disabled. Default is false
     readOnly: false
     # Toggles whether k9s should exit when CTRL-C is pressed. When set to true, you will need to exist k9s via the :quit command. Default is false.
     noExitOnCtrlC: false
+    #UI settings
+    ui:
+      # Enable mouse support. Default false
+      enableMouse: false
+      # Set to true to hide K9s header. Default false
+      headless: false
+      # Set to true to hide the K9S logo Default false
+      logoless: false
+      # Set to true to hide K9s crumbs. Default false
+      crumbsless: false
+      noIcons: false
+      # Toggles reactive UI. This option provide for watching on disk artifacts changes and update the UI live Defaults to false.
+      reactive: false
+      # By default all contexts wil use the dracula skin unless explicitly overridden in the context config file.
+      skin: dracula # => assumes the file skins/dracula.yaml is present in the  $XDG_DATA_HOME/k9s/skins directory
+      # By default start all Live_View in full screen mode. (yaml, helm history, describe, value_extender) Default false
+      fullScreenLView: false
     # Toggles icons display as not all terminal support these chars.
     noIcons: false
     # Toggles whether k9s should check for the latest revision from the Github repository releases. Default is false.
@@ -410,7 +421,7 @@ K9s uses aliases to navigate most K8s resources.
       # Represents how far to go back in the log timeline in seconds. Setting to -1 will tail logs. Default is -1.
       sinceSeconds: 300 # => tail the last 5 mins.
       # Go full screen while displaying logs. Default false
-      fullScreenLogs: false
+      fullScreen: false
       # Toggles log line wrap. Default false
       textWrap: false
       # Toggles log line timestamp info. Default false
@@ -912,6 +923,7 @@ k9s:
     reactive: false
     # By default all contexts wil use the dracula skin unless explicitly overridden in the context config file.
     skin: dracula # => assumes the file skins/dracula.yaml is present in the  $XDG_DATA_HOME/k9s/skins directory
+    fullScreenLView: false
   skipLatestRevCheck: false
   disablePodCounting: false
   shellPod:

--- a/README.md
+++ b/README.md
@@ -404,8 +404,8 @@ K9s uses aliases to navigate most K8s resources.
       reactive: false
       # By default all contexts wil use the dracula skin unless explicitly overridden in the context config file.
       skin: dracula # => assumes the file skins/dracula.yaml is present in the  $XDG_DATA_HOME/k9s/skins directory
-      # By default start all Live_View in full screen mode. (yaml, helm history, describe, value_extender) Default false
-      fullScreenLView: false
+      # Allows to set certain views default fullscreen mode. (yaml, helm history, describe, value_extender, details, logs) Default false
+      defaultsToFullScreen: false
     # Toggles icons display as not all terminal support these chars.
     noIcons: false
     # Toggles whether k9s should check for the latest revision from the Github repository releases. Default is false.
@@ -420,8 +420,6 @@ K9s uses aliases to navigate most K8s resources.
       buffer: 500
       # Represents how far to go back in the log timeline in seconds. Setting to -1 will tail logs. Default is -1.
       sinceSeconds: 300 # => tail the last 5 mins.
-      # Go full screen while displaying logs. Default false
-      fullScreen: false
       # Toggles log line wrap. Default false
       textWrap: false
       # Toggles log line timestamp info. Default false
@@ -923,7 +921,7 @@ k9s:
     reactive: false
     # By default all contexts wil use the dracula skin unless explicitly overridden in the context config file.
     skin: dracula # => assumes the file skins/dracula.yaml is present in the  $XDG_DATA_HOME/k9s/skins directory
-    fullScreenLView: false
+    defaultsToFullScreen: false
   skipLatestRevCheck: false
   disablePodCounting: false
   shellPod:
@@ -941,7 +939,6 @@ k9s:
     tail: 100
     buffer: 5000
     sinceSeconds: -1
-    fullScreen: false
     textWrap: false
     showTime: false
   thresholds:

--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -25,7 +25,8 @@
             "crumbsless": {"type": "boolean"},
             "noIcons": {"type": "boolean"},
             "reactive": {"type": "boolean"},
-            "skin": {"type": "string"}
+            "skin": {"type": "string"},
+            "fullScreenLView": {"type": "boolean"}
           }
         },
         "shellPod": {

--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -26,7 +26,7 @@
             "noIcons": {"type": "boolean"},
             "reactive": {"type": "boolean"},
             "skin": {"type": "string"},
-            "fullScreenLView": {"type": "boolean"}
+            "defaultsToFullScreen": {"type": "boolean"}
           }
         },
         "shellPod": {
@@ -102,7 +102,6 @@
             "tail": {"type": "integer"},
             "buffer": {"type": "integer"},
             "sinceSeconds": {"type": "integer"},
-            "fullScreen": {"type": "boolean"},
             "textWrap": {"type": "boolean"},
             "showTime": {"type": "boolean"}
           }

--- a/internal/config/json/testdata/k9s/cool.yaml
+++ b/internal/config/json/testdata/k9s/cool.yaml
@@ -28,7 +28,6 @@ k9s:
     tail: 100
     buffer: 5000
     sinceSeconds: -1
-    fullScreen: false
     textWrap: false
     showTime: false
   thresholds:

--- a/internal/config/json/testdata/k9s/toast.yaml
+++ b/internal/config/json/testdata/k9s/toast.yaml
@@ -22,7 +22,6 @@ k9s:
     tail: 100
     buffer: 5000
     sinceSeconds: -1
-    fullScreen: false
     textWrap: false
     showTime: false
   thresholds:

--- a/internal/config/logger.go
+++ b/internal/config/logger.go
@@ -19,7 +19,6 @@ type Logger struct {
 	TailCount    int64 `json:"tail" yaml:"tail"`
 	BufferSize   int   `json:"buffer" yaml:"buffer"`
 	SinceSeconds int64 `json:"sinceSeconds" yaml:"sinceSeconds"`
-	FullScreen   bool  `json:"fullScreen" yaml:"fullScreen"`
 	TextWrap     bool  `json:"textWrap" yaml:"textWrap"`
 	ShowTime     bool  `json:"showTime" yaml:"showTime"`
 }

--- a/internal/config/testdata/configs/default.yaml
+++ b/internal/config/testdata/configs/default.yaml
@@ -12,7 +12,7 @@ k9s:
     crumbsless: false
     reactive: false
     noIcons: false
-    fullScreenLView: false
+    defaultsToFullScreen: false
   skipLatestRevCheck: false
   disablePodCounting: false
   shellPod:
@@ -30,7 +30,6 @@ k9s:
     tail: 100
     buffer: 5000
     sinceSeconds: -1
-    fullScreen: false
     textWrap: false
     showTime: false
   thresholds:

--- a/internal/config/testdata/configs/default.yaml
+++ b/internal/config/testdata/configs/default.yaml
@@ -12,6 +12,7 @@ k9s:
     crumbsless: false
     reactive: false
     noIcons: false
+    fullScreenLView: false
   skipLatestRevCheck: false
   disablePodCounting: false
   shellPod:

--- a/internal/config/testdata/configs/expected.yaml
+++ b/internal/config/testdata/configs/expected.yaml
@@ -12,7 +12,7 @@ k9s:
     crumbsless: false
     reactive: false
     noIcons: false
-    fullScreenLView: false
+    defaultsToFullScreen: false
   skipLatestRevCheck: false
   disablePodCounting: false
   shellPod:
@@ -30,7 +30,6 @@ k9s:
     tail: 500
     buffer: 800
     sinceSeconds: -1
-    fullScreen: false
     textWrap: false
     showTime: false
   thresholds:

--- a/internal/config/testdata/configs/expected.yaml
+++ b/internal/config/testdata/configs/expected.yaml
@@ -12,6 +12,7 @@ k9s:
     crumbsless: false
     reactive: false
     noIcons: false
+    fullScreenLView: false
   skipLatestRevCheck: false
   disablePodCounting: false
   shellPod:

--- a/internal/config/testdata/configs/k9s.yaml
+++ b/internal/config/testdata/configs/k9s.yaml
@@ -12,7 +12,7 @@ k9s:
     crumbsless: false
     reactive: false
     noIcons: false
-    fullScreenLView: false
+    defaultsToFullScreen: false
   skipLatestRevCheck: false
   disablePodCounting: false
   shellPod:
@@ -30,7 +30,6 @@ k9s:
     tail: 200
     buffer: 2000
     sinceSeconds: -1
-    fullScreen: false
     textWrap: false
     showTime: false
   thresholds:

--- a/internal/config/testdata/configs/k9s.yaml
+++ b/internal/config/testdata/configs/k9s.yaml
@@ -12,6 +12,7 @@ k9s:
     crumbsless: false
     reactive: false
     noIcons: false
+    fullScreenLView: false
   skipLatestRevCheck: false
   disablePodCounting: false
   shellPod:

--- a/internal/config/testdata/configs/k9s_toast.yaml
+++ b/internal/config/testdata/configs/k9s_toast.yaml
@@ -28,7 +28,6 @@ k9s:
     tail: 200
     buffer: 2000
     sinceSeconds: -1
-    fullScreen: false
     textWrap: false
     showTime: false
   thresholds:

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -32,6 +32,6 @@ type UI struct {
 	// Can be overridden per context.
 	Skin string `json:"skin" yaml:"skin,omitempty"`
 
-	// FullScreenLView sets default full screen for live_view.
-	FullScreenLView bool `json:"fullScreenLView" yaml:"fullScreenLView"`
+	// DefaultsToFullScreen toggles fullscreen on views like logs, yaml, details.
+	DefaultsToFullScreen bool `json:"defaultsToFullScreen" yaml:"defaultsToFullScreen"`
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -31,4 +31,7 @@ type UI struct {
 	// Skin reference the general k9s skin name.
 	// Can be overridden per context.
 	Skin string `json:"skin" yaml:"skin,omitempty"`
+
+	// FullScreenLView sets default full screen for live_view.
+	FullScreenLView bool `json:"fullScreenLView" yaml:"fullScreenLView"`
 }

--- a/internal/view/details.go
+++ b/internal/view/details.go
@@ -76,6 +76,7 @@ func (d *Details) Init(_ context.Context) error {
 
 	d.app.Styles.AddListener(d)
 	d.StylesChanged(d.app.Styles)
+	d.setFullScreen(d.app.Config.K9s.UI.DefaultsToFullScreen)
 
 	d.app.Prompt().SetModel(d.cmdBuff)
 	d.cmdBuff.AddListener(d)
@@ -226,16 +227,20 @@ func (d *Details) toggleFullScreenCmd(evt *tcell.EventKey) *tcell.EventKey {
 		return evt
 	}
 
-	d.fullScreen = !d.fullScreen
-	d.SetFullScreen(d.fullScreen)
-	d.Box.SetBorder(!d.fullScreen)
-	if d.fullScreen {
+	d.setFullScreen(!d.fullScreen)
+
+	return nil
+}
+
+func (d *Details) setFullScreen(isFullScreen bool) {
+	d.fullScreen = isFullScreen
+	d.SetFullScreen(isFullScreen)
+	d.Box.SetBorder(!isFullScreen)
+	if isFullScreen {
 		d.Box.SetBorderPadding(0, 0, 0, 0)
 	} else {
 		d.Box.SetBorderPadding(0, 0, 1, 1)
 	}
-
-	return nil
 }
 
 func (d *Details) prevCmd(evt *tcell.EventKey) *tcell.EventKey {

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -78,6 +78,7 @@ func (v *LiveView) Init(_ context.Context) error {
 
 	v.app.Styles.AddListener(v)
 	v.StylesChanged(v.app.Styles)
+	v.setFullScreen(v.app.Config.K9s.UI.FullScreenLView)
 
 	v.app.Prompt().SetModel(v.cmdBuff)
 	v.cmdBuff.AddListener(v)
@@ -286,16 +287,20 @@ func (v *LiveView) toggleFullScreenCmd(evt *tcell.EventKey) *tcell.EventKey {
 		return evt
 	}
 
-	v.fullScreen = !v.fullScreen
-	v.SetFullScreen(v.fullScreen)
-	v.Box.SetBorder(!v.fullScreen)
-	if v.fullScreen {
+	v.setFullScreen(!v.fullScreen)
+
+	return nil
+}
+
+func (v *LiveView) setFullScreen(isFullScreen bool) {
+	v.fullScreen = isFullScreen
+	v.SetFullScreen(isFullScreen)
+	v.Box.SetBorder(!isFullScreen)
+	if isFullScreen {
 		v.Box.SetBorderPadding(0, 0, 0, 0)
 	} else {
 		v.Box.SetBorderPadding(0, 0, 1, 1)
 	}
-
-	return nil
 }
 
 func (v *LiveView) nextCmd(evt *tcell.EventKey) *tcell.EventKey {

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -78,7 +78,7 @@ func (v *LiveView) Init(_ context.Context) error {
 
 	v.app.Styles.AddListener(v)
 	v.StylesChanged(v.app.Styles)
-	v.setFullScreen(v.app.Config.K9s.UI.FullScreenLView)
+	v.setFullScreen(v.app.Config.K9s.UI.DefaultsToFullScreen)
 
 	v.app.Prompt().SetModel(v.cmdBuff)
 	v.cmdBuff.AddListener(v)

--- a/internal/view/log_indicator.go
+++ b/internal/view/log_indicator.go
@@ -34,7 +34,7 @@ func NewLogIndicator(cfg *config.Config, styles *config.Styles, allContainers bo
 		TextView:                   tview.NewTextView(),
 		indicator:                  make([]byte, 0, 100),
 		scrollStatus:               1,
-		fullScreen:                 cfg.K9s.Logger.FullScreen,
+		fullScreen:                 cfg.K9s.UI.DefaultsToFullScreen,
 		textWrap:                   cfg.K9s.Logger.TextWrap,
 		showTime:                   cfg.K9s.Logger.ShowTime,
 		shouldDisplayAllContainers: allContainers,


### PR DESCRIPTION
Added fullScreenlView flag to config.yaml to allow setting default behaviour for LiveView which includes yaml, helm history, describe, value_extender. [2506](https://github.com/derailed/k9s/issues/2506)

I am not quite sure if this flag is the best under UI.