### PR TITLE
Fix Mark-Range command: ensure that NS Favorite doesn't exceed the limit

### DIFF
--- a/internal/config/data/ns.go
+++ b/internal/config/data/ns.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// MaxFavoritesNS number # favorite namespaces to keep in the configuration.
-	MaxFavoritesNS = 9
+	MaxFavoritesNS = 10
 )
 
 // Namespace tracks active and favorites namespaces.
@@ -66,6 +66,13 @@ func (n *Namespace) Validate(c client.Connection) {
 		if !c.IsValidNamespace(ns) {
 			log.Debug().Msgf("[Namespace] Invalid favorite found '%s' - %t", ns, n.isAllNamespaces())
 			n.rmFavNS(ns)
+		}
+	}
+
+	if len(n.Favorites) > MaxFavoritesNS {
+		log.Debug().Msgf("[Namespace] Number of favorite exceeds hard limit of %v. Trimming.", MaxFavoritesNS)
+		for _, ns := range n.Favorites[MaxFavoritesNS:] {
+            n.rmFavNS(ns)
 		}
 	}
 }
@@ -128,3 +135,4 @@ func (n *Namespace) rmFavNS(ns string) {
 
 	n.Favorites = append(n.Favorites[:victim], n.Favorites[victim+1:]...)
 }
+

--- a/internal/config/data/ns.go
+++ b/internal/config/data/ns.go
@@ -135,4 +135,3 @@ func (n *Namespace) rmFavNS(ns string) {
 
 	n.Favorites = append(n.Favorites[:victim], n.Favorites[victim+1:]...)
 }
-

--- a/internal/config/data/ns_test.go
+++ b/internal/config/data/ns_test.go
@@ -76,4 +76,3 @@ func TestNSValidateRmFavs(t *testing.T) {
 
 	assert.Equal(t, []string{"default", "fred"}, ns.Favorites)
 }
-

--- a/internal/config/data/ns_test.go
+++ b/internal/config/data/ns_test.go
@@ -35,6 +35,17 @@ func TestNSValidateNoNS(t *testing.T) {
 	assert.Equal(t, []string{"default"}, ns.Favorites)
 }
 
+func TestNsValidateMaxNS(t *testing.T) {
+	allNS := []string{"ns9","ns8","ns7","ns6","ns5","ns4", "ns3", "ns2", "ns1", "all", "default"}
+    ns := data.NewNamespace()
+
+    ns.Favorites = allNS
+
+    ns.Validate(mock.NewMockConnection())
+
+    assert.Equal(t, data.MaxFavoritesNS, len(ns.Favorites))
+}
+
 func TestNSSetActive(t *testing.T) {
 	allNS := []string{"ns4", "ns3", "ns2", "ns1", "all", "default"}
 	uu := []struct {
@@ -65,3 +76,4 @@ func TestNSValidateRmFavs(t *testing.T) {
 
 	assert.Equal(t, []string{"default", "fred"}, ns.Favorites)
 }
+


### PR DESCRIPTION
Fixes #1191 

While the root cause of the issue, where the number of favorites exceeds the limit, is still unknown, I believe this is a nice check to have, when validating namespaces. And as pointed out in the #1191, it fixes the issue with mark-range not working and instead showing in the tooltip the namespace that exceeds the limit.

- Increased the `MaxFavoritesNS` to cover all 0-9 numbers.
- Tests are updated  

Manually validated that configs are updating properly and the number of favorites doesn't exceed the limit.

Tested on MacOs. 

```
> make test
?       github.com/derailed/k9s [no test files]
?       github.com/derailed/k9s/internal/config/mock    [no test files]
ok      github.com/derailed/k9s/cmd     3.981s
ok      github.com/derailed/k9s/internal        0.618s
ok      github.com/derailed/k9s/internal/client 1.895s
ok      github.com/derailed/k9s/internal/color  4.033s
ok      github.com/derailed/k9s/internal/config 1.241s
ok      github.com/derailed/k9s/internal/config/data    2.608s
ok      github.com/derailed/k9s/internal/config/json    4.345s
?       github.com/derailed/k9s/internal/perf   [no test files]
ok      github.com/derailed/k9s/internal/dao    1.324s
ok      github.com/derailed/k9s/internal/health 0.259s
?       github.com/derailed/k9s/internal/render/helm    [no test files]
ok      github.com/derailed/k9s/internal/model  4.526s
ok      github.com/derailed/k9s/internal/model1 1.220s
ok      github.com/derailed/k9s/internal/port   0.687s
ok      github.com/derailed/k9s/internal/render 2.912s
ok      github.com/derailed/k9s/internal/tchart 1.612s
ok      github.com/derailed/k9s/internal/ui     1.385s
ok      github.com/derailed/k9s/internal/ui/dialog      3.250s
ok      github.com/derailed/k9s/internal/view   2.166s
ok      github.com/derailed/k9s/internal/view/cmd       0.608s
ok      github.com/derailed/k9s/internal/vul    3.068s
ok      github.com/derailed/k9s/internal/watch  4.615s
ok      github.com/derailed/k9s/internal/xray   4.032s
```