### PR TITLE
feat: add dup plugin

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -16,5 +16,6 @@ Following is an example of some of plugin files in this directory. Other files a
 | log_jq.yml         | View resource logs using jq                                      | pods                     | Ctrl-j   | kubectl-plugins/kubectl-jq                                                            |
 | log_full.yml       | get full logs from pod/container                                 | pods/containers          | Ctrl-l   |                                                                                       |
 | ai-incident-investigation.yaml | Run AI investigation on application issues to find the root cause in seconds | all | Shift-h/o | [HolmesGPT](https://github.com/robusta-dev/holmesgpt) |
+| dup.yaml                       | Duplicate, edit and Debug resources                                          | all                                 | Shift-d/e/v | [dup](https://github.com/vash/dup)                                                    |
 [1]: https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container
 [2]: https://github.com/nicolaka/netshoot

--- a/plugins/dup.yaml
+++ b/plugins/dup.yaml
@@ -1,0 +1,84 @@
+plugins:
+  dup:
+    shortCut: Shift-D
+    description: Duplicate
+    scopes:
+      - all
+    command: bash
+    background: false
+    confirm: true
+    args:
+      - -c
+      - "kubectl dup -k $RESOURCE_NAME $NAME -n $NAMESPACE --context $CONTEXT"
+  dup_edit:
+    # Prompted to edit a new duplicate resource
+    shortCut: Shift-E
+    description: Duplicate + Edit
+    scopes:
+      - all
+    command: bash
+    background: false
+    confirm: true
+    args:
+      - -c
+      - "kubectl dup $RESOURCE_NAME $NAME -n $NAMESPACE --context $CONTEXT"
+  dup_debug_pods:
+    # Spawn a resource with no readiness probes and infinite running command.
+    shortCut: Shift-V
+    description: Debug
+    scopes:
+      - pods
+    command: bash
+    background: true
+    confirm: true
+    args:
+      - -c
+      - "kubectl dup -kdl $RESOURCE_NAME $NAME -n $NAMESPACE --context $CONTEXT"
+  dup_debug_deploy:
+    # Spawn a resource with no readiness probes and infinite running command.
+    shortCut: Shift-V
+    description: Debug
+    scopes:
+      - deployments
+    command: bash
+    background: true
+    confirm: true
+    args:
+      - -c
+      - "kubectl dup -kdl $RESOURCE_NAME $NAME -n $NAMESPACE --context $CONTEXT"
+  dup_debug_sts:
+    # Spawn a resource with no readiness probes and infinite running command.
+    shortCut: Shift-V
+    description: Debug
+    scopes:
+      - statefulsets
+    command: bash
+    background: true
+    confirm: true
+    args:
+      - -c
+      - "kubectl dup -kdl $RESOURCE_NAME $NAME -n $NAMESPACE --context $CONTEXT"
+  dup_debug_cronjob:
+    # Spawn a resource with no readiness probes and infinite running command.
+    shortCut: Shift-V
+    description: Debug
+    scopes:
+      - cronjobs
+    command: bash
+    background: true
+    confirm: true
+    args:
+      - -c
+      - "kubectl dup -kdl $RESOURCE_NAME $NAME -n $NAMESPACE --context $CONTEXT"
+  dup_debug_jobs:
+    # Spawn a resource with no readiness probes and infinite running command.
+    shortCut: Shift-V
+    description: Debug
+    scopes:
+      - jobs
+    command: bash
+    background: true
+    confirm: true
+    args:
+      - -c
+      - "kubectl dup -kdl $RESOURCE_NAME $NAME -n $NAMESPACE --context $CONTEXT"


### PR DESCRIPTION
Adding the kubectl `dup` plugin for duplication of all types of kubernetes resources (inc. custom).

Three modes were added : 
- Duplicate (on all resources)
- Duplicate + Edit (on all resources) - Opens editor to edit the manifest and creates the object upon saving.
- Debug - Duplicate complex resources (deploy,sts,cronjob,job) and pods,without probes with modified command 
to prevent the pod from exiting (requires `tail` binary in the container)
                  
https://github.com/vash/dup

