### PR TITLE
fix: "Toggle Decode" only implemented for Describe

### DIFF
--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -22,6 +22,7 @@ import (
 const (
 	liveViewTitleFmt = "[fg:bg:b] %s([hilite:bg:b]%s[fg:bg:-])[fg:bg:-] "
 	yamlAction       = "YAML"
+	describeAction   = "Describe"
 )
 
 // LiveView represents a live text viewer.
@@ -158,7 +159,7 @@ func (v *LiveView) bindKeys() {
 	if v.title == yamlAction {
 		v.actions.Add(ui.KeyM, ui.NewKeyAction("Toggle ManagedFields", v.toggleManagedCmd, true))
 	}
-	if v.model != nil && v.model.GVR().IsDecodable() {
+	if v.model != nil && v.model.GVR().IsDecodable() && v.title == describeAction {
 		v.actions.Add(ui.KeyX, ui.NewKeyAction("Toggle Decode", v.toggleEncodedDecodedCmd, true))
 	}
 }


### PR DESCRIPTION
Secret decode toggling is only implemented for describe action, for yaml action it's not, so this change would limit it to the former.
Would it make sense to implement decode toggling for yaml too?