### PR TITLE
fix view sorting being reset

### DIFF
--- a/internal/config/views.go
+++ b/internal/config/views.go
@@ -4,10 +4,12 @@
 package config
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/derailed/k9s/internal/config/data"
@@ -46,6 +48,16 @@ func (v *ViewSetting) SortCol() (string, bool, error) {
 	}
 
 	return tt[0], tt[1] == "desc", nil
+}
+
+func (v *ViewSetting) Equals(vs *ViewSetting) bool {
+	if v == nil || vs == nil {
+		return v == nil && vs == nil
+	}
+	if c := slices.Compare(v.Columns, vs.Columns); c != 0 {
+		return false
+	}
+	return cmp.Compare(v.SortColumn, vs.SortColumn) == 0
 }
 
 // CustomView represents a collection of view customization.

--- a/internal/config/views_test.go
+++ b/internal/config/views_test.go
@@ -17,3 +17,24 @@ func TestViewSettingsLoad(t *testing.T) {
 	assert.Equal(t, 1, len(cfg.Views))
 	assert.Equal(t, 4, len(cfg.Views["v1/pods"].Columns))
 }
+
+func TestViewSetting_Equals(t *testing.T) {
+	tests := []struct {
+		v1, v2 *config.ViewSetting
+		equals bool
+	}{
+		{nil, nil, true},
+		{&config.ViewSetting{}, nil, false},
+		{nil, &config.ViewSetting{}, false},
+		{&config.ViewSetting{}, &config.ViewSetting{}, true},
+		{&config.ViewSetting{Columns: []string{"A"}}, &config.ViewSetting{}, false},
+		{&config.ViewSetting{Columns: []string{"A"}}, &config.ViewSetting{Columns: []string{"A"}}, true},
+		{&config.ViewSetting{Columns: []string{"A"}}, &config.ViewSetting{Columns: []string{"B"}}, false},
+		{&config.ViewSetting{SortColumn: "A"}, &config.ViewSetting{SortColumn: "B"}, false},
+		{&config.ViewSetting{SortColumn: "A"}, &config.ViewSetting{SortColumn: "A"}, true},
+	}
+
+	for _, tt := range tests {
+		assert.Equalf(t, tt.equals, tt.v1.Equals(tt.v2), "%#v and %#v", tt.v1, tt.v2)
+	}
+}

--- a/internal/ui/select_table.go
+++ b/internal/ui/select_table.go
@@ -218,7 +218,7 @@ func (s *SelectTable) markRange(prev, curr int) {
 }
 
 // IsMarked returns true if this item was marked.
-func (s *Table) IsMarked(item string) bool {
+func (s *SelectTable) IsMarked(item string) bool {
 	_, ok := s.marks[item]
 	return ok
 }

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -106,11 +106,16 @@ func (t *Table) getMSort() bool {
 	return t.manualSort
 }
 
-func (t *Table) setVs(vs *config.ViewSetting) {
+func (t *Table) setVs(vs *config.ViewSetting) bool {
 	t.mx.Lock()
 	defer t.mx.Unlock()
 
-	t.viewSetting = vs
+	if !t.viewSetting.Equals(vs) {
+		t.viewSetting = vs
+		return true
+	}
+
+	return false
 }
 
 func (t *Table) getVs() *config.ViewSetting {
@@ -150,9 +155,10 @@ func (t *Table) GVR() client.GVR { return t.gvr }
 
 // ViewSettingsChanged notifies listener the view configuration changed.
 func (t *Table) ViewSettingsChanged(vs config.ViewSetting) {
-	t.setVs(&vs)
-	t.setMSort(false)
-	t.Refresh()
+	if t.setVs(&vs) {
+		t.setMSort(false)
+		t.Refresh()
+	}
 }
 
 // StylesChanged notifies the skin changed.

--- a/internal/view/types.go
+++ b/internal/view/types.go
@@ -73,7 +73,7 @@ type Viewer interface {
 type TableViewer interface {
 	Viewer
 
-	// Table returns a table component.
+	// GetTable returns a table component.
 	GetTable() *Table
 }
 
@@ -90,7 +90,7 @@ type ResourceViewer interface {
 	// SetContextFn provision a custom context.
 	SetContextFn(ContextFunc)
 
-	// AddBindKeys provision additional key bindings.
+	// AddBindKeysFn provision additional key bindings.
 	AddBindKeysFn(BindKeysFunc)
 
 	// SetInstance sets a parent FQN


### PR DESCRIPTION
this PR fixes #2734.

When the `Init` method in the `view.Table` object is executed, the `app.RefreshCustomViews` method is called to reload the custom view, which triggers the `ViewSettingsChanged` event, ultimately causes the `ui.Table` object to reset the sorting of the user settings.