### PR TITLE
feat(plugins/crossplane): change to crossplane cli & add crossplane-watch

### DIFF
--- a/plugins/crossplane.yaml
+++ b/plugins/crossplane.yaml
@@ -1,21 +1,37 @@
 plugins:
-  # List all the resources managed by a Composite Resource
-  kube-lineage:
-    shortCut: Ctrl-U
+  # crossplane-trace list all the relationships with a resource (Claim, Composite, or Managed Resource)
+  # Requires 'crossplane' cli binary installed
+  crossplane-trace:
+    shortCut: t
     confirm: false
-    description: "Kube Lineage"
+    description: "Crossplane Trace"
     scopes:
       - all
     command: sh
     background: false
     args:
       - -c
-      - >-
-        kubectl lineage
-        -d 6
-        --exclude-types Event,ProviderConfigUsage.aws.upbound.io,ProviderConfigUsage.kubernetes.crossplane.io
-        --show-group
-        --context $CONTEXT
-        $RESOURCE_NAME
-        $NAME
-        | less -K
+      - |
+        if [ -n "$NAMESPACE" ]; then
+          crossplane beta trace --context $CONTEXT -n $NAMESPACE $RESOURCE_NAME.$RESOURCE_GROUP $NAME -owide | less -K
+        else
+          crossplane beta trace --context $CONTEXT $RESOURCE_NAME.$RESOURCE_GROUP $NAME -owide | less -K
+        fi
+  # crossplane-watch requires 'crossplane' cli and 'viddy' binaries installed
+  # 'viddy' is a modern implementation of 'watch' command written in rust. Read more on https://github.com/sachaos/viddy.
+  crossplane-watch:
+    shortCut: w
+    confirm: false
+    description: "Crossplane Watch"
+    scopes:
+      - all
+    command: sh
+    background: false
+    args:
+      - -c
+      - |
+        if [ -n "$NAMESPACE" ]; then
+          viddy -pw 'crossplane beta trace --context $CONTEXT -n $NAMESPACE $RESOURCE_NAME.$RESOURCE_GROUP $NAME -owide'
+        else
+          viddy -pw 'crossplane beta trace --context $CONTEXT $RESOURCE_NAME.$RESOURCE_GROUP $NAME -owide'
+        fi


### PR DESCRIPTION
This pull request includes changes to the `plugins/crossplane.yaml` file to replace the `kube-lineage` plugin with two new plugins, `crossplane-trace` and `crossplane-watch`. These changes enhance the functionality for tracing and monitoring resources managed by Crossplane.

Changes to plugins:

* Replaced `kube-lineage` plugin with `crossplane-trace` plugin, which lists all relationships with a resource and requires the `crossplane` CLI binary.
* Added `crossplane-watch` plugin, which monitors resources using the `viddy` binary, a modern implementation of the `watch` command written in Rust.

Credits to @clementblaise for an old PR that likely covered this main idea.

