### PR TITLE
Feature: goto owner (ctrl-o)

### DIFF
--- a/internal/dao/registry.go
+++ b/internal/dao/registry.go
@@ -123,6 +123,24 @@ func (m *Meta) AllGVRs() client.GVRs {
 	return kk
 }
 
+func (m *Meta) FindGVRForAPIVersionAndKind(apiVersion, kind string) *client.GVR {
+	m.mx.RLock()
+	defer m.mx.RUnlock()
+
+	g, v, hasGroup := strings.Cut(apiVersion, "/")
+	if !hasGroup {
+		// if no slash, the first part is the version (no group)
+		g, v = "", g
+	}
+
+	for gvr, rsrc := range m.resMetas {
+		if strings.EqualFold(rsrc.Group, g) && strings.EqualFold(rsrc.Version, v) && strings.EqualFold(rsrc.Kind, kind) {
+			return &gvr
+		}
+	}
+	return nil
+}
+
 // IsCRD checks if resource represents a CRD
 func IsCRD(r metav1.APIResource) bool {
 	for _, c := range r.Categories {


### PR DESCRIPTION
# TL;DR:

Allow traversing to the first resolvable `ownerReference` on any resource. 

Pressing ctrl-o will switch to the view of the owner's resource type, and focus the cursor on the owner itself. The stack is preserved so `esc` will bring you back down to the child.

Confirmed to work for both cluster-scoped and namespaced resources (ownerReferences are not allowed to cross namespaces, namespaced resources must have namespaced owners in the same namespace, etc. etc.)

# Nuances

1. No effort was put into what to do in the case of multiple owners. This is exceedingly rare in the wild.
2. The GVK -> GVR reverse mapping search is not optimal and holds the readlock. In most cluster(s) I'd expect this to be negligible (maybe a few hundred resource-versions at most?). Since the search happens on user input, it is not noticeable.
