### PR TITLE
Fixed trimming of favorite namespaces in Config

### DIFF
--- a/internal/config/data/context_int_test.go
+++ b/internal/config/data/context_int_test.go
@@ -75,6 +75,26 @@ func Test_contextMerge(t *testing.T) {
 			c2: &Context{},
 			e:  NewContext(),
 		},
+		"too-many-favs": {
+			c1: &Context{
+				Namespace: &Namespace{
+					Active:    "ns1",
+					Favorites: []string{"ns1", "ns2", "ns3", "ns4", "ns5", "ns6", "ns7", "ns8", "ns9"},
+				},
+			},
+			c2: &Context{
+				Namespace: &Namespace{
+					Active:    "ns10",
+					Favorites: []string{"ns10", "ns11", "ns12"},
+				},
+			},
+			e: &Context{
+				Namespace: &Namespace{
+					Active:    "ns1",
+					Favorites: []string{"ns1", "ns2", "ns3", "ns4", "ns5", "ns6", "ns7", "ns8", "ns9"},
+				},
+			},
+		},
 	}
 
 	for k, u := range uu {

--- a/internal/config/data/ns.go
+++ b/internal/config/data/ns.go
@@ -52,6 +52,8 @@ func (n *Namespace) merge(old *Namespace) {
 		}
 		n.Favorites = append(n.Favorites, fav)
 	}
+
+	n.trimFavNs()
 }
 
 // Validate validates a namespace is setup correctly.
@@ -69,12 +71,7 @@ func (n *Namespace) Validate(c client.Connection) {
 		}
 	}
 
-	if len(n.Favorites) > MaxFavoritesNS {
-		log.Debug().Msgf("[Namespace] Number of favorite exceeds hard limit of %v. Trimming.", MaxFavoritesNS)
-		for _, ns := range n.Favorites[MaxFavoritesNS:] {
-			n.rmFavNS(ns)
-		}
-	}
+	n.trimFavNs()
 }
 
 // SetActive set the active namespace.
@@ -134,4 +131,11 @@ func (n *Namespace) rmFavNS(ns string) {
 	}
 
 	n.Favorites = append(n.Favorites[:victim], n.Favorites[victim+1:]...)
+}
+
+func (n *Namespace) trimFavNs() {
+	if len(n.Favorites) > MaxFavoritesNS {
+		log.Debug().Msgf("[Namespace] Number of favorite exceeds hard limit of %v. Trimming.", MaxFavoritesNS)
+		n.Favorites = n.Favorites[:MaxFavoritesNS]
+	}
 }


### PR DESCRIPTION
## Summary
Fixed the way favorite namespaces are trimmed when validating and merging cluster configs.
Related issue: https://github.com/derailed/k9s/issues/2978

## Changed
- `Namespace.merge` now trims the favorite namespaces list after merging with the old `Namespace` object
- fixed trimming logic so it doesn't delete elements of the list it is iterating over (anti-pattern)
- extracted trimming logic into private helper method `Namespace.trimFavNs`

## Added
- Additional test case in `internal/config/data/context_int_test.go` for merging two oversized `Namespace` objects
