### PR TITLE
Adding eks-node-viewer plugin

### DIFF
--- a/plugins/eks-node-viewer.yaml
+++ b/plugins/eks-node-viewer.yaml
@@ -1,0 +1,15 @@
+# plugin to easily open eks-node-viewer on viewed context
+# requires eks-node-viewer installed on system
+# https://github.com/awslabs/eks-node-viewer/
+plugins:
+  eks-node-viewer:
+    shortCut: Shift-X
+    description: "eks-node-viewer"
+    scopes:
+      - node
+    background: false
+    command: bash
+    args:
+    - -c
+    - |
+      env $(kubectl config view --context $CONTEXT --minify -o json | jq -r ".users[0].user.exec.env[] | select(.name == \"AWS_PROFILE\") | \"AWS_PROFILE=\" + .value" && kubectl config view --context $CONTEXT --minify -o json | jq -r ".users[0].user.exec.args | \"AWS_REGION=\" + .[1]") eks-node-viewer --context $CONTEXT --resources cpu,memory --extra-labels karpenter.sh/nodepool,eks-node-viewer/node-age --node-sort=creation=dsc


### PR DESCRIPTION
This plugin allows to easily open eks-node-viewer on selected k8s context

![image](https://github.com/user-attachments/assets/d7d05118-f90d-41be-9635-2fa705fd815a)

![image](https://github.com/user-attachments/assets/a391422a-bd31-49d1-96cd-81386aff3fee)
