### PR TITLE
Feature: Filter shortcuts in logs

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -36,6 +36,7 @@ func printInfo(cmd *cobra.Command, args []string) error {
 	printTuple(fmat, "Plugins", config.AppPluginsFile, color.Cyan)
 	printTuple(fmat, "Hotkeys", config.AppHotKeysFile, color.Cyan)
 	printTuple(fmat, "Aliases", config.AppAliasesFile, color.Cyan)
+	printTuple(fmat, "Filters", config.AppFilterFile, color.Cyan)
 	printTuple(fmat, "Skins", config.AppSkinsDir, color.Cyan)
 	printTuple(fmat, "Context Configs", config.AppContextsDir, color.Cyan)
 	printTuple(fmat, "Logs", config.AppLogFile, color.Cyan)

--- a/internal/config/files.go
+++ b/internal/config/files.go
@@ -80,6 +80,9 @@ var (
 
 	// AppHotKeysFile tracks hotkeys config file.
 	AppHotKeysFile string
+
+	// AppFilterFile tracks filter config file.
+	AppFilterFile string
 )
 
 // InitLogLoc initializes K9s logs location.
@@ -146,7 +149,7 @@ func initK9sEnvLocs() error {
 	AppAliasesFile = filepath.Join(AppConfigDir, "aliases.yaml")
 	AppPluginsFile = filepath.Join(AppConfigDir, "plugins.yaml")
 	AppViewsFile = filepath.Join(AppConfigDir, "views.yaml")
-
+	AppFilterFile = filepath.Join(AppConfigDir, "filters.yaml")
 	return nil
 }
 
@@ -167,6 +170,7 @@ func initXDGLocs() error {
 	AppAliasesFile = filepath.Join(AppConfigDir, "aliases.yaml")
 	AppPluginsFile = filepath.Join(AppConfigDir, "plugins.yaml")
 	AppViewsFile = filepath.Join(AppConfigDir, "views.yaml")
+	AppFilterFile = filepath.Join(AppConfigDir, "filters.yaml")
 
 	AppSkinsDir = filepath.Join(AppConfigDir, "skins")
 	if err := data.EnsureFullPath(AppSkinsDir, data.DefaultDirMod); err != nil {

--- a/internal/model/log.go
+++ b/internal/model/log.go
@@ -214,6 +214,11 @@ func (l *Log) ClearFilter() {
 	l.fireLogChanged(ll)
 }
 
+// GetFilter returns the current filter.
+func (l *Log) GetFilter() string {
+	return l.filter
+}
+
 // Filter filters the model using either fuzzy, regexp, or predefined filters.
 func (l *Log) Filter(q string) {
 	l.mx.Lock()

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -321,9 +321,9 @@ func (l *Log) updateTitle() {
 		title += ui.SkinTitle(fmt.Sprintf(logCoFmt, path, co, since), l.app.Styles.Frame())
 	}
 
-	buff := l.logs.cmdBuff.GetText()
-	if buff != "" {
-		title += ui.SkinTitle(fmt.Sprintf(ui.SearchFmt, buff), l.app.Styles.Frame())
+	filter := l.model.GetFilter()
+	if filter != "" {
+		title += ui.SkinTitle(fmt.Sprintf(ui.SearchFmt, filter), l.app.Styles.Frame())
 	}
 	l.SetTitle(title)
 }


### PR DESCRIPTION
This PR enables a set of shortcuts to be used when filtering through logs in `k9s`. 

A new config file `filters.yaml` is defined, an example of which is shown below:

```
 filters:
   http_errors: '"status_code":[4-5]\d{2}'
   http_success: '"status_code":[2]\d{2}'
   info: 'info'
```

When using the `/` keybind in the logs view for a pod, a user can type the `@` key followed by the name of the filter to access the pre-written regex or string they wish to match on. An example from the above would be `@http_errors` -- note how the title automatically resolves to the regex that was applied by the filter:

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/f35ac422-45c9-4171-b2dd-b65c5dd32d1a">

This is especially helpful when using complex regexes that a user might want to have close at hand when searching through logs.