### PR TITLE
k9s doesn't honor KUBECONFIG environment variable when replacing value for plugin

### DIFF
--- a/internal/view/helpers.go
+++ b/internal/view/helpers.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -96,6 +97,8 @@ func k8sEnv(c *client.Config) Env {
 	kcfg := c.Flags().KubeConfig
 	if kcfg != nil && *kcfg != "" {
 		cfg = *kcfg
+	} else {
+		cfg = os.Getenv("KUBECONFIG")
 	}
 
 	return Env{


### PR DESCRIPTION
 k9s does not utilize the KUBECONFIG environment variable, when flag value of --kubeconfig is empty.
 
 I am using plugin that will copy log command to clipboard.
 **The plugin** 
 ```yaml
plugins:
  logs-kubectl-cmd:
    shortCut: Ctrl-L
    confirm: false
    description: Copy log cmd to clipboard
    scopes:
      - pods
    background: true
    command: bash
    args:
      - -c
      - "echo kubectl logs -f $COL-NAME -n $NAMESPACE --context $CONTEXT --kubeconfig $KUBECONFIG | pbcopy"
   ```
   
  when I added logger here I found that value of ***kcfg** is empty
  ```go
var cfg string
kcfg := c.Flags().KubeConfig
if kcfg != nil && *kcfg != "" {
    cfg = *kcfg
    log.Info().Msg(fmt.Sprintf("Here is the KUBECONFIG, %v, %v", kcfg, cfg))
}
  ```
  
**logs**

> 12:12AM INF Here is the KUBECONFIG, 0x14000c6f200,
