### PR TITLE
fix: stop table header cells from being selectable

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -445,6 +445,7 @@ func (t *Table) AddHeaderCell(col int, h model1.HeaderColumn) {
 	sortCol := h.Name == sc.Name
 	c := tview.NewTableCell(sortIndicator(sortCol, sc.ASC, t.styles.Table(), h.Name))
 	c.SetExpansion(1)
+	c.SetSelectable(false)
 	c.SetAlign(h.Align)
 	t.SetCell(0, col, c)
 }


### PR DESCRIPTION
From what I can tell there are no reasons to be able to select the table headers.