### PR TITLE
use policy/v1 instead of policy/v1beta1

### DIFF
--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -184,7 +184,7 @@ var Registry = map[string]ResourceMeta{
 	},
 
 	// Policy...
-	"policy/v1beta1/poddisruptionbudgets": {
+	"policy/v1/poddisruptionbudgets": {
 		Renderer: &render.PodDisruptionBudget{},
 	},
 

--- a/internal/render/pdb.go
+++ b/internal/render/pdb.go
@@ -10,7 +10,7 @@ import (
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/model1"
 	"github.com/derailed/tview"
-	v1beta1 "k8s.io/api/policy/v1beta1"
+	v1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -44,7 +44,7 @@ func (p PodDisruptionBudget) Render(o interface{}, ns string, r *model1.Row) err
 	if !ok {
 		return fmt.Errorf("expected PodDisruptionBudget, but got %T", o)
 	}
-	var pdb v1beta1.PodDisruptionBudget
+	var pdb v1.PodDisruptionBudget
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(raw.Object, &pdb)
 	if err != nil {
 		return err

--- a/internal/render/testdata/pdb.json
+++ b/internal/render/testdata/pdb.json
@@ -1,16 +1,16 @@
 {
-  "apiVersion": "policy/v1beta1",
+  "apiVersion": "policy/v1",
   "kind": "PodDisruptionBudget",
   "metadata": {
     "annotations": {
-      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"policy/v1beta1\",\"kind\":\"PodDisruptionBudget\",\"metadata\":{\"annotations\":{},\"name\":\"fred\",\"namespace\":\"default\"},\"spec\":{\"minAvailable\":2,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}}}}\n"
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"policy/v1\",\"kind\":\"PodDisruptionBudget\",\"metadata\":{\"annotations\":{},\"name\":\"fred\",\"namespace\":\"default\"},\"spec\":{\"minAvailable\":2,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}}}}\n"
     },
     "creationTimestamp": "2019-08-31T03:48:10Z",
     "generation": 1,
     "name": "fred",
     "namespace": "default",
     "resourceVersion": "49885429",
-    "selfLink": "/apis/policy/v1beta1/namespaces/default/poddisruptionbudgets/fred",
+    "selfLink": "/apis/policy/v1/namespaces/default/poddisruptionbudgets/fred",
     "uid": "26b6cf70-cba2-11e9-990f-42010a800218"
   },
   "spec": {

--- a/internal/xray/tree_node.go
+++ b/internal/xray/tree_node.go
@@ -489,7 +489,7 @@ func toEmoji(gvr string) string {
 		return "👨🏻‍"
 	case "networking.k8s.io/v1/networkpolicies":
 		return "📕"
-	case "policy/v1beta1/poddisruptionbudgets":
+	case "policy/v1/poddisruptionbudgets":
 		return "🏷 "
 	case "policy/v1beta1/podsecuritypolicies":
 		return "👮‍♂️"


### PR DESCRIPTION
`policy/v1beta1` is no longer served as of v1.25
`policy/v1` is available since v1.21

Reference - https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125

Fixes: #2733 