### PR TITLE
feat: add custom shell option

### DIFF
--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -9,6 +9,7 @@
       "properties": {
         "liveViewAutoRefresh": { "type": "boolean" },
         "screenDumpDir": {"type": "string"},
+        "shell": {"type": "string"},
         "refreshRate": { "type": "integer" },
         "maxConnRetry": { "type": "integer" },
         "readOnly": { "type": "boolean" },

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -20,6 +20,7 @@ import (
 type K9s struct {
 	LiveViewAutoRefresh bool       `json:"liveViewAutoRefresh" yaml:"liveViewAutoRefresh"`
 	ScreenDumpDir       string     `json:"screenDumpDir" yaml:"screenDumpDir,omitempty"`
+	Shell               string     `json:"shell" yaml:"shell"`
 	RefreshRate         int        `json:"refreshRate" yaml:"refreshRate"`
 	MaxConnRetry        int        `json:"maxConnRetry" yaml:"maxConnRetry"`
 	ReadOnly            bool       `json:"readOnly" yaml:"readOnly"`
@@ -96,6 +97,7 @@ func (k *K9s) Merge(k1 *K9s) {
 	k.LiveViewAutoRefresh = k1.LiveViewAutoRefresh
 	k.ScreenDumpDir = k1.ScreenDumpDir
 	k.RefreshRate = k1.RefreshRate
+	k.Shell = k1.Shell
 	k.MaxConnRetry = k1.MaxConnRetry
 	k.ReadOnly = k1.ReadOnly
 	k.NoExitOnCtrlC = k1.NoExitOnCtrlC

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -394,7 +394,7 @@ func shellIn(a *App, fqn, co string) {
 	if err != nil {
 		log.Warn().Err(err).Msgf("os detect failed")
 	}
-	args := computeShellArgs(fqn, co, a.Conn().Config().Flags().KubeConfig, os)
+	args := computeShellArgs(a, fqn, co, a.Conn().Config().Flags().KubeConfig, os)
 
 	c := color.New(color.BgGreen).Add(color.FgBlack).Add(color.Bold)
 	err = runK(a, shellOpts{clear: true, banner: c.Sprintf(bannerFmt, fqn, co), args: args})
@@ -445,12 +445,16 @@ func attachIn(a *App, path, co string) {
 	}
 }
 
-func computeShellArgs(path, co string, kcfg *string, os string) []string {
+func computeShellArgs(a *App, path, co string, kcfg *string, os string) []string {
+	shell := a.Config.K9s.Shell
+	if shell == "" {
+		shell = "sh"
+	}
 	args := buildShellArgs("exec", path, co, kcfg)
 	if os == windowsOS {
 		return append(args, "--", powerShell)
 	}
-	return append(args, "--", "sh", "-c", shellCheck)
+	return append(args, "--", shell, "-c", shellCheck)
 }
 
 func buildShellArgs(cmd, path, co string, kcfg *string) []string {


### PR DESCRIPTION
I ran into issues getting a shell in pods where `sh` is not installed.

This PR adds a config option to define the shell to use under `k9s.shell`:

I.e.:
```yaml
k9s:
  shell: bash
```