### PR TITLE
fix the --write flag

### DIFF
--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -304,7 +304,7 @@ func (k *K9s) IsReadOnly() bool {
 		ro = *cfg.Context.ReadOnly
 	}
 	if k.manualReadOnly != nil {
-		ro = true
+		ro = *k.manualReadOnly
 	}
 
 	return ro


### PR DESCRIPTION
--write sets k.manualReadOnly to false, but this was previously setting the read only state to true if k.manualReadOnly was set at all

fixes #2371 (again)