### PR TITLE
enter replicasets from deployments

### DIFF
--- a/internal/view/dp.go
+++ b/internal/view/dp.go
@@ -5,10 +5,10 @@ package view
 
 import (
 	"errors"
-
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/dao"
 	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/tcell/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -47,6 +47,7 @@ func (d *Deploy) bindKeys(aa *ui.KeyActions) {
 		ui.KeyShiftR: ui.NewKeyAction("Sort Ready", d.GetTable().SortColCmd(readyCol, true), false),
 		ui.KeyShiftU: ui.NewKeyAction("Sort UpToDate", d.GetTable().SortColCmd(uptodateCol, true), false),
 		ui.KeyShiftL: ui.NewKeyAction("Sort Available", d.GetTable().SortColCmd(availCol, true), false),
+		ui.KeyZ:      ui.NewKeyAction("Show Replicasets", d.replicaSetsCmd, true),
 	})
 }
 
@@ -61,6 +62,20 @@ func (d *Deploy) logOptions(prev bool) (*dao.LogOptions, error) {
 	}
 
 	return podLogOptions(d.App(), path, prev, dp.ObjectMeta, dp.Spec.Template.Spec), nil
+}
+
+func (d *Deploy) replicaSetsCmd(evt *tcell.EventKey) *tcell.EventKey {
+	dName := d.GetTable().GetSelectedItem()
+	if dName == "" {
+		return evt
+	}
+	dp, err := d.getInstance(dName)
+	if err != nil {
+		d.App().Flash().Err(err)
+		return nil
+	}
+	showReplicasetsFromSelector(d.App(), dName, dp.Spec.Selector)
+	return nil
 }
 
 func (d *Deploy) showPods(app *App, model ui.Tabular, gvr client.GVR, fqn string) {
@@ -91,4 +106,14 @@ func showPodsFromSelector(app *App, path string, sel *metav1.LabelSelector) {
 	}
 
 	showPods(app, path, l.String(), "")
+}
+
+func showReplicasetsFromSelector(app *App, path string, sel *metav1.LabelSelector) {
+	l, err := metav1.LabelSelectorAsSelector(sel)
+	if err != nil {
+		app.Flash().Err(err)
+		return
+	}
+
+	showReplicasets(app, path, l.String(), "")
 }


### PR DESCRIPTION
Fixes #2951 

Today on entering a deployment, pods associated with it are listed. Changed behaviour to list replicasets instead. Entering replicaset will list the related pods.

Ran `make build && ./execs/k9s` on a test cluster to validate behaviour.