### PR TITLE
Add leading space to Kubernetes context suggestions

### DIFF
--- a/internal/view/cmd/helpers.go
+++ b/internal/view/cmd/helpers.go
@@ -113,6 +113,10 @@ func completeCtx(s string, cc []string) []string {
 	var suggests []string
 	for _, ctxName := range cc {
 		if suggest, ok := ShouldAddSuggest(s, ctxName); ok {
+			if len(s) == 0 {
+				suggests = append(suggests, " "+suggest)
+				continue
+			}
 			suggests = append(suggests, suggest)
 		}
 	}


### PR DESCRIPTION
This pull request addresses an issue with the current behavior of `ctx` suggestions. Previously, when users typed `ctx`, the first context suggestion would appear immediately adjacent to `ctx` without a leading space (e.g., `ctx<context>`), making it not possible to select the suggestion by pressing enter. This behavior required users to manually add a space before the context name, which was not intuitive and disrupted the workflow.

The proposed change introduces a leading space to the context suggestions. Now, when `ctx` is typed, the suggestion will appear as `ctx <context>`, allowing users to seamlessly use the arrow keys to navigate through the context suggestions and select one by pressing enter. This enhancement streamlines the user experience by making context selection more intuitive and efficient.