### PR TITLE
fix: coloring of rose-pine for values of log options

### DIFF
--- a/skins/rose-pine.yaml
+++ b/skins/rose-pine.yaml
@@ -111,5 +111,5 @@ k9s:
       indicator:
         fgColor: *foreground
         bgColor: *purple
-        toggleOnColor: *pink
-        toggleOffColor: *purple
+        toggleOnColor: *green
+        toggleOffColor: *selection


### PR DESCRIPTION
This PR fixes the reported coloring in https://github.com/derailed/k9s/issues/3013

![image](https://github.com/user-attachments/assets/bfb18201-18b0-45b9-bd79-8070bfe6162c)