### PR TITLE
Fix Flux trace plugin command

### DIFF
--- a/plugins/flux.yaml
+++ b/plugins/flux.yaml
@@ -162,7 +162,7 @@ plugins:
     args:
       - -c
       - >-
-        resource=$(echo $RESOURCE_NAME | sed -E 's/ies$/y/' | sed -E 's/ses$/se/' | sed -E 's/(s|es)$//g')
+        resource=$(echo $RESOURCE_NAME | sed -E 's/ies$/y/' | sed -E 's/ses$/se/' | sed -E 's/(s|es)$//g');
         flux
         trace
         --context $CONTEXT


### PR DESCRIPTION
The `resource` variable was not set because the whole args were just one command.