### PR TITLE
fix: status for completed pods in workload view

### DIFF
--- a/internal/dao/workload.go
+++ b/internal/dao/workload.go
@@ -158,7 +158,9 @@ func readiness(gvr client.GVR, r metav1.TableRow, h []metav1.TableColumnDefiniti
 func status(gvr client.GVR, r metav1.TableRow, h []metav1.TableColumnDefinition) string {
 	switch gvr {
 	case PodGVR:
-		if !isReady(r.Cells[indexOf("Ready", h)].(string)) || r.Cells[indexOf("Status", h)] != render.PhaseRunning {
+		if status := r.Cells[indexOf("Status", h)]; status == render.PhaseCompleted {
+			return StatusOK
+		} else if !isReady(r.Cells[indexOf("Ready", h)].(string)) || status != render.PhaseRunning {
 			return DegradedStatus
 		}
 	case DpGVR, StsGVR:


### PR DESCRIPTION
fixes #2720 

Here is a debug log for a table row having the issue - 
```
3:37PM INF Row [hello-28627115-mbm5t 0/1 Completed 0 2m43s 10.30.163.2 ip-10-30-175-245.us-west-2.compute.internal <none> <none>]
```

The READY column is `0/1` and that leads to the row being marked as DEGRADED.

Before:
![CleanShot 2024-06-05 at 16 26 39](https://github.com/derailed/k9s/assets/7345249/b85398f9-ab08-41c2-81fe-deac768efd53)


After:
![CleanShot 2024-06-05 at 16 27 20](https://github.com/derailed/k9s/assets/7345249/0cf14f5c-a7c0-45a5-81fd-47f2dad8026b)
