### PR TITLE
Update .goreleaser.yml with Linux riscv64 binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,7 @@ builds:
       - arm64
       - arm
       - ppc64le
+      - riscv64
       - s390x
     goarm:
       - 7


### PR DESCRIPTION
There are lots of boards with riscv64 architecture available. We can argue if this architecture is more popular accessible than s390x for example. Let's generate the binaries for its Linux OS.