### PR TITLE
fix: pass set retries to transfer command

### DIFF
--- a/internal/ui/dialog/transfer.go
+++ b/internal/ui/dialog/transfer.go
@@ -85,6 +85,10 @@ func ShowUploads(styles config.Dialog, pages *ui.Pages, opts TransferDialogOpts)
 	retries := strconv.Itoa(opts.Retries)
 	f.AddInputField("Retries:", retries, 30, nil, func(v string) {
 		retries = v
+
+		if retriesInt, err := strconv.Atoi(retries); err == nil {
+			args.Retries = retriesInt
+		}
 	})
 
 	f.AddButton("OK", func() {

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -326,6 +326,7 @@ func (p *Pod) transferCmd(evt *tcell.EventKey) *tcell.EventKey {
 		opts = append(opts, strings.TrimSpace(args.From))
 		opts = append(opts, strings.TrimSpace(args.To))
 		opts = append(opts, fmt.Sprintf("--no-preserve=%t", args.NoPreserve))
+		opts = append(opts, fmt.Sprintf("--retries=%d", args.Retries))
 		if args.CO != "" {
 			opts = append(opts, "-c="+args.CO)
 		}


### PR DESCRIPTION
The newly introduced `retries` field in the transfer dialog was not passed to the transfer command. This commit fixes that.

Follow-up of #2584