### PR TITLE
Put log levels in order in cmd help

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -188,7 +188,7 @@ func initK9sFlags() {
 		k9sFlags.LogLevel,
 		"logLevel", "l",
 		config.DefaultLogLevel,
-		"Specify a log level (info, warn, debug, trace, error)",
+		"Specify a log level (error, warn, info, debug, trace)",
 	)
 	rootCmd.Flags().StringVarP(
 		k9sFlags.LogFile,


### PR DESCRIPTION
Hi, I feel that listing log levels in severity order might make this more readable - what do you think?

Thanks
Tom