### PR TITLE
chore(plugins,remove-finalizers): make sure the resources api group is respected

### DIFF
--- a/plugins/remove-finalizers.yaml
+++ b/plugins/remove-finalizers.yaml
@@ -25,7 +25,7 @@ plugins:
       - $CONTEXT
       - --namespace
       - $NAMESPACE
-      - $RESOURCE_NAME
+      - $RESOURCE_NAME.$RESOURCE_GROUP
       - $NAME
       - -p
       - '{"metadata":{"finalizers":null}}'


### PR DESCRIPTION
I had an issue where RabbitMQ created a CRD called `policies`, but Kyverno also did and the finalizer removal did not hit the RabbitMQ policy object due to `$RESOURCE_NAME` not being unique.