### PR TITLE
Case sensitive history

### DIFF
--- a/internal/model/history.go
+++ b/internal/model/history.go
@@ -3,10 +3,6 @@
 
 package model
 
-import (
-	"strings"
-)
-
 // MaxHistory tracks max command history.
 const MaxHistory = 20
 
@@ -42,7 +38,6 @@ func (h *History) Push(c string) {
 		return
 	}
 
-	c = strings.ToLower(c)
 	if i := h.indexOf(c); i != -1 {
 		return
 	}

--- a/internal/model/history_test.go
+++ b/internal/model/history_test.go
@@ -22,6 +22,18 @@ func TestHistory(t *testing.T) {
 	assert.True(t, h.Empty())
 }
 
+func TestHistoryCase(t *testing.T) {
+	h := model.NewHistory(3)
+	for i := 1; i < 5; i++ {
+		h.Push(fmt.Sprintf("ABC%d", i))
+	}
+
+	assert.Equal(t, []string{"ABC4", "ABC3", "ABC2"}, h.List())
+	assert.NotEqual(t, []string{"abc4", "abc3", "abc2"}, h.List())
+	h.Clear()
+	assert.True(t, h.Empty())
+}
+
 func TestHistoryDups(t *testing.T) {
 	h := model.NewHistory(3)
 	for i := 1; i < 4; i++ {


### PR DESCRIPTION
Remove the `ToLower` from History so filters, etc are case sensitive.