### PR TITLE
feat: add duplik8s plugin

### DIFF
--- a/plugins/duplik8s.yaml
+++ b/plugins/duplik8s.yaml
@@ -1,0 +1,50 @@
+# Duplicate Pods, Deployments and StatefulSet for easy debugging
+# and troubleshooting.
+#
+# See https://github.com/Telemaco019/duplik8s
+plugins:
+  duplicate-pod:
+    shortCut: Ctrl-T
+    description: Duplicate Pod
+    scopes:
+      - po
+    command: kubectl
+    background: true
+    args:
+      - duplicate
+      - pod
+      - $NAME
+      - -n
+      - $NAMESPACE
+      - --context
+      - $CONTEXT
+  duplicate-deployment:
+    shortCut: Ctrl-T
+    description: Duplicate Deployment
+    scopes:
+      - deploy
+    command: kubectl
+    background: true
+    args:
+      - duplicate
+      - deploy
+      - $NAME
+      - -n
+      - $NAMESPACE
+      - --context
+      - $CONTEXT
+  duplicate-statefulset:
+    shortCut: Ctrl-T
+    description: Duplicate StatefulSet
+    scopes:
+      - statefulset
+    command: kubectl
+    background: true
+    args:
+      - duplicate
+      - statefulset
+      - $NAME
+      - -n
+      - $NAMESPACE
+      - --context
+      - $CONTEXT


### PR DESCRIPTION
Hi! I've been using k9s for a while now and it's one of my favourite tools ever, thanks for the amazing work!

In my workflow with k9s, I found myself needing an easy way to duplicate Pods for debugging and troubleshooting. Since kubectl debug --copy-to didn't quite meet my needs, I developed my own plugin with some additional features: [duplik8s](https://github.com/Telemaco019/duplik8s).

I thought this might be useful to others, so I've decided to open a PR :)