### PR TITLE
Create kubectl-get-in-shell.yaml

### DIFF
--- a/plugins/kubectl-get-in-shell.yaml
+++ b/plugins/kubectl-get-in-shell.yaml
@@ -1,4 +1,6 @@
 plugins:
+  # provides a way to continue working on the currently selected object in a new shell without doing lengthy copy/paste of current context.
+  # It simply formats the `kubectl get` command, taking care to omit -n when the namespace is not defined (typically for cluster-wide resources)
   kubectl-get-cmd:
     shortCut: Shift-B
     confirm: false

--- a/plugins/kubectl-get-in-shell.yaml
+++ b/plugins/kubectl-get-in-shell.yaml
@@ -1,0 +1,14 @@
+plugins:
+  kubectl-get-cmd:
+    shortCut: Shift-B
+    confirm: false
+    description: get into shell
+    scopes:
+      - all
+    command: bash
+    background: false
+    args:
+      - -c
+      - (printf "copy/paste in a shell:\n\n"; if [ "$NAMESPACE" != "" -a  "$NAMESPACE" != "-"  ]; then printf "kubectl get  --context $CONTEXT -n $NAMESPACE $RESOURCE_NAME $NAME \n" ; else printf "kubectl get  --context $CONTEXT $RESOURCE_NAME $NAME \n"; fi ) |& less
+
+


### PR DESCRIPTION
This simple plugin provides a way to continue working on the currently selected object in a new shell without doing lengthy copy/paste of current context.

It simply displays the kubectl command, taking care to omit `-n` when the namespace is not defined (typically for cluster-wide resources)