### PR TITLE
feat: Add plugins for kubectl node-shell

### DIFF
--- a/plugins/node-shell.yaml
+++ b/plugins/node-shell.yaml
@@ -11,8 +11,8 @@ plugins:
     shortCut: s  
     # Whether or not to prompt for user confirmation before executing the plugin
     confirm: false
-    # What will be shown on the K9s menu
-    description: "Node shell"  # Description of the plugin (displayed in the UI)
+    # Description of the plugin (displayed in the k9s UI)
+    description: "Node shell"
     # Collections of views that support this shortcut. (You can use `all`)
     # `node` indicates that the plugin operates on `node` kubernetes resources
     scopes:

--- a/plugins/node-shell.yaml
+++ b/plugins/node-shell.yaml
@@ -1,0 +1,27 @@
+# $XDG_CONFIG_HOME/k9s/plugins.yaml
+plugins:
+  ## NOTE:
+  ## The kubectl plugin "node-shell" must be installed beforehand.
+  ## See: https://github.com/kvaps/kubectl-node-shell
+
+  # Defines a plugin to provide a shortcut for accessing the node shell.
+  node-shell:
+    # Define a mnemonic to invoke the plugin
+    # Shortcut key to execute the plugin (e.g., 's' key)
+    shortCut: s  
+    # Whether or not to prompt for user confirmation before executing the plugin
+    confirm: false
+    # What will be shown on the K9s menu
+    description: "Node shell"  # Description of the plugin (displayed in the UI)
+    # Collections of views that support this shortcut. (You can use `all`)
+    # `node` indicates that the plugin operates on `node` kubernetes resources
+    scopes:
+      - node
+    # The command to run upon invocation. Can use Krew plugins here too!
+    command: sh
+    # Whether or not to run the command in background mode
+    background: false
+    # Defines the command arguments
+    args:
+      - -c
+      - "kubectl node-shell $NAME --context $CONTEXT"


### PR DESCRIPTION
## Description

Hi.

DevOps Engineers or SREs mainly use the `kubectl node-shell` plugin when connecting to the inside of a worker node (for on-call response or operational tasks, etc.). Add plugins to make it easier to use the [node-shell](https://github.com/kvaps/kubectl-node-shell) plugin in k9s.

## Changes Made

- Add `node-shell` plugins to use `kubectl node-shell <NODE>` in k9s directly.

## Screenshot

Successfully tested in k9s `0.32.5` with minikube cluster:

<img width="833" alt="image" src="https://github.com/user-attachments/assets/70ebe571-3246-4a91-9473-6c8793bf7194">

<img width="352" alt="image" src="https://github.com/user-attachments/assets/7640f2f7-cc30-435e-abe5-962f239ba209">

