### PR TITLE
fix(argo-rollouts plugin): resolve improper piping in watch command

### DIFF
--- a/plugins/argo-rollouts.yaml
+++ b/plugins/argo-rollouts.yaml
@@ -26,7 +26,7 @@ plugins:
     background: false
     args:
       - -c
-      - kubectl argo rollouts get rollout $NAME --context $CONTEXT -n $NAMESPACE -w |& less
+      - kubectl argo rollouts get rollout $NAME --context $CONTEXT -n $NAMESPACE -w
   argo-rollouts-promote:
     shortCut: p
     confirm: true


### PR DESCRIPTION
The `-w` or `--watch` flag is designed for continuous monitoring and should not pipe to `less` to avoid unnecessary screen rolling.