### PR TITLE
Strict unmarshal for plugin files

### DIFF
--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -62,7 +62,7 @@ func (p Plugins) Load(path string) error {
 		errs = errors.Join(errs, err)
 	}
 
-	for _, dataDir := range xdg.DataDirs {
+	for _, dataDir := range append(xdg.DataDirs, xdg.DataHome, xdg.ConfigHome) {
 		if err := p.loadPluginDir(filepath.Join(dataDir, k9sPluginsDir)); err != nil {
 			errs = errors.Join(errs, err)
 		}
@@ -88,9 +88,9 @@ func (p Plugins) loadPluginDir(dir string) error {
 			errs = errors.Join(errs, err)
 		}
 		var plugin Plugin
-		if err = yaml.Unmarshal(fileContent, &plugin); err != nil {
+		if err = yaml.UnmarshalStrict(fileContent, &plugin); err != nil {
 			var plugins Plugins
-			if err = yaml.Unmarshal(fileContent, &plugins); err != nil {
+			if err = yaml.UnmarshalStrict(fileContent, &plugins); err != nil {
 				return fmt.Errorf("cannot parse %s into either a single plugin nor plugins: %w", fileName, err)
 			}
 			for name, plugin := range plugins.Plugins {


### PR DESCRIPTION
This PR aims to improve the behaviour introduced in https://github.com/derailed/k9s/pull/2770.

The regular `Unmarshal` function does not result in an `err` when trying to unmarshal a yaml file that contains a `plugins` key into a `Plugin` var. The `UnmarshalStrict` function will, since it finds the undefined `plugins` key, causing the next loop to actually trigger.

I have also taken the liberty to make it look for plugins in the `XDG_DATA_HOME` and `XDG_CONFIG_HOME` folders. This is especially useful since `XDG_DATA_HOME` is not included in the `XDG_DATA_DIRS` by default (as per https://specifications.freedesktop.org/basedir-spec/latest/#variables). This allows users to define per-user plugins in addition to the ones in `/usr/local/share/:/usr/share/`.