### PR TITLE
Feature/DisableAutoscroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,7 +954,7 @@ k9s:
     buffer: 5000
     sinceSeconds: -1
     textWrap: false
-    scrollStatus: true
+    disableAutoscroll: false
     showTime: false
   thresholds:
     cpu:

--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ You can now override the context portForward default address configuration by se
       sinceSeconds: 300 # => tail the last 5 mins.
       # Toggles log line wrap. Default false
       textWrap: false
+      # Autoscroll in logs will be disabled. Default is false.
+      disableAutoscroll: false
       # Toggles log line timestamp info. Default false
       showTime: false
     # Provide shell pod customization when nodeShell feature gate is enabled!
@@ -952,6 +954,7 @@ k9s:
     buffer: 5000
     sinceSeconds: -1
     textWrap: false
+    scrollStatus: true
     showTime: false
   thresholds:
     cpu:

--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -103,6 +103,7 @@
             "buffer": {"type": "integer"},
             "sinceSeconds": {"type": "integer"},
             "textWrap": {"type": "boolean"},
+            "disableAutoscroll": {"type": "boolean"},
             "showTime": {"type": "boolean"}
           }
         },

--- a/internal/config/json/testdata/k9s/cool.yaml
+++ b/internal/config/json/testdata/k9s/cool.yaml
@@ -29,6 +29,7 @@ k9s:
     buffer: 5000
     sinceSeconds: -1
     textWrap: false
+    disableAutoscroll: false
     showTime: false
   thresholds:
     cpu:

--- a/internal/config/json/testdata/k9s/toast.yaml
+++ b/internal/config/json/testdata/k9s/toast.yaml
@@ -23,6 +23,7 @@ k9s:
     buffer: 5000
     sinceSeconds: -1
     textWrap: false
+    disableAutoscroll: false
     showTime: false
   thresholds:
     cpu:

--- a/internal/config/logger.go
+++ b/internal/config/logger.go
@@ -16,11 +16,12 @@ const (
 
 // Logger tracks logger options.
 type Logger struct {
-	TailCount    int64 `json:"tail" yaml:"tail"`
-	BufferSize   int   `json:"buffer" yaml:"buffer"`
-	SinceSeconds int64 `json:"sinceSeconds" yaml:"sinceSeconds"`
-	TextWrap     bool  `json:"textWrap" yaml:"textWrap"`
-	ShowTime     bool  `json:"showTime" yaml:"showTime"`
+	TailCount         int64 `json:"tail" yaml:"tail"`
+	BufferSize        int   `json:"buffer" yaml:"buffer"`
+	SinceSeconds      int64 `json:"sinceSeconds" yaml:"sinceSeconds"`
+	TextWrap          bool  `json:"textWrap" yaml:"textWrap"`
+	DisableAutoscroll bool  `json:"disableAutoscroll" yaml:"disableAutoscroll"`
+	ShowTime          bool  `json:"showTime" yaml:"showTime"`
 }
 
 // NewLogger returns a new instance.

--- a/internal/config/testdata/configs/default.yaml
+++ b/internal/config/testdata/configs/default.yaml
@@ -31,6 +31,7 @@ k9s:
     buffer: 5000
     sinceSeconds: -1
     textWrap: false
+    disableAutoscroll: false
     showTime: false
   thresholds:
     cpu:

--- a/internal/config/testdata/configs/expected.yaml
+++ b/internal/config/testdata/configs/expected.yaml
@@ -31,6 +31,7 @@ k9s:
     buffer: 800
     sinceSeconds: -1
     textWrap: false
+    disableAutoscroll: false
     showTime: false
   thresholds:
     cpu:

--- a/internal/config/testdata/configs/k9s.yaml
+++ b/internal/config/testdata/configs/k9s.yaml
@@ -31,6 +31,7 @@ k9s:
     buffer: 2000
     sinceSeconds: -1
     textWrap: false
+    disableAutoscroll: false
     showTime: false
   thresholds:
     cpu:

--- a/internal/config/testdata/configs/k9s_toast.yaml
+++ b/internal/config/testdata/configs/k9s_toast.yaml
@@ -29,6 +29,7 @@ k9s:
     buffer: 2000
     sinceSeconds: -1
     textWrap: false
+    disableAutoscroll: false
     showTime: false
   thresholds:
     cpu:

--- a/internal/view/log_indicator.go
+++ b/internal/view/log_indicator.go
@@ -39,6 +39,10 @@ func NewLogIndicator(cfg *config.Config, styles *config.Styles, allContainers bo
 		showTime:                   cfg.K9s.Logger.ShowTime,
 		shouldDisplayAllContainers: allContainers,
 	}
+
+	if cfg.K9s.Logger.DisableAutoscroll {
+		l.scrollStatus = 0
+	}
 	l.StylesChanged(styles)
 	styles.AddListener(&l)
 	l.SetTextAlign(tview.AlignCenter)


### PR DESCRIPTION
Pull Request for Issue https://github.com/derailed/k9s/issues/2863: Make scrollStatus Configurable

Summary
This pull request addresses issue https://github.com/derailed/k9s/issues/2863 by making the scrollStatus configurable through the configuration file. The default value for scrollStatus is set to true to maintain the current behavior for existing installations.