### PR TITLE
Allow overwriting plugin output with command's stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,7 @@ A plugin is defined as follows:
 * Command represents ad-hoc commands the plugin runs upon activation
 * Background specifies whether or not the command runs in the background
 * Args specifies the various arguments that should apply to the command above
+* OverwriteOutput options allows plugin developers to provide custom messages on plugin execution
 
 K9s does provide additional environment variables for you to customize your plugins arguments. Currently, the available environment variables are as follows:
 

--- a/internal/config/json/schemas/plugins.json
+++ b/internal/config/json/schemas/plugins.json
@@ -21,6 +21,7 @@
           },
           "command": { "type": "string" },
           "background": { "type": "boolean" },
+          "overwriteOutput": { "type": "boolean" },
           "args": {
             "type": "array",
             "items": { "type": ["string", "number"] }

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -27,16 +27,17 @@ type Plugins struct {
 
 // Plugin describes a K9s plugin.
 type Plugin struct {
-	Scopes      []string `yaml:"scopes"`
-	Args        []string `yaml:"args"`
-	ShortCut    string   `yaml:"shortCut"`
-	Override    bool     `yaml:"override"`
-	Pipes       []string `yaml:"pipes"`
-	Description string   `yaml:"description"`
-	Command     string   `yaml:"command"`
-	Confirm     bool     `yaml:"confirm"`
-	Background  bool     `yaml:"background"`
-	Dangerous   bool     `yaml:"dangerous"`
+	Scopes          []string `yaml:"scopes"`
+	Args            []string `yaml:"args"`
+	ShortCut        string   `yaml:"shortCut"`
+	Override        bool     `yaml:"override"`
+	Pipes           []string `yaml:"pipes"`
+	Description     string   `yaml:"description"`
+	Command         string   `yaml:"command"`
+	Confirm         bool     `yaml:"confirm"`
+	Background      bool     `yaml:"background"`
+	Dangerous       bool     `yaml:"dangerous"`
+	OverwriteOutput bool     `yaml:"overwriteOutput"`
 }
 
 func (p Plugin) String() string {

--- a/internal/config/plugin_test.go
+++ b/internal/config/plugin_test.go
@@ -22,23 +22,25 @@ var pluginYmlTestData = Plugin{
 }
 
 var test1YmlTestData = Plugin{
-	Scopes:      []string{"po", "dp"},
-	Args:        []string{"-n", "$NAMESPACE", "-boolean"},
-	ShortCut:    "shift-s",
-	Description: "blee",
-	Command:     "duh",
-	Confirm:     true,
-	Background:  false,
+	Scopes:          []string{"po", "dp"},
+	Args:            []string{"-n", "$NAMESPACE", "-boolean"},
+	ShortCut:        "shift-s",
+	Description:     "blee",
+	Command:         "duh",
+	Confirm:         true,
+	Background:      false,
+	OverwriteOutput: true,
 }
 
 var test2YmlTestData = Plugin{
-	Scopes:      []string{"svc", "ing"},
-	Args:        []string{"-n", "$NAMESPACE", "-oyaml"},
-	ShortCut:    "shift-r",
-	Description: "bla",
-	Command:     "duha",
-	Confirm:     false,
-	Background:  true,
+	Scopes:          []string{"svc", "ing"},
+	Args:            []string{"-n", "$NAMESPACE", "-oyaml"},
+	ShortCut:        "shift-r",
+	Description:     "bla",
+	Command:         "duha",
+	Confirm:         false,
+	Background:      true,
+	OverwriteOutput: false,
 }
 
 func TestPluginLoad(t *testing.T) {

--- a/internal/view/actions.go
+++ b/internal/view/actions.go
@@ -206,7 +206,15 @@ func pluginAction(r Runner, p config.Plugin) ui.ActionHandler {
 			}
 			go func() {
 				for st := range statusChan {
-					r.App().Flash().Infof("Plugin command launched successfully: %q", st)
+					if !p.OverwriteOutput {
+						r.App().Flash().Infof("Plugin command launched successfully: %q", st)
+					} else {
+						if strings.Contains(st, outputPrefix) {
+							infoMsg := strings.TrimPrefix(st, outputPrefix)
+							r.App().Flash().Info(strings.TrimSpace(infoMsg))
+							return
+						}
+					}
 				}
 			}()
 

--- a/internal/view/actions.go
+++ b/internal/view/actions.go
@@ -208,12 +208,10 @@ func pluginAction(r Runner, p config.Plugin) ui.ActionHandler {
 				for st := range statusChan {
 					if !p.OverwriteOutput {
 						r.App().Flash().Infof("Plugin command launched successfully: %q", st)
-					} else {
-						if strings.Contains(st, outputPrefix) {
-							infoMsg := strings.TrimPrefix(st, outputPrefix)
-							r.App().Flash().Info(strings.TrimSpace(infoMsg))
-							return
-						}
+					} else if strings.Contains(st, outputPrefix) {
+						infoMsg := strings.TrimPrefix(st, outputPrefix)
+						r.App().Flash().Info(strings.TrimSpace(infoMsg))
+						return
 					}
 				}
 			}()

--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -34,8 +34,9 @@ import (
 )
 
 const (
-	shellCheck = `command -v bash >/dev/null && exec bash || exec sh`
-	bannerFmt  = "<<K9s-Shell>> Pod: %s | Container: %s \n"
+	shellCheck   = `command -v bash >/dev/null && exec bash || exec sh`
+	bannerFmt    = "<<K9s-Shell>> Pod: %s | Container: %s \n"
+	outputPrefix = "[output]"
 )
 
 var editorEnvVars = []string{"KUBE_EDITOR", "K9S_EDITOR", "EDITOR"}
@@ -492,7 +493,7 @@ func pipe(_ context.Context, opts shellOpts, statusChan chan<- string, w, e *byt
 				} else {
 					for _, l := range strings.Split(w.String(), "\n") {
 						if l != "" {
-							statusChan <- fmt.Sprintf("[output] %s", l)
+							statusChan <- fmt.Sprintf("%s %s", outputPrefix, l)
 						}
 					}
 					statusChan <- fmt.Sprintf("Command completed successfully: %q", render.Truncate(cmd.String(), 20))


### PR DESCRIPTION
Closes #2617 

This allows plugin developers to overwrite standard `Plugin command launched successfully: "Command completed successfully:.....` with their custom messages. 

I have a plugin that finds all ingress hosts and saves them in MacOS clipboard:

```
plugins:
  copy-ingress-hosts:
    shortCut: h
    confirm: false
    overwriteOutput: true
    description: Copy ingress hosts
    scopes:
      - ingresses
    command: sh
    background: true
    args:
      - -c
      - >-
        kubectl --context $CONTEXT
        get ingress -n $NAMESPACE $NAME
        -o go-template='{{range .spec.rules}}{{.host}},{{end}}' | sed 's/,$//' | pbcopy && echo "Successfully copied hosts"
```

with `overwriteOutput: true` when I execute the plugin I receive `Successfully copied hosts`:

![CleanShot 2024-03-27 at 15 48 41@2x](https://github.com/derailed/k9s/assets/29075662/3834676a-84ec-4974-833b-36c885a47adf)
