### PR TITLE
fix kubectl url and fail build on download errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=build /k9s/execs/k9s /bin/k9s
 RUN apk --no-cache add --update ca-certificates \
   && apk --no-cache add --update -t deps curl vim \
   && TARGET_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
-  && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${TARGET_ARCH}/kubectl -o /usr/local/bin/kubectl \
+  && curl -f -L https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGET_ARCH}/kubectl -o /usr/local/bin/kubectl \
   && chmod +x /usr/local/bin/kubectl \
   && apk del --purge deps
 


### PR DESCRIPTION
looking at the latest build of this docker image, I'm seeing failures on kubectl:

```
$ docker pull derailed/k9s
Using default tag: latest
latest: Pulling from derailed/k9s
da9db072f522: Already exists 
908ff4b574ff: Pull complete 
b44627110f63: Pull complete 
Digest: sha256:502554a094cd1e845033485f49f71458c5a1d4318b3af1263a67ec6afe9159e8
Status: Downloaded newer image for derailed/k9s:latest
docker.io/derailed/k9s:latest
```

```
$ docker run -it --rm --entrypoint=/bin/sh derailed/k9s
/ # cat $(which kubectl)
<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: kubernetes-release/release/v1.31.2/bin/linux/amd64/kubectl</Details></Error>/ # 
/ # 
```

This fix should cause the image build to fail if the curl is unsuccessful (adds `-f`) and updates the URL based on the recommended location here: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/