### PR TITLE
Update brew install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Binaries for Linux, Windows and Mac are available as tarballs in the [release pa
 * Via [Homebrew](https://brew.sh/) for macOS or Linux
 
    ```shell
-   brew install k9s
+   brew install derailed/k9s/k9s
    ```
 
 * Via [MacPorts](https://www.macports.org)


### PR DESCRIPTION
Update brew install steps to match website install steps.  

Ran into some issues installed k9s on MacOS 14 using the git readme docs.
```shell
brew install k9s
```

However the install steps on the k9s website https://k9scli.io/topics/install/ worked. 
```shell
brew install derailed/k9s/k9s
```