### PR TITLE
Add Rose Pine moon and dawn variants to skins

### DIFF
--- a/skins/rose-pine-dawn.yaml
+++ b/skins/rose-pine-dawn.yaml
@@ -1,0 +1,110 @@
+# -----------------------------------------------------------------------------
+# Rose Pine Dawn
+# https://rosepinetheme.com/palette/ingredients/
+# -----------------------------------------------------------------------------
+#
+text: &text "#575279"
+base: &base "#faf4ed"
+overlay: &overlay "#f2e9e1"
+muted: &muted "#9893a5"
+rose: &rose "#d7827e"
+pine: &pine "#286983"
+gold: &gold "#ea9d34"
+iris: &iris "#907aa9"
+love: &love "#b4637a"
+
+# Skin...
+k9s:
+  # General K9s styles
+  body:
+    fgColor: *text
+    bgColor: *base
+    logoColor: *iris
+  # Command prompt styles
+  prompt:
+    fgColor: *text
+    bgColor: *base
+    suggestColor: *iris
+  # ClusterInfoView styles.
+  info:
+    fgColor: *iris
+    sectionColor: *text
+  # Dialog styles.
+  dialog:
+    fgColor: *text
+    bgColor: *base
+    buttonFgColor: *text
+    buttonBgColor: *iris
+    buttonFocusFgColor: *gold
+    buttonFocusBgColor: *iris
+    labelFgColor: *gold
+    fieldFgColor: *text
+  frame:
+    # Borders styles.
+    border:
+      fgColor: *overlay
+      focusColor: *overlay
+    menu:
+      fgColor: *text
+      keyColor: *iris
+      # Used for favorite namespaces
+      numKeyColor: *iris
+    # CrumbView attributes for history navigation.
+    crumbs:
+      fgColor: *text
+      bgColor: *overlay
+      activeColor: *overlay
+    # Resource status and update styles
+    status:
+      newColor: *rose
+      modifyColor: *iris
+      addColor: *pine
+      errorColor: *love
+      highlightcolor: *gold
+      killColor: *muted
+      completedColor: *muted
+    # Border title styles.
+    title:
+      fgColor: *text
+      bgColor: *overlay
+      highlightColor: *gold
+      counterColor: *iris
+      filterColor: *iris
+  views:
+    # Charts skins...
+    charts:
+      bgColor: default
+      defaultDialColors:
+        - *iris
+        - *love
+      defaultChartColors:
+        - *iris
+        - *love
+    # TableView attributes.
+    table:
+      fgColor: *text
+      bgColor: *base
+      # Header row styles.
+      header:
+        fgColor: *text
+        bgColor: *base
+        sorterColor: *rose
+    # Xray view attributes.
+    xray:
+      fgColor: *text
+      bgColor: *base
+      cursorColor: *overlay
+      graphicColor: *iris
+      showIcons: false
+    # YAML info styles.
+    yaml:
+      keyColor: *iris
+      colonColor: *iris
+      valueColor: *text
+    # Logs styles.
+    logs:
+      fgColor: *text
+      bgColor: *base
+      indicator:
+        fgColor: *text
+        bgColor: *iris

--- a/skins/rose-pine-moon.yaml
+++ b/skins/rose-pine-moon.yaml
@@ -1,0 +1,110 @@
+# -----------------------------------------------------------------------------
+# Rose Pine Main
+# https://rosepinetheme.com/palette/ingredients/
+# -----------------------------------------------------------------------------
+#
+text: &text "#e0def4"
+base: &base "#232136"
+overlay: &overlay "#393552"
+muted: &muted "#6e6a86"
+rose: &rose "#ea9a97"
+pine: &pine "#3e8fb0"
+gold: &gold "#f6c177"
+iris: &iris "#c4a7e7"
+love: &love "#eb6f92"
+
+# Skin...
+k9s:
+  # General K9s styles
+  body:
+    fgColor: *text
+    bgColor: *base
+    logoColor: *iris
+  # Command prompt styles
+  prompt:
+    fgColor: *text
+    bgColor: *base
+    suggestColor: *iris
+  # ClusterInfoView styles.
+  info:
+    fgColor: *iris
+    sectionColor: *text
+  # Dialog styles.
+  dialog:
+    fgColor: *text
+    bgColor: *base
+    buttonFgColor: *text
+    buttonBgColor: *iris
+    buttonFocusFgColor: *gold
+    buttonFocusBgColor: *iris
+    labelFgColor: *gold
+    fieldFgColor: *text
+  frame:
+    # Borders styles.
+    border:
+      fgColor: *overlay
+      focusColor: *overlay
+    menu:
+      fgColor: *text
+      keyColor: *iris
+      # Used for favorite namespaces
+      numKeyColor: *iris
+    # CrumbView attributes for history navigation.
+    crumbs:
+      fgColor: *text
+      bgColor: *overlay
+      activeColor: *overlay
+    # Resource status and update styles
+    status:
+      newColor: *rose
+      modifyColor: *iris
+      addColor: *pine
+      errorColor: *love
+      highlightcolor: *gold
+      killColor: *muted
+      completedColor: *muted
+    # Border title styles.
+    title:
+      fgColor: *text
+      bgColor: *overlay
+      highlightColor: *gold
+      counterColor: *iris
+      filterColor: *iris
+  views:
+    # Charts skins...
+    charts:
+      bgColor: default
+      defaultDialColors:
+        - *iris
+        - *love
+      defaultChartColors:
+        - *iris
+        - *love
+    # TableView attributes.
+    table:
+      fgColor: *text
+      bgColor: *base
+      # Header row styles.
+      header:
+        fgColor: *text
+        bgColor: *base
+        sorterColor: *rose
+    # Xray view attributes.
+    xray:
+      fgColor: *text
+      bgColor: *base
+      cursorColor: *overlay
+      graphicColor: *iris
+      showIcons: false
+    # YAML info styles.
+    yaml:
+      keyColor: *iris
+      colonColor: *iris
+      valueColor: *text
+    # Logs styles.
+    logs:
+      fgColor: *text
+      bgColor: *base
+      indicator:
+        fgColor: *text
+        bgColor: *iris


### PR DESCRIPTION
Current skin is rose pine main variant. I've looked what rose-pine's role from palette were used at main skin already present at the repo and add  dawn and moon variants with same roles.

Based on https://rosepinetheme.com/palette/ingredients/

Dawn
<img width="1440" alt="Screenshot 2024-02-14 at 21 36 50" src="https://github.com/derailed/k9s/assets/38328305/c54dfd56-a746-40ac-b597-cae39c784eaf">

Moon
<img width="1438" alt="Screenshot 2024-02-14 at 21 38 47" src="https://github.com/derailed/k9s/assets/38328305/313081b8-41e3-46b6-abd0-104867da645e">
