### PR TITLE
fix: properly initialize key actions in picker

### DIFF
--- a/internal/view/picker.go
+++ b/internal/view/picker.go
@@ -23,7 +23,7 @@ type Picker struct {
 func NewPicker() *Picker {
 	return &Picker{
 		List:    tview.NewList(),
-		actions: ui.KeyActions{},
+		actions: *ui.NewKeyActions(),
 	}
 }
 


### PR DESCRIPTION
This commit fixes a bug introcuded in v0.32.0 where the shell-in and attach commands would fail with a nil pointer exception for pods with more than one container.

Resolves #2585