### PR TITLE
Add a spark-operator plugin

### DIFF
--- a/plugins/spark-operator.yaml
+++ b/plugins/spark-operator.yaml
@@ -1,0 +1,23 @@
+# See https://github.com/kubeflow/spark-operator
+plugins:
+  toggleScheduledSparkApp:
+    shortCut: s
+    confirm: true
+    dangerous: true
+    scopes:
+      - scheduledsparkapp
+    description: Toggle suspend
+    command: kubectl
+    background: true
+    args:
+      - patch
+      - scheduledsparkapp
+      - $NAME
+      - -n
+      - $NAMESPACE
+      - --context
+      - $CONTEXT
+      - -p
+      - '{"spec": {"suspend": $!COL-SUSPEND}}'
+      - --type
+      - merge


### PR DESCRIPTION
Add a community plugin for toggling the suspend field of the `ScheduledSparkApplication` CR from https://github.com/kubeflow/spark-operator. This plugin is inspired by https://github.com/derailed/k9s/blob/master/plugins/job-suspend.yaml