### PR TITLE
fix: jump to namespaceless owner reference

### DIFF
--- a/internal/dao/registry.go
+++ b/internal/dao/registry.go
@@ -125,17 +125,17 @@ func (m *Meta) AllGVRs() client.GVRs {
 }
 
 // GVK2GVR convert gvk to gvr
-func (m *Meta) GVK2GVR(gv schema.GroupVersion, kind string) (client.GVR, bool) {
+func (m *Meta) GVK2GVR(gv schema.GroupVersion, kind string) (client.GVR, bool, bool) {
 	m.mx.RLock()
 	defer m.mx.RUnlock()
 
 	for gvr, meta := range m.resMetas {
 		if gv.Group == meta.Group && gv.Version == meta.Version && kind == meta.Kind {
-			return gvr, true
+			return gvr, meta.Namespaced, true
 		}
 	}
 
-	return client.NoGVR, false
+	return client.NoGVR, false, false
 }
 
 // IsCRD checks if resource represents a CRD

--- a/internal/view/owner_extender.go
+++ b/internal/view/owner_extender.go
@@ -93,12 +93,19 @@ func (v *OwnerExtender) jumpOwner(ns string, owner metav1.OwnerReference) error 
 		return err
 	}
 
-	gvr, found := dao.MetaAccess.GVK2GVR(gv, owner.Kind)
+	gvr, namespaced, found := dao.MetaAccess.GVK2GVR(gv, owner.Kind)
 	if !found {
 		return errors.Errorf("unsupported GVK: %s/%s", owner.APIVersion, owner.Kind)
 	}
 
-	v.App().gotoResource(gvr.String(), client.FQN(ns, owner.Name), false)
+	var ownerFQN string
+	if namespaced {
+		ownerFQN = client.FQN(ns, owner.Name)
+	} else {
+		ownerFQN = owner.Name
+	}
+
+	v.App().gotoResource(gvr.String(), ownerFQN, false)
 	return nil
 }
 


### PR DESCRIPTION
#2700 introduced navigation to resource owners. Navigating to namespaceless owners like nodes failed though.
This fixes the navigation by checking if the owner is namespaced.