### PR TITLE
Fix: switch context fails after failed connection

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -545,6 +545,12 @@ func (a *APIClient) SwitchContext(name string) error {
 	if err := a.config.SwitchContext(name); err != nil {
 		return err
 	}
+
+	if !a.CheckConnectivity() {
+		log.Debug().Msg("No connectivity, skipping cache invalidation")
+	} else if err := a.invalidateCache(); err != nil {
+		return err
+	}
 	a.reset()
 	ResetMetrics()
 


### PR DESCRIPTION
Fixes https://github.com/derailed/k9s/issues/3032

It should not fail to invalidate the cache when there is no cached connection.