### PR TITLE
feat: allow plugins block in plugin files

### DIFF
--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -82,13 +82,21 @@ func (p Plugins) loadPluginDir(dir string) error {
 		if file.IsDir() || !isYamlFile(file.Name()) {
 			continue
 		}
-		bb, err := os.ReadFile(filepath.Join(dir, file.Name()))
+		fileName := filepath.Join(dir, file.Name())
+		fileContent, err := os.ReadFile(fileName)
 		if err != nil {
 			errs = errors.Join(errs, err)
 		}
 		var plugin Plugin
-		if err = yaml.Unmarshal(bb, &plugin); err != nil {
-			return err
+		if err = yaml.Unmarshal(fileContent, &plugin); err != nil {
+			var plugins Plugins
+			if err = yaml.Unmarshal(fileContent, &plugins); err != nil {
+				return fmt.Errorf("cannot parse %s into either a single plugin nor plugins: %w", fileName, err)
+			}
+			for name, plugin := range plugins.Plugins {
+				p.Plugins[name] = plugin
+			}
+			continue
 		}
 		p.Plugins[strings.TrimSuffix(file.Name(), filepath.Ext(file.Name()))] = plugin
 	}


### PR DESCRIPTION
This allows setting a `plugins` block in the plugin file, meaning you can bundle multiple plugins in a single file
Closes #2571
