### PR TITLE
Bump version of netshoot image in debug-container plugin

### DIFF
--- a/plugins/debug-container.yaml
+++ b/plugins/debug-container.yaml
@@ -12,4 +12,4 @@ plugins:
     confirm: true
     args:
       - -c
-      - "kubectl --kubeconfig=$KUBECONFIG debug -it --context $CONTEXT -n=$NAMESPACE $POD --target=$NAME --image=nicolaka/netshoot:v0.12 --share-processes -- bash"
+      - "kubectl --kubeconfig=$KUBECONFIG debug -it --context $CONTEXT -n=$NAMESPACE $POD --target=$NAME --image=nicolaka/netshoot:v0.13 --share-processes -- bash"


### PR DESCRIPTION
Latest version of netshoot image is 0.13, see https://github.com/nicolaka/netshoot/pkgs/container/netshoot/216758080?tag=v0.13 and https://hub.docker.com/layers/nicolaka/netshoot/v0.13/images/sha256-5a21d467fed653554bdc483ca5e7e866805c5b4c8f7ecb195a43f778c8d02fb8?context=explore.