### PR TITLE
fix: add kubeconfig if k9s is launched with --kubeconfig

### DIFF
--- a/plugins/debug-container.yaml
+++ b/plugins/debug-container.yaml
@@ -12,4 +12,4 @@ plugins:
     confirm: true
     args:
       - -c
-      - "kubectl debug -it --context $CONTEXT -n=$NAMESPACE $POD --target=$NAME --image=nicolaka/netshoot:v0.12 --share-processes -- bash"
+      - "kubectl --kubeconfig=$KUBECONFIG debug -it --context $CONTEXT -n=$NAMESPACE $POD --target=$NAME --image=nicolaka/netshoot:v0.12 --share-processes -- bash"


### PR DESCRIPTION
Specify the --kubeconfig argument, as if k9s is also launched with --kubeconfig, the container will be loaded on the same cluster and not on the default one