### PR TITLE
Add proxy configuration at the context level

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -286,8 +286,8 @@ func (a *APIClient) CheckConnectivity() bool {
 		}
 	}()
 
-	// Need reload to pick up any kubeconfig changes.
-	cfg, err := NewConfig(a.config.flags).RESTConfig()
+	cfg, err := a.config.RESTConfig()
+
 	if err != nil {
 		log.Error().Err(err).Msgf("restConfig load failed")
 		a.connOK = false
@@ -551,9 +551,8 @@ func (a *APIClient) SwitchContext(name string) error {
 	a.reset()
 	ResetMetrics()
 
-	if !a.CheckConnectivity() {
-		return fmt.Errorf("unable to connect to context %q", name)
-	}
+	// Need reload to pick up any kubeconfig changes.
+	a.config = NewConfig(a.config.flags)
 
 	return nil
 }

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -6,6 +6,8 @@ package client
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -27,6 +29,7 @@ const (
 type Config struct {
 	flags *genericclioptions.ConfigFlags
 	mx    sync.RWMutex
+	proxy func(*http.Request) (*url.URL, error)
 }
 
 // NewConfig returns a new k8s config or an error if the flags are invalid.
@@ -50,7 +53,17 @@ func (c *Config) CallTimeout() time.Duration {
 }
 
 func (c *Config) RESTConfig() (*restclient.Config, error) {
-	return c.clientConfig().ClientConfig()
+	cfg, err := c.clientConfig().ClientConfig()
+
+	if err != nil {
+		return nil, err
+	}
+
+	if c.proxy != nil {
+		cfg.Proxy = c.proxy
+	}
+
+	return cfg, nil
 }
 
 // Flags returns configuration flags.
@@ -174,6 +187,15 @@ func (c *Config) GetContext(n string) (*api.Context, error) {
 	}
 
 	return nil, fmt.Errorf("getcontext - invalid context specified: %q", n)
+}
+
+func (c *Config) SetProxy(proxy func(*http.Request) (*url.URL, error)) {
+	c.proxy = proxy
+}
+
+func (c *Config) WithProxy(proxy func(*http.Request) (*url.URL, error)) *Config {
+	c.SetProxy(proxy)
+	return c
 }
 
 // Contexts fetch all available contexts.

--- a/internal/config/data/context.go
+++ b/internal/config/data/context.go
@@ -20,6 +20,7 @@ type Context struct {
 	View               *View        `yaml:"view"`
 	FeatureGates       FeatureGates `yaml:"featureGates"`
 	PortForwardAddress string       `yaml:"portForwardAddress"`
+	Proxy              *Proxy       `yaml:"proxy"`
 	mx                 sync.RWMutex
 }
 

--- a/internal/config/data/proxy.go
+++ b/internal/config/data/proxy.go
@@ -1,0 +1,6 @@
+package data
+
+// Proxy tracks a context's proxy configuration.
+type Proxy struct {
+	Address string `yaml:"address"`
+}

--- a/internal/config/data/types.go
+++ b/internal/config/data/types.go
@@ -4,6 +4,8 @@
 package data
 
 import (
+	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/derailed/k9s/internal/config/json"
@@ -43,4 +45,7 @@ type KubeSettings interface {
 
 	// GetContext returns a given context configuration or err if not found.
 	GetContext(string) (*api.Context, error)
+
+	// SetProxy sets the proxy for the active context, if present
+	SetProxy(proxy func(*http.Request) (*url.URL, error))
 }

--- a/internal/config/json/schemas/context.json
+++ b/internal/config/json/schemas/context.json
@@ -11,6 +11,19 @@
         "readOnly": {"type": "boolean"},
         "skin": { "type": "string" },
         "portForwardAddress": { "type": "string" },
+        "proxy": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties":
+              {
+                "address": {"type": "string"}
+              }
+            }
+          ]
+        },
         "namespace": {
           "type": "object",
           "additionalProperties": false,

--- a/internal/config/mock/test_helpers.go
+++ b/internal/config/mock/test_helpers.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -105,6 +107,8 @@ func (m mockKubeSettings) ContextNames() (map[string]struct{}, error) {
 
 	return mm, nil
 }
+
+func (m mockKubeSettings) SetProxy(proxy func(*http.Request) (*url.URL, error)) {}
 
 type mockConnection struct {
 	ct string


### PR DESCRIPTION
Fixes #825
Fixes #371

This PR adds proxy configuration (new field `proxy`) at the context level as seen in the config bellow:

```json
k9s:
  cluster: kind-k9s-test
  namespace:
    active: default
    lockFavorites: false
    favorites:
    - default
  view:
    active: po
  featureGates:
    nodeShell: false
  portForwardAddress: localhost
  proxy:
    address: http://localhost:3128
```

Testes with a squid proxy:
```conf
http_port 80
http_port 3128

# Define ACLs
acl all_traffic src all

# Request forwarding configuration
request_header_access Authorization allow all

# Allow all traffic
http_access allow all_traffic

# Define a custom log format named "combined"
logformat squid      %ts.%03tu %6tr %>a %Ss/%03>Hs %<st %rm %ru %[un %Sh/%<a %mt

# Use the custom log format for access logging
access_log stdio:/var/log/squid/access.log squid

```
