### PR TITLE
1302: Add support for localtime in log viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,8 @@ K9s uses aliases to navigate most K8s resources.
       textWrap: false
       # Toggles log line timestamp info. Default false
       showTime: false
+      # Show time in local time rather than cluster time. Default false
+      localTime: false
     # Provide shell pod customization when nodeShell feature gate is enabled!
     shellPod:
       # The shell pod image to use.
@@ -944,6 +946,7 @@ k9s:
     sinceSeconds: -1
     textWrap: false
     showTime: false
+    localTime: false
   thresholds:
     cpu:
       critical: 90

--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -103,7 +103,8 @@
             "buffer": {"type": "integer"},
             "sinceSeconds": {"type": "integer"},
             "textWrap": {"type": "boolean"},
-            "showTime": {"type": "boolean"}
+            "showTime": {"type": "boolean"},
+            "localTime": {"type": "boolean"}
           }
         },
         "thresholds": {

--- a/internal/config/json/testdata/k9s/cool.yaml
+++ b/internal/config/json/testdata/k9s/cool.yaml
@@ -30,6 +30,7 @@ k9s:
     sinceSeconds: -1
     textWrap: false
     showTime: false
+    localTime: false
   thresholds:
     cpu:
       critical: 90

--- a/internal/config/json/testdata/k9s/toast.yaml
+++ b/internal/config/json/testdata/k9s/toast.yaml
@@ -24,6 +24,7 @@ k9s:
     sinceSeconds: -1
     textWrap: false
     showTime: false
+    localTime: false
   thresholds:
     cpu:
       critical: 90

--- a/internal/config/logger.go
+++ b/internal/config/logger.go
@@ -21,6 +21,7 @@ type Logger struct {
 	SinceSeconds int64 `json:"sinceSeconds" yaml:"sinceSeconds"`
 	TextWrap     bool  `json:"textWrap" yaml:"textWrap"`
 	ShowTime     bool  `json:"showTime" yaml:"showTime"`
+	LocalTime    bool  `json:"localTime" yaml:"localTime"`
 }
 
 // NewLogger returns a new instance.

--- a/internal/config/testdata/configs/default.yaml
+++ b/internal/config/testdata/configs/default.yaml
@@ -32,6 +32,7 @@ k9s:
     sinceSeconds: -1
     textWrap: false
     showTime: false
+    localTime: false
   thresholds:
     cpu:
       critical: 90

--- a/internal/config/testdata/configs/expected.yaml
+++ b/internal/config/testdata/configs/expected.yaml
@@ -32,6 +32,7 @@ k9s:
     sinceSeconds: -1
     textWrap: false
     showTime: false
+    localTime: false
   thresholds:
     cpu:
       critical: 90

--- a/internal/config/testdata/configs/k9s.yaml
+++ b/internal/config/testdata/configs/k9s.yaml
@@ -32,6 +32,7 @@ k9s:
     sinceSeconds: -1
     textWrap: false
     showTime: false
+    localTime: false
   thresholds:
     cpu:
       critical: 90

--- a/internal/config/testdata/configs/k9s_toast.yaml
+++ b/internal/config/testdata/configs/k9s_toast.yaml
@@ -30,6 +30,7 @@ k9s:
     sinceSeconds: -1
     textWrap: false
     showTime: false
+    localTime: false
   thresholds:
     cpu:
       critical: 90

--- a/internal/dao/log_items_test.go
+++ b/internal/dao/log_items_test.go
@@ -6,6 +6,7 @@ package dao_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/dao"
@@ -74,7 +75,7 @@ func TestLogItemsFilter(t *testing.T) {
 			for _, i := range ii.Items() {
 				i.Pod, i.Container = n, u.opts.Container
 			}
-			res, _, err := ii.Filter(0, u.q, false)
+			res, _, err := ii.Filter(0, u.q, false, nil)
 			assert.Equal(t, u.err, err)
 			if err == nil {
 				assert.Equal(t, u.e, res)
@@ -84,6 +85,7 @@ func TestLogItemsFilter(t *testing.T) {
 }
 
 func TestLogItemsRender(t *testing.T) {
+	tz, _ := time.LoadLocation("Europe/Berlin")
 	uu := map[string]struct {
 		opts dao.LogOptions
 		e    string
@@ -110,8 +112,9 @@ func TestLogItemsRender(t *testing.T) {
 				Path:          "blee/fred",
 				Container:     "blee",
 				ShowTimestamp: true,
+				Timezone:      tz,
 			},
-			e: "[gray::b]2018-12-14T10:36:43.326972-07:00 [-::-][teal::]fred [teal::b]blee[-::-] Testing 1,2,3...\n",
+			e: "[gray::b]2018-12-14T18:36:43.326972000+01:00 [-::-][teal::]fred [teal::b]blee[-::-] Testing 1,2,3...\n",
 		},
 	}
 
@@ -124,7 +127,7 @@ func TestLogItemsRender(t *testing.T) {
 		ii.Items()[0].Pod, ii.Items()[0].Container = n, u.opts.Container
 		t.Run(k, func(t *testing.T) {
 			res := make([][]byte, 1)
-			ii.Render(0, u.opts.ShowTimestamp, res)
+			ii.Render(0, u.opts.ShowTimestamp, u.opts.Timezone, res)
 			assert.Equal(t, u.e, string(res[0]))
 		})
 	}

--- a/internal/dao/log_options.go
+++ b/internal/dao/log_options.go
@@ -26,6 +26,7 @@ type LogOptions struct {
 	SingleContainer  bool
 	MultiPods        bool
 	ShowTimestamp    bool
+	Timezone         *time.Location
 	AllContainers    bool
 }
 
@@ -49,6 +50,7 @@ func (o *LogOptions) Clone() *LogOptions {
 		SingleContainer:  o.SingleContainer,
 		MultiPods:        o.MultiPods,
 		ShowTimestamp:    o.ShowTimestamp,
+		Timezone:         o.Timezone,
 		SinceTime:        o.SinceTime,
 		SinceSeconds:     o.SinceSeconds,
 		AllContainers:    o.AllContainers,

--- a/internal/model/log_test.go
+++ b/internal/model/log_test.go
@@ -157,7 +157,7 @@ func TestLogBasic(t *testing.T) {
 	assert.Equal(t, 1, v.clearCalled)
 	assert.Equal(t, 0, v.errCalled)
 	ll := make([][]byte, data.Len())
-	data.Lines(0, false, ll)
+	data.Lines(0, false, nil, ll)
 	assert.Equal(t, ll, v.data)
 }
 
@@ -171,7 +171,7 @@ func TestLogAppend(t *testing.T) {
 	items.Add(dao.NewLogItemFromString("blah blah"))
 	m.Set(items)
 	ll := make([][]byte, items.Len())
-	items.Lines(0, false, ll)
+	items.Lines(0, false, nil, ll)
 	assert.Equal(t, ll, v.data)
 
 	data := dao.NewLogItems()
@@ -184,7 +184,7 @@ func TestLogAppend(t *testing.T) {
 	}
 	assert.Equal(t, 1, v.dataCalled)
 	ll = make([][]byte, items.Len())
-	items.Lines(0, false, ll)
+	items.Lines(0, false, nil, ll)
 	assert.Equal(t, ll, v.data)
 
 	m.Notify()

--- a/internal/view/container.go
+++ b/internal/view/container.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
@@ -113,6 +114,9 @@ func (c *Container) logOptions(prev bool) (*dao.LogOptions, error) {
 		SingleContainer: true,
 		ShowTimestamp:   cfg.ShowTime,
 		Previous:        prev,
+	}
+	if cfg.LocalTime {
+		opts.Timezone = time.Local
 	}
 
 	return &opts, nil

--- a/internal/view/dp.go
+++ b/internal/view/dp.go
@@ -5,6 +5,7 @@ package view
 
 import (
 	"errors"
+	"time"
 
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/dao"
@@ -82,6 +83,9 @@ func (d *Deploy) logOptions(prev bool) (*dao.LogOptions, error) {
 		AllContainers:   allCos,
 		ShowTimestamp:   cfg.ShowTime,
 		Previous:        prev,
+	}
+	if cfg.LocalTime {
+		opts.Timezone = time.Local
 	}
 	if co == "" {
 		opts.AllContainers = true

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -257,6 +257,7 @@ func (l *Log) bindKeys() {
 		ui.KeyS:         ui.NewKeyAction("Toggle AutoScroll", l.toggleAutoScrollCmd, true),
 		ui.KeyF:         ui.NewKeyAction("Toggle FullScreen", l.toggleFullScreenCmd, true),
 		ui.KeyT:         ui.NewKeyAction("Toggle Timestamp", l.toggleTimestampCmd, true),
+		ui.KeyZ:         ui.NewKeyAction("Toggle LocalTime", l.toggleLocalTime, true),
 		ui.KeyW:         ui.NewKeyAction("Toggle Wrap", l.toggleTextWrapCmd, true),
 		tcell.KeyCtrlS:  ui.NewKeyAction("Save", l.SaveCmd, true),
 		ui.KeyC:         ui.NewKeyAction("Copy", cpCmd(l.app.Flash(), l.logs.TextView), true),
@@ -478,6 +479,18 @@ func (l *Log) toggleTextWrapCmd(evt *tcell.EventKey) *tcell.EventKey {
 
 	l.indicator.ToggleTextWrap()
 	l.logs.SetWrap(l.indicator.textWrap)
+	l.indicator.Refresh()
+
+	return nil
+}
+
+func (l *Log) toggleLocalTime(evt *tcell.EventKey) *tcell.EventKey {
+	if l.app.InCmdMode() {
+		return evt
+	}
+
+	l.indicator.ToggleLocalTime()
+	l.model.ToggleLocaltime(l.indicator.LocalTime())
 	l.indicator.Refresh()
 
 	return nil

--- a/internal/view/log_indicator.go
+++ b/internal/view/log_indicator.go
@@ -23,6 +23,7 @@ type LogIndicator struct {
 	fullScreen                 bool
 	textWrap                   bool
 	showTime                   bool
+	localTime                  bool
 	allContainers              bool
 	shouldDisplayAllContainers bool
 }
@@ -37,6 +38,7 @@ func NewLogIndicator(cfg *config.Config, styles *config.Styles, allContainers bo
 		fullScreen:                 cfg.K9s.UI.DefaultsToFullScreen,
 		textWrap:                   cfg.K9s.Logger.TextWrap,
 		showTime:                   cfg.K9s.Logger.ShowTime,
+		localTime:                  cfg.K9s.Logger.LocalTime,
 		shouldDisplayAllContainers: allContainers,
 	}
 	l.StylesChanged(styles)
@@ -64,6 +66,11 @@ func (l *LogIndicator) Timestamp() bool {
 	return l.showTime
 }
 
+// Localtime reports the current timezone mode (local or cluster).
+func (l *LogIndicator) LocalTime() bool {
+	return l.localTime
+}
+
 // TextWrap reports the current wrap mode.
 func (l *LogIndicator) TextWrap() bool {
 	return l.textWrap
@@ -77,6 +84,11 @@ func (l *LogIndicator) FullScreen() bool {
 // ToggleTimestamp toggles the current timestamp mode.
 func (l *LogIndicator) ToggleTimestamp() {
 	l.showTime = !l.showTime
+}
+
+// ToggleLocaltime toggles the current timezone mode (local or cluster).
+func (l *LogIndicator) ToggleLocalTime() {
+	l.localTime = !l.localTime
 }
 
 // ToggleFullScreen toggles the screen mode.
@@ -146,6 +158,12 @@ func (l *LogIndicator) Refresh() {
 		l.indicator = append(l.indicator, fmt.Sprintf(toggleOnFmt, "Timestamps", spacer)...)
 	} else {
 		l.indicator = append(l.indicator, fmt.Sprintf(toggleOffFmt, "Timestamps", spacer)...)
+	}
+
+	if l.LocalTime() {
+		l.indicator = append(l.indicator, fmt.Sprintf(toggleOnFmt, "LocalTime", spacer)...)
+	} else {
+		l.indicator = append(l.indicator, fmt.Sprintf(toggleOffFmt, "LocalTime", spacer)...)
 	}
 
 	if l.TextWrap() {

--- a/internal/view/log_indicator_test.go
+++ b/internal/view/log_indicator_test.go
@@ -18,10 +18,10 @@ func TestLogIndicatorRefresh(t *testing.T) {
 		e  string
 	}{
 		"all-containers": {
-			view.NewLogIndicator(config.NewConfig(nil), defaults, true), "[::b]AllContainers:[gray::d]Off[-::]     [::b]Autoscroll:[limegreen::b]On[-::]      [::b]FullScreen:[gray::d]Off[-::]     [::b]Timestamps:[gray::d]Off[-::]     [::b]Wrap:[gray::d]Off[-::]\n",
+			view.NewLogIndicator(config.NewConfig(nil), defaults, true), "[::b]AllContainers:[gray::d]Off[-::]     [::b]Autoscroll:[limegreen::b]On[-::]      [::b]FullScreen:[gray::d]Off[-::]     [::b]Timestamps:[gray::d]Off[-::]     [::b]LocalTime:[gray::d]Off[-::]     [::b]Wrap:[gray::d]Off[-::]\n",
 		},
 		"plain": {
-			view.NewLogIndicator(config.NewConfig(nil), defaults, false), "[::b]Autoscroll:[limegreen::b]On[-::]      [::b]FullScreen:[gray::d]Off[-::]     [::b]Timestamps:[gray::d]Off[-::]     [::b]Wrap:[gray::d]Off[-::]\n",
+			view.NewLogIndicator(config.NewConfig(nil), defaults, false), "[::b]Autoscroll:[limegreen::b]On[-::]      [::b]FullScreen:[gray::d]Off[-::]     [::b]Timestamps:[gray::d]Off[-::]     [::b]LocalTime:[gray::d]Off[-::]     [::b]Wrap:[gray::d]Off[-::]\n",
 		},
 	}
 

--- a/internal/view/log_int_test.go
+++ b/internal/view/log_int_test.go
@@ -26,10 +26,10 @@ func TestLogAutoScroll(t *testing.T) {
 	v.GetModel().Set(ii)
 	v.GetModel().Notify()
 
-	assert.Equal(t, 16, len(v.Hints()))
+	assert.Equal(t, 17, len(v.Hints()))
 
 	v.toggleAutoScrollCmd(nil)
-	assert.Equal(t, "Autoscroll:Off     FullScreen:Off     Timestamps:Off     Wrap:Off", v.Indicator().GetText(true))
+	assert.Equal(t, "Autoscroll:Off     FullScreen:Off     Timestamps:Off     LocalTime:Off     Wrap:Off", v.Indicator().GetText(true))
 }
 
 func TestLogViewNav(t *testing.T) {
@@ -87,7 +87,7 @@ func TestLogTimestamp(t *testing.T) {
 	l.SendKeys(ui.KeyT)
 	l.Logs().Clear()
 	ll := make([][]byte, ii.Len())
-	ii.Lines(0, true, ll)
+	ii.Lines(0, true, nil, ll)
 	l.Flush(ll)
 
 	assert.Equal(t, fmt.Sprintf("%-30s %s", "ttt", "fred/blee c1 Testing 1, 2, 3\n"), l.Logs().GetText(true))

--- a/internal/view/log_test.go
+++ b/internal/view/log_test.go
@@ -30,7 +30,7 @@ func TestLog(t *testing.T) {
 	ii := dao.NewLogItems()
 	ii.Add(dao.NewLogItemFromString("blee\n"), dao.NewLogItemFromString("bozo\n"))
 	ll := make([][]byte, ii.Len())
-	ii.Lines(0, false, ll)
+	ii.Lines(0, false, nil, ll)
 	v.Flush(ll)
 
 	assert.Equal(t, "Waiting for logs...\nblee\nbozo\n", v.Logs().GetText(true))
@@ -50,7 +50,7 @@ func TestLogFlush(t *testing.T) {
 		dao.NewLogItemFromString("\033[0;32mBozo\n"),
 	)
 	ll := make([][]byte, items.Len())
-	items.Lines(0, false, ll)
+	items.Lines(0, false, nil, ll)
 	v.Flush(ll)
 
 	assert.Equal(t, "[orange::d]Waiting for logs...\n[black::]blee\n[green::]Bozo\n\n", v.Logs().GetText(false))
@@ -71,7 +71,7 @@ func BenchmarkLogFlush(b *testing.B) {
 		dao.NewLogItemFromString("\033[0;101mBozo\n"),
 	)
 	ll := make([][]byte, items.Len())
-	items.Lines(0, false, ll)
+	items.Lines(0, false, nil, ll)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -106,7 +106,7 @@ func TestLogViewSave(t *testing.T) {
 	ii := dao.NewLogItems()
 	ii.Add(dao.NewLogItemFromString("blee"), dao.NewLogItemFromString("bozo"))
 	ll := make([][]byte, ii.Len())
-	ii.Lines(0, false, ll)
+	ii.Lines(0, false, nil, ll)
 	v.Flush(ll)
 
 	dd := "/tmp/test-dumps/na"

--- a/internal/view/logs_extender.go
+++ b/internal/view/logs_extender.go
@@ -4,6 +4,8 @@
 package view
 
 import (
+	"time"
+
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/dao"
 	"github.com/derailed/k9s/internal/ui"
@@ -87,6 +89,9 @@ func (l *LogsExtender) buildLogOpts(path, co string, prevLogs bool) *dao.LogOpti
 	}
 	if opts.Container == "" {
 		opts.AllContainers = true
+	}
+	if cfg.LocalTime {
+		opts.Timezone = time.Local
 	}
 
 	return &opts

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
@@ -152,6 +153,9 @@ func (p *Pod) logOptions(prev bool) (*dao.LogOptions, error) {
 		opts.Container = cc[0]
 	} else {
 		opts.AllContainers = true
+	}
+	if cfg.LocalTime {
+		opts.Timezone = time.Local
 	}
 
 	return &opts, nil

--- a/internal/view/sts.go
+++ b/internal/view/sts.go
@@ -5,6 +5,7 @@ package view
 
 import (
 	"errors"
+	"time"
 
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/dao"
@@ -71,6 +72,9 @@ func (s *StatefulSet) logOptions(prev bool) (*dao.LogOptions, error) {
 		AllContainers:   allCos,
 		ShowTimestamp:   cfg.ShowTime,
 		Previous:        prev,
+	}
+	if cfg.LocalTime {
+		opts.Timezone = time.Local
 	}
 	if co == "" {
 		opts.AllContainers = true


### PR DESCRIPTION
Support displaying logs timestamp in local rather than cluster time. The option can be controlled from the log viewer with the 'z' key, or set in the config yaml. ('z' seemed a good choice for its association with "Zulu" time).

Fixes #1302