### PR TITLE
Update README GO Version Required

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Binaries for Linux, Windows and Mac are available as tarballs in the [release pa
 
 ## Building From Source
 
- K9s is currently using GO v1.21.X or above.
+ K9s is currently using GO v1.22.X or above.
  In order to build K9s from source you must:
 
  1. Clone the repo


### PR DESCRIPTION
Bump from GO 1.21.X to 1.22.X

To reflect changes in #2812