### PR TITLE
Feature: add pod last restart column to pod section

### DIFF
--- a/internal/model/table_int_test.go
+++ b/internal/model/table_int_test.go
@@ -35,7 +35,7 @@ func TestTableReconcile(t *testing.T) {
 	err := ta.reconcile(ctx)
 	assert.Nil(t, err)
 	data := ta.Peek()
-	assert.Equal(t, 23, data.HeaderCount())
+	assert.Equal(t, 24, data.HeaderCount())
 	assert.Equal(t, 1, data.RowCount())
 	assert.Equal(t, client.NamespaceAll, data.GetNamespace())
 }

--- a/internal/model/table_test.go
+++ b/internal/model/table_test.go
@@ -36,7 +36,7 @@ func TestTableRefresh(t *testing.T) {
 	ctx = context.WithValue(ctx, internal.KeyWithMetrics, false)
 	assert.NoError(t, ta.Refresh(ctx))
 	data := ta.Peek()
-	assert.Equal(t, 23, data.HeaderCount())
+	assert.Equal(t, 24, data.HeaderCount())
 	assert.Equal(t, 1, data.RowCount())
 	assert.Equal(t, client.NamespaceAll, data.GetNamespace())
 	assert.Equal(t, 1, l.count)

--- a/internal/render/helpers.go
+++ b/internal/render/helpers.go
@@ -203,15 +203,6 @@ func toAgeHuman(s string) string {
 	return duration.HumanDuration(time.Since(t))
 }
 
-// ToRestartAge converts pod last restart time to human duration.
-func ToRestartAge(t metav1.Time) string {
-	if t.IsZero() {
-		return NAValue
-	}
-	
-	return duration.HumanDuration(time.Since(t.Time))
-}
-
 // Truncate a string to the given l and suffix ellipsis if needed.
 func Truncate(str string, width int) string {
 	return runewidth.Truncate(str, width, string(tview.SemigraphicsHorizontalEllipsis))

--- a/internal/render/helpers.go
+++ b/internal/render/helpers.go
@@ -203,6 +203,15 @@ func toAgeHuman(s string) string {
 	return duration.HumanDuration(time.Since(t))
 }
 
+// ToRestartAge converts pod last restart time to human duration.
+func ToRestartAge(t metav1.Time) string {
+	if t.IsZero() {
+		return NAValue
+	}
+	
+	return duration.HumanDuration(time.Since(t.Time))
+}
+
 // Truncate a string to the given l and suffix ellipsis if needed.
 func Truncate(str string, width int) string {
 	return runewidth.Truncate(str, width, string(tview.SemigraphicsHorizontalEllipsis))

--- a/internal/render/helpers_test.go
+++ b/internal/render/helpers_test.go
@@ -98,40 +98,6 @@ func TestToAgeHuman(t *testing.T) {
 	}
 }
 
-func TestToRestartAge(t *testing.T) {
-	t.Parallel()
-
-	cases := map[string]struct {
-		input    metav1.Time
-		expected string
-	}{
-		"zero time": {
-			input:    metav1.Time{},
-			expected: NAValue,
-		},
-		"valid time": {
-			input:    metav1.Time{Time: time.Now().Add(-10 * time.Minute)},
-			expected: "10m",
-		},
-		"valid time hours": {
-			input:    metav1.Time{Time: time.Now().Add(-3 * time.Hour)},
-			expected: "3h",
-		},
-		"valid time minutes": {
-			input:    metav1.Time{Time: time.Now().Add(-5 * time.Hour).Add(-21 * time.Minute)},
-			expected: "5h21m",
-		},
-	}
-
-	for n, tc := range cases {
-		tc := tc
-		t.Run(n, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.expected, ToRestartAge(tc.input))
-		})
-	}
-}
-
 func TestJoin(t *testing.T) {
 	uu := map[string]struct {
 		i []string

--- a/internal/render/helpers_test.go
+++ b/internal/render/helpers_test.go
@@ -54,7 +54,7 @@ func TestTableHydrate(t *testing.T) {
 
 	assert.Nil(t, model1.Hydrate("blee", oo, rr, Pod{}))
 	assert.Equal(t, 1, len(rr))
-	assert.Equal(t, 23, len(rr[0].Fields))
+	assert.Equal(t, 24, len(rr[0].Fields))
 }
 
 func TestToAge(t *testing.T) {
@@ -94,6 +94,40 @@ func TestToAgeHuman(t *testing.T) {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
 			assert.Equal(t, u.e, toAgeHuman(u.t))
+		})
+	}
+}
+
+func TestToRestartAge(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		input    metav1.Time
+		expected string
+	}{
+		"zero time": {
+			input:    metav1.Time{},
+			expected: NAValue,
+		},
+		"valid time": {
+			input:    metav1.Time{Time: time.Now().Add(-10 * time.Minute)},
+			expected: "10m",
+		},
+		"valid time hours": {
+			input:    metav1.Time{Time: time.Now().Add(-3 * time.Hour)},
+			expected: "3h",
+		},
+		"valid time minutes": {
+			input:    metav1.Time{Time: time.Now().Add(-5 * time.Hour).Add(-21 * time.Minute)},
+			expected: "5h21m",
+		},
+	}
+
+	for n, tc := range cases {
+		tc := tc
+		t.Run(n, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, ToRestartAge(tc.input))
 		})
 	}
 }

--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -93,7 +93,7 @@ func (p Pod) Header(ns string) model1.Header {
 		model1.HeaderColumn{Name: "READY"},
 		model1.HeaderColumn{Name: "STATUS"},
 		model1.HeaderColumn{Name: "RESTARTS", Align: tview.AlignRight},
-		model1.HeaderColumn{Name: "LAST RESTART", Align: tview.AlignRight, Time: true},
+		model1.HeaderColumn{Name: "LAST RESTART", Align: tview.AlignRight, Time: true, Wide: true},
 		model1.HeaderColumn{Name: "CPU", Align: tview.AlignRight, MX: true},
 		model1.HeaderColumn{Name: "MEM", Align: tview.AlignRight, MX: true},
 		model1.HeaderColumn{Name: "CPU/R:L", Align: tview.AlignRight, Wide: true},
@@ -129,7 +129,7 @@ func (p Pod) Render(o interface{}, ns string, row *model1.Row) error {
 	_, _, irc := p.Statuses(ics)
 	cs := po.Status.ContainerStatuses
 	cr, _, rc := p.Statuses(cs)
-	lr := p.LastRestart(cs)
+	lr := p.lastRestart(cs)
 
 	var ccmx []mv1beta1.ContainerMetrics
 	if pwm.MX != nil {
@@ -147,7 +147,7 @@ func (p Pod) Render(o interface{}, ns string, row *model1.Row) error {
 		strconv.Itoa(cr) + "/" + strconv.Itoa(len(po.Spec.Containers)),
 		phase,
 		strconv.Itoa(rc + irc),
-		ToRestartAge(lr),
+		ToAge(lr),
 		toMc(c.cpu),
 		toMi(c.mem),
 		toMc(r.cpu) + ":" + toMc(r.lcpu),
@@ -318,8 +318,8 @@ func (*Pod) Statuses(ss []v1.ContainerStatus) (cr, ct, rc int) {
 	return
 }
 
-// LastRestart returns the last container restart time.
-func (*Pod) LastRestart(ss []v1.ContainerStatus) (latest metav1.Time) {
+// lastRestart returns the last container restart time.
+func (*Pod) lastRestart(ss []v1.ContainerStatus) (latest metav1.Time) {
 	for _, c := range ss {
 		if c.LastTerminationState.Terminated == nil {
 			continue
@@ -331,7 +331,6 @@ func (*Pod) LastRestart(ss []v1.ContainerStatus) (latest metav1.Time) {
 	}
 	return
 }
-
 
 // Phase reports the given pod phase.
 func (p *Pod) Phase(po *v1.Pod) string {

--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -12,6 +12,7 @@ import (
 	"github.com/derailed/tview"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -92,6 +93,7 @@ func (p Pod) Header(ns string) model1.Header {
 		model1.HeaderColumn{Name: "READY"},
 		model1.HeaderColumn{Name: "STATUS"},
 		model1.HeaderColumn{Name: "RESTARTS", Align: tview.AlignRight},
+		model1.HeaderColumn{Name: "LAST RESTART", Align: tview.AlignRight, Time: true},
 		model1.HeaderColumn{Name: "CPU", Align: tview.AlignRight, MX: true},
 		model1.HeaderColumn{Name: "MEM", Align: tview.AlignRight, MX: true},
 		model1.HeaderColumn{Name: "CPU/R:L", Align: tview.AlignRight, Wide: true},
@@ -127,6 +129,7 @@ func (p Pod) Render(o interface{}, ns string, row *model1.Row) error {
 	_, _, irc := p.Statuses(ics)
 	cs := po.Status.ContainerStatuses
 	cr, _, rc := p.Statuses(cs)
+	lr := p.LastRestart(cs)
 
 	var ccmx []mv1beta1.ContainerMetrics
 	if pwm.MX != nil {
@@ -144,6 +147,7 @@ func (p Pod) Render(o interface{}, ns string, row *model1.Row) error {
 		strconv.Itoa(cr) + "/" + strconv.Itoa(len(po.Spec.Containers)),
 		phase,
 		strconv.Itoa(rc + irc),
+		ToRestartAge(lr),
 		toMc(c.cpu),
 		toMi(c.mem),
 		toMc(r.cpu) + ":" + toMc(r.lcpu),
@@ -313,6 +317,21 @@ func (*Pod) Statuses(ss []v1.ContainerStatus) (cr, ct, rc int) {
 
 	return
 }
+
+// LastRestart returns the last container restart time.
+func (*Pod) LastRestart(ss []v1.ContainerStatus) (latest metav1.Time) {
+	for _, c := range ss {
+		if c.LastTerminationState.Terminated == nil {
+			continue
+		}
+		ts := c.LastTerminationState.Terminated.FinishedAt
+		if latest.IsZero() || ts.After(latest.Time) {
+			latest = ts
+		}
+	}
+	return
+}
+
 
 // Phase reports the given pod phase.
 func (p *Pod) Phase(po *v1.Pod) string {

--- a/internal/render/pod_int_test.go
+++ b/internal/render/pod_int_test.go
@@ -426,9 +426,8 @@ func Test_lastRestart(t *testing.T) {
 	}
 
 	var p Pod
-	for k := range uu {
-		u := uu[k]
-		t.Run(k, func(t *testing.T) {
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, u.expected, p.lastRestart(u.containerStatuses))
 		})
 	}

--- a/internal/render/pod_int_test.go
+++ b/internal/render/pod_int_test.go
@@ -4,12 +4,15 @@
 package render
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/derailed/k9s/internal/client"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	res "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	mv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
 
@@ -355,6 +358,82 @@ func Test_filterRestartableInitCO(t *testing.T) {
 	}
 }
 
+func Test_lastRestart(t *testing.T) {
+	uu := map[string]struct {
+		containerStatuses []v1.ContainerStatus
+		expected          metav1.Time
+	}{
+		"no-restarts": {
+			containerStatuses: []v1.ContainerStatus{
+				{
+					Name:                 "c1",
+					LastTerminationState: v1.ContainerState{},
+				},
+			},
+			expected: metav1.Time{},
+		},
+		"single-container-restart": {
+			containerStatuses: []v1.ContainerStatus{
+				{
+					Name: "c1",
+					LastTerminationState: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							FinishedAt: metav1.Time{Time: testTime()},
+						},
+					},
+				},
+			},
+			expected: metav1.Time{Time: testTime()},
+		},
+		"multiple-container-restarts": {
+			containerStatuses: []v1.ContainerStatus{
+				{
+					Name: "c1",
+					LastTerminationState: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							FinishedAt: metav1.Time{Time: testTime().Add(-1 * time.Hour)},
+						},
+					},
+				},
+				{
+					Name: "c2",
+					LastTerminationState: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							FinishedAt: metav1.Time{Time: testTime()},
+						},
+					},
+				},
+			},
+			expected: metav1.Time{Time: testTime()},
+		},
+		"mixed-termination-states": {
+			containerStatuses: []v1.ContainerStatus{
+				{
+					Name:                 "c1",
+					LastTerminationState: v1.ContainerState{},
+				},
+				{
+					Name: "c2",
+					LastTerminationState: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							FinishedAt: metav1.Time{Time: testTime()},
+						},
+					},
+				},
+			},
+			expected: metav1.Time{Time: testTime()},
+		},
+	}
+
+	var p Pod
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.expected, p.lastRestart(u.containerStatuses))
+		})
+	}
+}
+
 func Test_gatherPodMx(t *testing.T) {
 	uu := map[string]struct {
 		spec *v1.PodSpec
@@ -546,4 +625,12 @@ func makeCoMX(n string, c, m string) mv1beta1.ContainerMetrics {
 		Name:  n,
 		Usage: makeRes(c, m),
 	}
+}
+
+func testTime() time.Time {
+	t, err := time.Parse(time.RFC3339, "2018-12-14T10:36:43.326972-07:00")
+	if err != nil {
+		fmt.Println("TestTime Failed", err)
+	}
+	return t
 }

--- a/internal/render/pod_test.go
+++ b/internal/render/pod_test.go
@@ -5,6 +5,7 @@ package render_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/derailed/k9s/internal/model1"
 	"github.com/derailed/k9s/internal/render"
@@ -163,8 +164,8 @@ func TestPodRender(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "default/nginx", r.ID)
-	e := model1.Fields{"default", "nginx", "0", "●", "1/1", "Running", "0", "100", "50", "100:0", "70:170", "100", "n/a", "71", "29", "172.17.0.6", "minikube", "<none>", "<none>"}
-	assert.Equal(t, e, r.Fields[:19])
+	e := model1.Fields{"default", "nginx", "0", "●", "1/1", "Running", "0", "n/a", "100", "50", "100:0", "70:170", "100", "n/a", "71", "29", "172.17.0.6", "minikube", "<none>", "<none>"}
+	assert.Equal(t, e, r.Fields[:20])
 }
 
 func BenchmarkPodRender(b *testing.B) {
@@ -194,8 +195,8 @@ func TestPodInitRender(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "default/nginx", r.ID)
-	e := model1.Fields{"default", "nginx", "0", "●", "1/1", "Init:0/1", "0", "10", "10", "100:0", "70:170", "10", "n/a", "14", "5", "172.17.0.6", "minikube", "<none>", "<none>"}
-	assert.Equal(t, e, r.Fields[:19])
+	e := model1.Fields{"default", "nginx", "0", "●", "1/1", "Init:0/1", "0", "n/a", "10", "10", "100:0", "70:170", "10", "n/a", "14", "5", "172.17.0.6", "minikube", "<none>", "<none>"}
+	assert.Equal(t, e, r.Fields[:20])
 }
 
 func TestPodSidecarRender(t *testing.T) {
@@ -210,8 +211,8 @@ func TestPodSidecarRender(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "default/sleep", r.ID)
-	e := model1.Fields{"default", "sleep", "0", "●", "1/1", "Running", "0", "100", "40", "50:250", "50:80", "200", "40", "80", "50", "10.244.0.8", "kind-control-plane", "<none>", "<none>"}
-	assert.Equal(t, e, r.Fields[:19])
+	e := model1.Fields{"default", "sleep", "0", "●", "1/1", "Running", "0", "n/a", "100", "40", "50:250", "50:80", "200", "40", "80", "50", "10.244.0.8", "kind-control-plane", "<none>", "<none>"}
+	assert.Equal(t, e, r.Fields[:20])
 }
 
 func TestCheckPodStatus(t *testing.T) {
@@ -539,6 +540,82 @@ func TestCheckPodStatus(t *testing.T) {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
 			assert.Equal(t, u.e, render.PodStatus(&u.pod))
+		})
+	}
+}
+
+func TestPodLastRestart(t *testing.T) {
+	uu := map[string]struct {
+		containerStatuses []v1.ContainerStatus
+		expected          metav1.Time
+	}{
+		"no-restarts": {
+			containerStatuses: []v1.ContainerStatus{
+				{
+					Name:                 "c1",
+					LastTerminationState: v1.ContainerState{},
+				},
+			},
+			expected: metav1.Time{},
+		},
+		"single-container-restart": {
+			containerStatuses: []v1.ContainerStatus{
+				{
+					Name: "c1",
+					LastTerminationState: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							FinishedAt: metav1.Time{Time: testTime()},
+						},
+					},
+				},
+			},
+			expected: metav1.Time{Time: testTime()},
+		},
+		"multiple-container-restarts": {
+			containerStatuses: []v1.ContainerStatus{
+				{
+					Name: "c1",
+					LastTerminationState: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							FinishedAt: metav1.Time{Time: testTime().Add(-1 * time.Hour)},
+						},
+					},
+				},
+				{
+					Name: "c2",
+					LastTerminationState: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							FinishedAt: metav1.Time{Time: testTime()},
+						},
+					},
+				},
+			},
+			expected: metav1.Time{Time: testTime()},
+		},
+		"mixed-termination-states": {
+			containerStatuses: []v1.ContainerStatus{
+				{
+					Name:                 "c1",
+					LastTerminationState: v1.ContainerState{},
+				},
+				{
+					Name: "c2",
+					LastTerminationState: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							FinishedAt: metav1.Time{Time: testTime()},
+						},
+					},
+				},
+			},
+			expected: metav1.Time{Time: testTime()},
+		},
+	}
+
+	var p render.Pod
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.expected, p.LastRestart(u.containerStatuses))
 		})
 	}
 }


### PR DESCRIPTION
This PR adds a new feature on K9s requested on #2834. It creates a `ToRestartAge` function that calculates the pod last restart time to age. Chose not to use `ToAge` existing function because it returns an `<unknown>` and its scope does not look that we should use it to calculate the age of last restarts.

It also provides a new function to `Pod` definition like `Statuses`: `LastRestart`, running through the containers last terminated states and getting the `FinishedAt` field - thus returning the last restart of a container inside the pod. 

I have tweaked the current tests to pass in order to follow the new column called "LAST RESTARTS" and also created new unit tests in order to test both new functions.

Preview with a dummy restarting pod:

<img width="968" alt="image" src="https://github.com/user-attachments/assets/d55a812c-1f74-4bb3-b48b-ad340ef780ef">

### How to test this PR

With a cluster connected, copy the following file into `restart-container.yaml` and run `kubectl apply -f restart-container.yaml`:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: restarting-deployment
  labels:
    app: restart-demo
spec:
  replicas: 2
  selector:
    matchLabels:
      app: restart-demo
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 1
  template:
    metadata:
      labels:
        app: restart-demo
    spec:
      containers:
        - name: restart-container
          image: busybox:latest
          command: ["/bin/sh", "-c"]
          args:
            - |
              for i in {1..18}; do
                sleep 10
              done
              exit 1
          resources:
            requests:
              memory: "64Mi"
              cpu: "100m"
            limits:
              memory: "128Mi"
              cpu: "200m"
```
