### PR TITLE
Create and Duplicate Resource actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="assets/k9s.png" alt="k9s">
 
-## K9s - Kubernetes CLI To Manage Your Clusters In Style!
+## K9s - Kubernetes CLI To Manage Your Clusters In Style
 
 K9s provides a terminal UI to interact with your Kubernetes clusters.
 The aim of this project is to make it easier to navigate, observe and manage
@@ -9,7 +9,7 @@ for changes and offers subsequent commands to interact with your observed resour
 
 ---
 
-## Note...
+## Note
 
 K9s is not pimped out by a big corporation with deep pockets.
 It is a complex OSS project that demands a lot of my time to maintain and support.
@@ -356,8 +356,10 @@ K9s uses aliases to navigate most K8s resources.
 | To view and switch directly to another Kubernetes context (Last used view)      | `:`ctx context-name⏎          |                                                                        |
 | To view and switch to another Kubernetes namespace                              | `:`ns⏎                        |                                                                        |
 | To view all saved resources                                                     | `:`screendump or sd⏎          |                                                                        |
+| To launch a new editor to create a new resource                                 | `ctrl-n`                      |                                                                        |
 | To delete a resource (TAB and ENTER to confirm)                                 | `ctrl-d`                      |                                                                        |
 | To kill a resource (no confirmation dialog, equivalent to kubectl delete --now) | `ctrl-k`                      |                                                                        |
+| To duplicate a resource                                                         | `shift-d`                     | Only in YAML view, opens a new editor with the current resource        |
 | Launch pulses view                                                              | `:`pulses or pu⏎              |                                                                        |
 | Launch XRay view                                                                | `:`xray RESOURCE [NAMESPACE]⏎ | RESOURCE can be one of po, svc, dp, rs, sts, ds, NAMESPACE is optional |
 | Launch Popeye view                                                              | `:`popeye or pop⏎             | See [popeye](#popeye)                                                  |
@@ -1056,7 +1058,7 @@ K9s will most likely blow up if...
 
 ---
 
-## ATTA Girls/Boys!
+## ATTA Girls/Boys
 
 K9s sits on top of many open source projects and libraries. Our *sincere*
 appreciations to all the OSS contributors that work nights and weekends
@@ -1064,10 +1066,10 @@ to make this project a reality!
 
 ---
 
-## Meet The Core Team!
+## Meet The Core Team
 
 * [Fernand Galiana](https://github.com/derailed)
-  * <img src="assets/mail.png" width="16" height="auto" alt="email"/>  fernand@imhotep.io
+  * <img src="assets/mail.png" width="16" height="auto" alt="email"/>  <fernand@imhotep.io>
   * <img src="assets/twitter.png" width="16" height="auto" alt="twitter"/> [@kitesurfer](https://twitter.com/kitesurfer?lang=en)
 
 * [Aleksei Romanenko](https://github.com/slimus)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/fvbommel/sortorder v1.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-runewidth v0.0.15
+	github.com/mattn/go-shellwords v1.0.12
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/petergtz/pegomock v2.9.0+incompatible
 	github.com/rakyll/hey v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -845,6 +845,8 @@ github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
 github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -688,7 +688,19 @@ func editAndCreateFromFile(app *App, filePath string) *tcell.EventKey {
 		return nil
 	}
 
-	return createFromFile(app, filePath)
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		app.Flash().Errf("Failed to create resource from file %s", err)
+		return nil
+	}
+
+	dumpedFile, err := saveYAML(app.Config.K9s.ContextScreenDumpDir(), "create", string(content))
+	if err != nil {
+		app.Flash().Err(err)
+		return nil
+	}
+
+	return createFromFile(app, dumpedFile)
 }
 
 func isFileEmpty(filePath string) (bool, error) {

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -318,10 +318,12 @@ func (b *Browser) createCmd(_ *tcell.EventKey) *tcell.EventKey {
 	defer tmpFile.Close()
 
 	_, err = tmpFile.WriteString(strings.Join([]string{
-		"# To create a new resource, provide a definition below.",
-		"# Multiple documents are supported.",
+		"# Please add your resource definitions below. Lines beginning with a '#' will be ignored.",
+		"# Multiple resources are supported and can be separated by '---'.",
 		"# When done, save and close the editor, K9s will then `kubectl create` the resource.",
-		"",
+		fmt.Sprintf("# The content will also be saved in '%s'", b.App().Config.K9s.ContextScreenDumpDir()),
+		"# in case you need to recover it.",
+		"#",
 	}, "\n"))
 	if err != nil {
 		b.App().Flash().Err(errors.New("Failed to write to temporary resource file: " + err.Error()))

--- a/internal/view/exec_test.go
+++ b/internal/view/exec_test.go
@@ -1,0 +1,69 @@
+package view
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var fakeLookPath = func(file string) (string, error) {
+	return fmt.Sprintf("/usr/bin/%s", file), nil
+}
+
+func TestFindEditor(t *testing.T) {
+	type result struct {
+		binary string
+		args   []string
+	}
+
+	uu := map[string]struct {
+		env map[string]string
+		e   result
+		err bool
+	}{
+		"no-editor": {
+			env: map[string]string{},
+			e:   result{binary: "", args: nil},
+			err: true,
+		},
+		"vi-by-EDITOR": {
+			env: map[string]string{"EDITOR": "vi"},
+			e:   result{binary: "vi", args: nil},
+		},
+		"vim-with-args-by-EDITOR": {
+			env: map[string]string{"EDITOR": "vim --wait --some=thing"},
+			e:   result{binary: "vim", args: []string{"--wait", "--some=thing"}},
+		},
+		"code-with-args-by-KUBE_EDITOR": {
+			env: map[string]string{"KUBE_EDITOR": "code -w"},
+			e:   result{binary: "code", args: []string{"-w"}},
+		},
+		"code-with-args-by-K9S-EDITOR": {
+			env: map[string]string{"K9S_EDITOR": "code --wait"},
+			e:   result{binary: "code", args: []string{"--wait"}},
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			opts := shellOpts{}
+
+			for _, v := range editorEnvVars {
+				if _, ok := u.env[v]; !ok {
+					t.Setenv(v, "")
+				}
+			}
+
+			for k, v := range u.env {
+				t.Setenv(k, v)
+			}
+
+			got, err := findEditor(opts)
+			assert.Equal(t, u.err, err != nil)
+			assert.Contains(t, got.binary, u.e.binary)
+			assert.Equal(t, u.e.args, got.args)
+		})
+	}
+}

--- a/internal/view/exec_test.go
+++ b/internal/view/exec_test.go
@@ -12,6 +12,8 @@ var fakeLookPath = func(file string) (string, error) {
 }
 
 func TestFindEditor(t *testing.T) {
+	lookPath = fakeLookPath
+
 	type result struct {
 		binary string
 		args   []string

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -398,10 +398,12 @@ func (v *LiveView) duplicateCmd(_ *tcell.EventKey) *tcell.EventKey {
 	defer tmpFile.Close()
 
 	_, err = tmpFile.WriteString(strings.Join([]string{
-		"# To duplicate a resource, edit the resource and make the necessary changes.",
+		"# To duplicate a resource, please edit the definition below and make the necessary changes.",
 		"# Make sure to change the resource name and remove owner references if necessary.",
 		"# When done, save and close the editor, K9s will then `kubectl create` the resource.",
-		"",
+		fmt.Sprintf("# The content will also be saved in '%s'", v.app.Config.K9s.ContextScreenDumpDir()),
+		"# in case you need to recover it.",
+		"#",
 		v.text.GetText(true),
 	}, "\n"))
 	if err != nil {


### PR DESCRIPTION
This PR is basically a rework of PR #954 which is coming originally from @nickymateev - as there hasn't been any real activity by him on his original PR for the last 3 years and the functionality would be nice to have, I've rebased his work and streamlined it a bit.

Functionality in general is still the same, this PR introduces two new options:

1. **Create** triggered by <kbd>Ctrl</kbd> + <kbd>N</kbd> on every resource browse view, which opens the default editor, puts in some explanation and waits for the user to save and close the editor. Then it will run `kubectl create` on the provided contents to create these resources.
2. **Duplicate** triggered by <kbd>Shift</kbd> + <kbd>D</kbd> on the YAML view of a resource. Behaviour is very similar, instead of showing an empty file, it will grab the YAML of the selected resource and again run `kubectl create` on the contents once saved on closed.

There is one key difference between the approach in #954 and this PR, in the original `kubectl apply` was used while this PR switched to `kubectl create`. Why? Well, the answer is simple, `create` will make sure that the user can't overwrite an existing resource simply by specifying the same name - for this the good old edit action has been around for a long time. This way, kubectl itself will act as a safeguard preventing users that simply forgot to change the name from messing up existing resources by  either the create or duplicate actions.

Also, this PR fixes the way the lookup of the preferred editor from the env vars `KUBE_EDITOR`, `K9S_EDITOR` and / `EDITOR` works. For most non-terminal editors, e.g. VSCode, one has to additionally pass an argument to prevent it from closing immediately, i.e. `KUBE_EDITOR="code --wait"`. This broke the lookup, as k9s was trying to find a binary with the name `code --wait` on the `$PATH`. This is now refactored to properly split any args from the binary to make sure we're really only looking for a binary name. _Should_ hopefully also work on Windows, but I'm not able to test it myself.

Readonly flag is supported, so both actions are not enabled if read-only flag is set.

On the original PR, @derailed noted that he doesn't like running imperative commands on a cluster to create resources without keeping the manifest on disk. For this PR, I simply decided to abuse the screen dumps dir and store a copy of the provided yaml file in there. The path is shown as part of the result of the create call.

### Screenshots

![Screenshot 2024-02-23 at 22 32 55](https://github.com/derailed/k9s/assets/203061/377469da-f12e-443a-b595-493dda452068)
![Screenshot 2024-02-23 at 22 33 33](https://github.com/derailed/k9s/assets/203061/1aa8fd5b-cd3d-4f55-993b-c2873f5e3507)
![Screenshot 2024-02-23 at 22 34 00](https://github.com/derailed/k9s/assets/203061/ae4c866f-1732-4a45-9a92-66b40bb487f4)