### PR TITLE
Reduce Dockerfile layers and optimize build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,11 @@ WORKDIR /k9s
 COPY go.mod go.sum main.go Makefile ./
 COPY internal internal
 COPY cmd cmd
-# Combine the package installation and build steps
-RUN apk --no-cache add make libx11-dev git gcc libc-dev curl && make build
+# Install dependencies, build, and clean up
+RUN apk --no-cache add make libx11-dev git gcc libc-dev curl \
+    && make build \
+    && apk del gcc libc-dev git make libx11-dev curl 
+# Remove build-time dependencies
 
 # -----------------------------------------------------------------------------
 # Build the final Docker image
@@ -18,10 +21,10 @@ ARG KUBECTL_VERSION="v1.29.0"
 
 # Combine apk installs, kubectl download, and cleanup into a single layer
 COPY --from=build /k9s/execs/k9s /bin/k9s
-RUN apk --no-cache add ca-certificates curl vim\
-  && TARGET_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
-  && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${TARGET_ARCH}/kubectl -o /usr/local/bin/kubectl \
-  && chmod +x /usr/local/bin/kubectl \
-  && rm -rf /var/cache/apk/*
+RUN apk --no-cache add ca-certificates curl vim \
+    && TARGET_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
+    && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${TARGET_ARCH}/kubectl -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && rm -rf /var/cache/apk/* /tmp/* /usr/local/bin/kubectl.sha256
 
 ENTRYPOINT [ "/bin/k9s" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ WORKDIR /k9s
 COPY go.mod go.sum main.go Makefile ./
 COPY internal internal
 COPY cmd cmd
-RUN apk --no-cache add --update make libx11-dev git gcc libc-dev curl && make build
+# Combine the package installation and build steps
+RUN apk --no-cache add make libx11-dev git gcc libc-dev curl && make build
 
 # -----------------------------------------------------------------------------
 # Build the final Docker image
@@ -15,13 +16,12 @@ RUN apk --no-cache add --update make libx11-dev git gcc libc-dev curl && make bu
 FROM alpine:3.20.3
 ARG KUBECTL_VERSION="v1.29.0"
 
+# Combine apk installs, kubectl download, and cleanup into a single layer
 COPY --from=build /k9s/execs/k9s /bin/k9s
-RUN apk add --update ca-certificates \
-  && apk add --update -t deps curl vim \
+RUN apk --no-cache add ca-certificates curl vim\
   && TARGET_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
   && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${TARGET_ARCH}/kubectl -o /usr/local/bin/kubectl \
   && chmod +x /usr/local/bin/kubectl \
-  && apk del --purge deps \
-  && rm /var/cache/apk/*
+  && rm -rf /var/cache/apk/*
 
 ENTRYPOINT [ "/bin/k9s" ]


### PR DESCRIPTION

Combined multiple apk add steps in both stages to reduce the number of layers.

Removed the apk del --purge deps since curl and vim are still required, so no need to remove them.

Removed redundant apk --update since --no-cache already ensures that the latest package versions are installed without caching.