### PR TITLE
plugin/trace-dns: Trace DNS requests using Inspektor Gadget

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -5,7 +5,7 @@ K9s plugins extend the tool to provide additional functionality via actions to f
 Following is an example of some of plugin files in this directory. Other files are not listed in this table.
 
 | Plugin-Name                    | Description                                                                  | Available on Views                  | Shortcut  | Kubectl plugin, external dependencies                                                 |
-| ------------------------------ | ---------------------------------------------------------------------------- | ----------------------------------- | --------- | ------------------------------------------------------------------------------------- |
+| ------------------------------ | ---------------------------------------------------------------------------- | ----------------------------------- |-----------| ------------------------------------------------------------------------------------- |
 | debug-container.yml            | Add [ephemeral debug container](1)<br>([nicolaka/netshoot](2))               | containers                          | Shift-d   |                                                                                       |
 | dive.yml                       | Dive image layers                                                            | containers                          | d         | [Dive](https://github.com/wagoodman/dive)                                             |
 | get-all.yml                    | get all resources in a namespace                                             | all                                 | g         | [Krew](https://krew.sigs.k8s.io/), [ketall](https://github.com/corneliusweig/ketall/) |
@@ -16,9 +16,10 @@ Following is an example of some of plugin files in this directory. Other files a
 | log_jq.yml                     | View resource logs using jq                                                  | pods                                | Ctrl-j    | kubectl-plugins/kubectl-jq                                                            |
 | log_full.yml                   | get full logs from pod/container                                             | pods/containers                     | Ctrl-l    |                                                                                       |
 | ai-incident-investigation.yaml | Run AI investigation on application issues to find the root cause in seconds | all                                 | Shift-h/o | [HolmesGPT](https://github.com/robusta-dev/holmesgpt)                                 |
-| toggle-keda                    | Enable/disable [keda](3) ScaledObject autoscaler                                  | scaledobjects                       | Ctrl-N    |                                                                                       |
-
+| toggle-keda                    | Enable/disable [keda](3) ScaledObject autoscaler                             | scaledobjects                       | Ctrl-N    |                                                                                       |
+| trace-dns                      | Trace DNS resolution using Inspektor Gadget (4)                              | containers/pods/nodes               | Shift-d   |                                                                                       |
 
 [1]: https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container
 [2]: https://github.com/nicolaka/netshoot
 [3]: https://keda.sh/
+[4]: https://inspektor-gadget.io/

--- a/plugins/trace-dns.yaml
+++ b/plugins/trace-dns.yaml
@@ -1,0 +1,65 @@
+# Author: Qasim Sarfraz
+# Trace DNS requests for containers, pods, and nodes
+# Requires kubectl version 1.30 or later
+# https://github.com/inspektor-gadget/inspektor-gadget
+# https://www.inspektor-gadget.io/docs/latest/gadgets/trace_dns
+plugins:
+  trace-dns:
+    shortCut: Shift-D
+    description: Trace DNS requests
+    scopes:
+      - containers
+      - pods
+      - nodes
+    command: bash
+    confirm: false
+    background: false
+    args:
+      - -c
+      - |
+        IG_VERSION=v0.34.0
+        IG_IMAGE=ghcr.io/inspektor-gadget/ig:$IG_VERSION
+        IG_FIELD=k8s.podName,src,dst,qr,qtype,name,rcode,latency_ns
+        
+        GREEN='\033[0;32m'
+        RED='\033[0;31m'
+        BLUE='\033[0;34m'
+        NC='\033[0m' # No Color
+        
+        # Ensure kubectl version is 1.30 or later
+        KUBECTL_VERSION=$(kubectl version --client | awk '/Client Version:/{print $3}')
+        if [[ "$(echo "$KUBECTL_VERSION" | cut -d. -f2)" -lt 30 ]]; then
+          echo -e "${RED}kubectl version 1.30 or later is required${NC}"
+          sleep 3
+          exit
+        fi
+        
+        clear
+
+        # Handle containers
+        if [[ -n "$POD" ]]; then
+          echo -e "${GREEN}Tracing DNS requests for container ${BLUE}${NAME}${GREEN} in pod ${BLUE}${POD}${GREEN} in namespace ${BLUE}${NAMESPACE}${NC}"
+          IG_NODE=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.spec.nodeName}')
+          kubectl debug --kubeconfig=$KUBECONFIG  --context=$CONTEXT -q \
+            --profile=sysadmin "node/$IG_NODE" -it --image="$IG_IMAGE" -- \
+            ig run trace_dns:$IG_VERSION -F "k8s.podName==$POD" -F "k8s.containerName=$NAME" \
+            --fields "$IG_FIELD"
+            exit
+        fi
+        
+        # Handle pods
+        if [[ -n "$NAMESPACE" ]]; then
+          echo -e "${GREEN}Tracing DNS requests for pod ${BLUE}${NAME}${GREEN} in namespace ${BLUE}${NAMESPACE}${NC}"
+          IG_NODE=$(kubectl get pod "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.nodeName}')
+          kubectl debug --kubeconfig=$KUBECONFIG  --context=$CONTEXT -q \
+            --profile=sysadmin  -it --image="$IG_IMAGE" "node/$IG_NODE" -- \
+            ig run trace_dns:$IG_VERSION -F "k8s.podName==$NAME" \
+            --fields "$IG_FIELD"
+            exit
+        fi
+        
+        # Handle nodes
+        echo -e "${GREEN}Tracing DNS requests for node ${BLUE}${NAME}${NC}"
+        kubectl debug --kubeconfig=$KUBECONFIG  --context=$CONTEXT -q \
+          --profile=sysadmin -it --image="$IG_IMAGE" "node/$NAME" -- \
+          ig run trace_dns:$IG_VERSION --fields "$IG_FIELD"


### PR DESCRIPTION
This change adds a new plugin for tracing DNS requests at container, pod and node level.

# Usage

Copy the YAML definition  to plugin directory `/home/qasim/.config/k9s/plugins.yaml`. The plugin is available using `Shift-D` in container, pod and node views. 

## Testing done
Start by preparing a test pod:

```
$ kubectl create ns demo
$ kubectl -n demo run mypod --image=wbitt/network-multitool -- sleep inf
```

Once done get the shell for test pod in one terminal and start the trace (pod view) in another terminal. If you generate a test requests `nslookup microsoft.com.` you should see following: 

![image](https://github.com/user-attachments/assets/13826b5d-b617-475c-851e-b28fd6c5a0d2)





Ref: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_dns