### PR TITLE
fix: Ignore loading context plugins with empty context (derailed/k9s#2651)

### DIFF
--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -58,8 +58,12 @@ func (p Plugins) Load(path string) error {
 	if err := p.load(AppPluginsFile); err != nil {
 		errs = errors.Join(errs, err)
 	}
-	if err := p.load(path); err != nil {
-		errs = errors.Join(errs, err)
+	// Don't load any configuration from a context path if the path comes
+	// empty because the current context is also empty.
+	if path != "" {
+		if err := p.load(path); err != nil {
+			errs = errors.Join(errs, err)
+		}
 	}
 
 	for _, dataDir := range xdg.DataDirs {

--- a/internal/view/actions.go
+++ b/internal/view/actions.go
@@ -117,7 +117,11 @@ func pluginActions(r Runner, aa *ui.KeyActions) error {
 	})
 
 	path, err := r.App().Config.ContextPluginsPath()
-	if err != nil {
+	// The current context can be empty, and in that case the
+	// ContextPluginsPath() method will return an empty string and an error.
+	// In this particular case, the fact that there is no context plugin
+	// path if there is no context by itself is not really an error.
+	if err != nil && path != "" {
 		return err
 	}
 	pp := config.NewPlugins()


### PR DESCRIPTION
Fixes #2651

I decided to give it a shot at fixing the error message that appears when running `k9s` without a context.

This PR skips loading context-aware configurations when loading plugins if there is no current context (i.e. when `current-context` in the kubeconfig is empty). Note that, if there is no current context, `k9s` will still try to connect to the default k8s server address, which is `http://localhost:8080`, and will end with a connection error anyway if there isn't any `kube-apiserver` listening locally at that port.