### PR TITLE
fix: match node label kubernetes.io/role as suffix

### DIFF
--- a/internal/render/node.go
+++ b/internal/render/node.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	labelNodeRolePrefix = "node-role.kubernetes.io/"
-	nodeLabelRole       = "kubernetes.io/role"
+	labelNodeRoleSuffix = "kubernetes.io/role"
 )
 
 // Node renders a K8s Node to screen.
@@ -181,7 +181,7 @@ func nodeRoles(node *v1.Node, res []string) {
 				res[index] = role
 				index++
 			}
-		case k == nodeLabelRole && v != "":
+		case strings.HasSuffix(k, labelNodeRoleSuffix) && v != "":
 			res[index] = v
 			index++
 		}


### PR DESCRIPTION
Currently, `kubernetes.io/role` and `node-role.kubernetes.io/<role>` are not valid labels for kubelet flag `--node-labels`.

From [here](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=Labels%20to%20add%20when%20registering%20the):

> Labels to add when registering the node in the cluster. Labels must be key=value pairs separated by ','. Labels in the 'kubernetes.io' namespace must begin with an allowed prefix ('kubelet.kubernetes.io', 'node.kubernetes.io') or be in the specifically allowed set ('beta.kubernetes.io/arch', 'beta.kubernetes.io/instance-type', 'beta.kubernetes.io/os', 'failure-domain.beta.kubernetes.io/region', 'failure-domain.beta.kubernetes.io/zone', 'kubernetes.io/arch', 'kubernetes.io/hostname', 'kubernetes.io/os', 'node.kubernetes.io/instance-type', 'topology.kubernetes.io/region', 'topology.kubernetes.io/zone')

Some deployment methods (kOps) seem to set these labels after kubelet has started, but others, like [EKS node groups in AWS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group), set labels via this flag. So, to allow the valid label `node.kubernetes.io/role` while maintaining backwards compatibility, I've proposed looking for `kubernetes.io/role` as a suffix, rather than an exact match.

I've built and tested this locally and it is working great for me.

Resolves: https://github.com/derailed/k9s/issues/1095, https://github.com/derailed/k9s/issues/1240