### PR TITLE
Fix "Mark Range": reduce maximum namespaces in `favorites`, fix shadowing of ctrl+space

### DIFF
--- a/internal/config/data/ns.go
+++ b/internal/config/data/ns.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// MaxFavoritesNS number # favorite namespaces to keep in the configuration.
-	MaxFavoritesNS = 10
+	MaxFavoritesNS = 9
 )
 
 // Namespace tracks active and favorites namespaces.

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -593,10 +593,11 @@ func (b *Browser) namespaceActions(aa *ui.KeyActions) {
 		if numKey, ok := ui.NumKeys[index]; ok {
 			aa.Add(numKey, ui.NewKeyAction(ns, b.switchNamespaceCmd, true))
 			b.namespaces[index] = ns
+			index++
 		} else {
 			log.Warn().Msgf("No number key available for favorite namespace %s (%d of %d). Skipping...", ns, index, len(favNamespaces))
+			break
 		}
-		index++
 	}
 }
 

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -589,11 +589,12 @@ func (b *Browser) namespaceActions(aa *ui.KeyActions) {
 		if ns == client.NamespaceAll {
 			continue
 		}
+		// no assumption is made about the structure of NumKeys or the length of FavNamespaces
 		if numKey, ok := ui.NumKeys[index]; ok {
 			aa.Add(numKey, ui.NewKeyAction(ns, b.switchNamespaceCmd, true))
 			b.namespaces[index] = ns
-			index++
 		}
+		index++
 	}
 }
 

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -589,11 +589,13 @@ func (b *Browser) namespaceActions(aa *ui.KeyActions) {
 		if ns == client.NamespaceAll {
 			continue
 		}
-		// no assumption is made about the structure of NumKeys or the length of FavNamespaces
-		if numKey, ok := ui.NumKeys[index]; ok {
-			aa.Add(numKey, ui.NewKeyAction(ns, b.switchNamespaceCmd, true))
-			b.namespaces[index] = ns
+		numKey := ui.Key0 + tcell.Key(index)
+		// no assumption is made about the length of FavNamespaces
+		if numKey > ui.Key9 {
+			break
 		}
+		aa.Add(numKey, ui.NewKeyAction(ns, b.switchNamespaceCmd, true))
+		b.namespaces[index] = ns
 		index++
 	}
 }

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -585,17 +585,17 @@ func (b *Browser) namespaceActions(aa *ui.KeyActions) {
 	aa.Add(ui.Key0, ui.NewKeyAction(client.NamespaceAll, b.switchNamespaceCmd, true))
 	b.namespaces[0] = client.NamespaceAll
 	index := 1
-	for _, ns := range b.app.Config.FavNamespaces() {
+	favNamespaces := b.app.Config.FavNamespaces()
+	for _, ns := range favNamespaces {
 		if ns == client.NamespaceAll {
 			continue
 		}
-		numKey := ui.Key0 + tcell.Key(index)
-		// no assumption is made about the length of FavNamespaces
-		if numKey > ui.Key9 {
-			break
+		if numKey, ok := ui.NumKeys[index]; ok {
+			aa.Add(numKey, ui.NewKeyAction(ns, b.switchNamespaceCmd, true))
+			b.namespaces[index] = ns
+		} else {
+			log.Warn().Msgf("No number key available for favorite namespace %s (%d of %d). Skipping...", ns, index, len(favNamespaces))
 		}
-		aa.Add(numKey, ui.NewKeyAction(ns, b.switchNamespaceCmd, true))
-		b.namespaces[index] = ns
 		index++
 	}
 }

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -589,9 +589,11 @@ func (b *Browser) namespaceActions(aa *ui.KeyActions) {
 		if ns == client.NamespaceAll {
 			continue
 		}
-		aa.Add(ui.NumKeys[index], ui.NewKeyAction(ns, b.switchNamespaceCmd, true))
-		b.namespaces[index] = ns
-		index++
+		if numKey, ok := ui.NumKeys[index]; ok {
+			aa.Add(numKey, ui.NewKeyAction(ns, b.switchNamespaceCmd, true))
+			b.namespaces[index] = ns
+			index++
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #2187 (at least "Mark Range")

Hello!

The "Mark Range" command seems to have remained broken. I used delve to investigate the problem, and it seems that the problem is in `func namespaceActions`: we lookup the missing key `10` in `ui.NumKeys`, giving back `0` (empty value for `int`), corresponding to `tcell.KeyCtrlSpace`, and breaking "Mark Range".

This may be due to the increase to `MaxFavoriteNS` added by #2881: number keys are added for each namespace in `favorites` **plus the `all` namespace**, so `MaxFavoriteNS` should be `9`. I reduced `MaxFavoriteNS` back to `9`, and added a check in `func namespaceActions` for when we go beyond `ui.Key9`, while removing the need for the `ui.NumKeys`.

Thanks again for k9s! Let me know if you see any issues with my PR :)