### PR TITLE
Added cert-manager and openssl plugins

### DIFF
--- a/plugins/cert-manager.yaml
+++ b/plugins/cert-manager.yaml
@@ -1,0 +1,36 @@
+# Manage cert-manager Certificate resouces via cmctl.
+# See: https://github.com/cert-manager/cmctl
+plugins:
+  cert-status:
+    shortCut: Shift-S
+    confirm: false
+    description: Certificate status
+    scopes:
+      - certificates
+    command: bash
+    background: false
+    args:
+      - -c
+      - "cmctl status certificate --context $CONTEXT -n $NAMESPACE $NAME |& less"
+  cert-renew:
+    shortCut: Shift-R
+    confirm: false
+    description: Certificate renew
+    scopes:
+      - certificates
+    command: bash
+    background: false
+    args:
+      - -c
+      - "cmctl renew --context $CONTEXT -n $NAMESPACE $NAME |& less"
+  secret-inspect:
+    shortCut: Shift-I
+    confirm: false
+    description: Inspect secret
+    scopes:
+      - secrets
+    command: bash
+    background: false
+    args:
+      - -c
+      - "cmctl inspect secret --context $CONTEXT -n $NAMESPACE $NAME |& less"

--- a/plugins/openssl.yaml
+++ b/plugins/openssl.yaml
@@ -1,0 +1,25 @@
+# Inspect certificate chains with openssl.
+# See: https://github.com/openssl/openssl.
+plugins:
+  secret-openssl-ca:
+    shortCut: Ctrl-O
+    confirm: false
+    description: Openssl ca.crt
+    scopes:
+      - secrets
+    command: bash
+    background: false
+    args:
+      - -c
+      - kubectl get secret --context $CONTEXT -n $NAMESPACE $NAME -o jsonpath='{.data.ca\.crt}' | base64 -d | openssl storeutl -noout -text -certs /dev/stdin |& less
+  secret-openssl-tls:
+    shortCut: Shift-O
+    confirm: false
+    description: Openssl tls.crt
+    scopes:
+      - secrets
+    command: bash
+    background: false
+    args:
+      - -c
+      - kubectl get secret --context $CONTEXT -n $NAMESPACE $NAME -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl storeutl -noout -text -certs /dev/stdin |& less


### PR DESCRIPTION
Hey there @derailed! 

First of all, thank you very much for this fantastic project, my productivity has been sky-rocketed since I've adopted k9s, it's brilliant! 🙇🏻

I have also been using [cert-manager](https://github.com/cert-manager/cert-manager) for a while, so I ended up creating some plugins to boost my productivity when dealing with PKI:
- cert-manager plugin: Inspect `Certificate` resources via cert-manager [cmctl](https://github.com/cert-manager/cmctl) CLI.
- openssl plugin: Inspect certificate chains using  `openssl storeutl`.

Let me know if you think they need to be adapted. I hope you find them useful!