### PR TITLE
feature: add Custom columns labels support (#605)

### DIFF
--- a/internal/model1/fields.go
+++ b/internal/model1/fields.go
@@ -3,15 +3,44 @@
 
 package model1
 
-import "reflect"
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+)
 
 // Fields represents a collection of row fields.
 type Fields []string
 
 // Customize returns a subset of fields.
-func (f Fields) Customize(cols []int, out Fields) {
+func (f Fields) Customize(cols []int, out Fields, extractionInfoBag ExtractionInfoBag) {
 	for i, c := range cols {
 		if c < 0 {
+
+			// If current index can retrieve an extractionInfo from extractionInfoBag,
+			// meaning this column has to retrieve the actual value from other field.
+			// For example: `LABELS[kubernetes.io/hostname]` needs to extract the value from column `LABELS`
+			if extractionInfo, ok := extractionInfoBag[i]; ok {
+				idxInFields := extractionInfo.IdxInFields
+				key := extractionInfo.Key
+
+				// Escape dots from the key
+				// For example: `kubernetes.io/hostname` needs to be escaped to `kubernetes\.io/hostname`
+				escapedKey := strings.ReplaceAll(key, ".", "\\.")
+
+				// Extract the value by using regex
+				pattern := fmt.Sprintf(`%s=([^ ]+)`, escapedKey)
+				regex := regexp.MustCompile(pattern)
+
+				// Find the value in the field that store original values
+				matches := regex.FindStringSubmatch(f[idxInFields])
+				if len(matches) > 1 {
+					out[i] = matches[1]
+					continue
+				}
+			}
+
 			out[i] = NAValue
 			continue
 		}

--- a/internal/model1/header.go
+++ b/internal/model1/header.go
@@ -85,13 +85,19 @@ func (h Header) MapIndices(cols []string, wide bool) ([]int, ExtractionInfoBag) 
 
 	for _, col := range cols {
 		idx, ok := h.IndexOf(col, true)
-		if !ok {
-			log.Warn().Msgf("Column %q not found on resource", col)
-		}
+
 		ii, cc[idx] = append(ii, idx), struct{}{}
 
-		// If the column already found OR the it doesn't match the regex
-		if ok || !regex.MatchString(col) {
+		// Continue to next iteration if the column is found
+		if ok {
+			continue
+		}
+
+		log.Warn().Msgf("Column %q not found on resource", col)
+
+		// Continue to next iteration ff the column doesn't match the regex
+		if !regex.MatchString(col) {
+			log.Warn().Msgf("Column %q doesn't match regex pattern", col)
 			continue
 		}
 
@@ -103,9 +109,11 @@ func (h Header) MapIndices(cols []string, wide bool) ([]int, ExtractionInfoBag) 
 
 		// now only support LABELS
 		if headerName != "LABELS" {
+			log.Warn().Msgf("Custom Column %q is not supported", col)
 			continue
 		}
 
+		log.Warn().Msgf("Custom column %q is extracting value with header name: %q and key: %q", col, headerName, key)
 		currentIdx := len(ii) - 1
 		idxInFields, _ := h.IndexOf(headerName, true)
 		eib[currentIdx] = ExtractionInfo{idxInFields, headerName, key}

--- a/internal/model1/header_test.go
+++ b/internal/model1/header_test.go
@@ -16,34 +16,49 @@ func TestHeaderMapIndices(t *testing.T) {
 		cols []string
 		wide bool
 		e    []int
+		eib  model1.ExtractionInfoBag
 	}{
 		"all": {
 			h1:   makeHeader(),
 			cols: []string{"A", "B", "C"},
 			e:    []int{0, 1, 2},
+			eib:  model1.ExtractionInfoBag{},
 		},
 		"reverse": {
 			h1:   makeHeader(),
 			cols: []string{"C", "B", "A"},
 			e:    []int{2, 1, 0},
+			eib:  model1.ExtractionInfoBag{},
 		},
 		"missing": {
 			h1:   makeHeader(),
 			cols: []string{"Duh", "B", "A"},
 			e:    []int{-1, 1, 0},
+			eib:  model1.ExtractionInfoBag{},
 		},
 		"skip": {
 			h1:   makeHeader(),
 			cols: []string{"C", "A"},
 			e:    []int{2, 0},
+			eib:  model1.ExtractionInfoBag{},
+		},
+		"labels": {
+			h1:   makeHeader(),
+			cols: []string{"A", "LABELS[kubernetes.io/hostname]", "B", "LABELS[topology.kubernetes.io/region]"},
+			e:    []int{0, -1, 1, -1},
+			eib: model1.ExtractionInfoBag{
+				1: model1.ExtractionInfo{3, "LABELS", "kubernetes.io/hostname"},
+				3: model1.ExtractionInfo{3, "LABELS", "topology.kubernetes.io/region"},
+			},
 		},
 	}
 
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			ii := u.h1.MapIndices(u.cols, u.wide)
+			ii, eib := u.h1.MapIndices(u.cols, u.wide)
 			assert.Equal(t, u.e, ii)
+			assert.Equal(t, u.eib, eib)
 		})
 	}
 }
@@ -264,11 +279,11 @@ func TestHeaderColumns(t *testing.T) {
 		},
 		"regular": {
 			h: makeHeader(),
-			e: []string{"A", "C"},
+			e: []string{"A", "C", "LABELS"},
 		},
 		"wide": {
 			h:    makeHeader(),
-			e:    []string{"A", "B", "C"},
+			e:    []string{"A", "B", "C", "LABELS"},
 			wide: true,
 		},
 	}
@@ -314,5 +329,6 @@ func makeHeader() model1.Header {
 		model1.HeaderColumn{Name: "A"},
 		model1.HeaderColumn{Name: "B", Wide: true},
 		model1.HeaderColumn{Name: "C"},
+		model1.HeaderColumn{Name: "LABELS"},
 	}
 }

--- a/internal/model1/helpers.go
+++ b/internal/model1/helpers.go
@@ -6,6 +6,7 @@ package model1
 import (
 	"fmt"
 	"math"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -163,4 +164,24 @@ func lessNumber(s1, s2 string) bool {
 	v1, v2 := strings.Replace(s1, ",", "", -1), strings.Replace(s2, ",", "", -1)
 
 	return sortorder.NaturalLess(v1, v2)
+}
+
+// Escape dots from the string
+// For example: `kubernetes.io/hostname` needs to be escaped to `kubernetes\.io/hostname`
+func escapeDots(s string) string {
+	return strings.ReplaceAll(s, ".", "\\.")
+}
+
+func extractValueFromField(key string, field string) string {
+	// Extract the value by using regex
+	pattern := fmt.Sprintf(`%s=([^ ]+)`, key)
+	regex := regexp.MustCompile(pattern)
+
+	// Find the value in the field that store original values
+	matches := regex.FindStringSubmatch(field)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+
+	return ""
 }

--- a/internal/model1/helpers_test.go
+++ b/internal/model1/helpers_test.go
@@ -87,3 +87,29 @@ func BenchmarkDurationToSecond(b *testing.B) {
 		durationToSeconds(t)
 	}
 }
+
+func TestEscapeDots(t *testing.T) {
+	var s string
+
+	s = escapeDots("kubernetes.io/hostname")
+	assert.Equal(t, "kubernetes\\.io/hostname", s)
+
+	s = escapeDots("kubernetes-io/hostname")
+	assert.Equal(t, "kubernetes-io/hostname", s)
+}
+
+func TestExtractValueFromFields(t *testing.T) {
+	k := escapeDots("kubernetes.io/hostname")
+	f := "kubernetes.io/arch=amd64 kubernetes.io/hostname=a-b-c-d kubernetes.io/os=linux"
+
+	var s string
+
+	s = extractValueFromField(k, f)
+	assert.Equal(t, "a-b-c-d", s)
+
+	s = extractValueFromField(k, "kubernetes.io/hostname=e-f-g-h "+f)
+	assert.Equal(t, "e-f-g-h", s)
+
+	s = extractValueFromField("random-key", f)
+	assert.Equal(t, "", s)
+}

--- a/internal/model1/row.go
+++ b/internal/model1/row.go
@@ -29,9 +29,9 @@ func (r Row) Labelize(cols []int, labelCol int, labels []string) Row {
 }
 
 // Customize returns a row subset based on given col indices.
-func (r Row) Customize(cols []int) Row {
+func (r Row) Customize(cols []int, extractionInfoBag ExtractionInfoBag) Row {
 	out := NewRow(len(cols))
-	r.Fields.Customize(cols, out.Fields)
+	r.Fields.Customize(cols, out.Fields, extractionInfoBag)
 	out.ID = r.ID
 
 	return out

--- a/internal/model1/row_event.go
+++ b/internal/model1/row_event.go
@@ -47,7 +47,7 @@ func (r RowEvent) Clone() RowEvent {
 }
 
 // Customize returns a new subset based on the given column indices.
-func (r RowEvent) Customize(cols []int) RowEvent {
+func (r RowEvent) Customize(cols []int, extractionInfoBag ExtractionInfoBag) RowEvent {
 	delta := r.Deltas
 	if !r.Deltas.IsBlank() {
 		delta = make(DeltaRow, len(cols))
@@ -57,7 +57,7 @@ func (r RowEvent) Customize(cols []int) RowEvent {
 	return RowEvent{
 		Kind:   r.Kind,
 		Deltas: delta,
-		Row:    r.Row.Customize(cols),
+		Row:    r.Row.Customize(cols, extractionInfoBag),
 	}
 }
 
@@ -158,10 +158,10 @@ func (r *RowEvents) Labelize(cols []int, labelCol int, labels []string) *RowEven
 }
 
 // Customize returns custom row events based on columns layout.
-func (r *RowEvents) Customize(cols []int) *RowEvents {
+func (r *RowEvents) Customize(cols []int, extractionInfoBag ExtractionInfoBag) *RowEvents {
 	ee := make([]RowEvent, 0, len(cols))
 	for _, re := range r.events {
-		ee = append(ee, re.Customize(cols))
+		ee = append(ee, re.Customize(cols, extractionInfoBag))
 	}
 
 	return NewRowEventsWithEvts(ee...)

--- a/internal/model1/row_event_test.go
+++ b/internal/model1/row_event_test.go
@@ -15,6 +15,7 @@ func TestRowEventCustomize(t *testing.T) {
 	uu := map[string]struct {
 		re1, e model1.RowEvent
 		cols   []int
+		eib    model1.ExtractionInfoBag
 	}{
 		"empty": {
 			re1: model1.RowEvent{
@@ -101,7 +102,7 @@ func TestRowEventCustomize(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			assert.Equal(t, u.e, u.re1.Customize(u.cols))
+			assert.Equal(t, u.e, u.re1.Customize(u.cols, u.eib))
 		})
 	}
 }
@@ -297,6 +298,7 @@ func TestRowEventsCustomize(t *testing.T) {
 	uu := map[string]struct {
 		re, e *model1.RowEvents
 		cols  []int
+		eib   model1.ExtractionInfoBag
 	}{
 		"same": {
 			re: model1.NewRowEventsWithEvts(
@@ -355,7 +357,7 @@ func TestRowEventsCustomize(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			assert.Equal(t, u.e, u.re.Customize(u.cols))
+			assert.Equal(t, u.e, u.re.Customize(u.cols, u.eib))
 		})
 	}
 }

--- a/internal/model1/table_data.go
+++ b/internal/model1/table_data.go
@@ -340,8 +340,8 @@ func (t *TableData) Customize(vs *config.ViewSetting, sc SortColumn, manual, wid
 		namespace: t.namespace,
 		header:    t.header.Customize(cols, wide),
 	}
-	ids := t.header.MapIndices(cols, wide)
-	cdata.rowEvents = t.rowEvents.Customize(ids)
+	ids, extractionInfoBag := t.header.MapIndices(cols, wide)
+	cdata.rowEvents = t.rowEvents.Customize(ids, extractionInfoBag)
 	if manual || vs == nil {
 		return &cdata, sc
 	}


### PR DESCRIPTION
This PR adds a new feature on K9s requested on https://github.com/derailed/k9s/issues/605.
Users can define a specific label in the custom column.

**Example:**
```
views:
  v1/nodes:
    columns:
      - NAME
      - STATUS
      - PODS
      - LABELS[topology.kubernetes.io/region]
```

**Preview:**
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/d429880f-e387-4e64-806e-31146e9f935d">

**Description:**
I implemented a concept called "ExtractionInfo". 
When a custom column is not found in the headers, it will check if it can extract value from another field.
The "ExtractionInfo" will contain the index of the origin column in the field, the header name, and the key to lookup.
I have another struct called "ExtractionInfoBag", which is used to store all these "ExtractionInfo" by using the index of the column in the current field.

**Notes:**
I'm new to Golang and wish to contribute to the community, but I'm not sure whether my code is good enough.
This is my very first PR, please let me know if any feedback!

