### PR TITLE
README.md: Simplify install instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Binaries for Linux, Windows and Mac are available as tarballs in the [release pa
 * Via [Homebrew](https://brew.sh/) for macOS or Linux
 
    ```shell
-   brew install derailed/k9s/k9s
+   brew install k9s
    ```
 
 * Via [MacPorts](https://www.macports.org)


### PR DESCRIPTION
I installed this great tool recently, and the prefix name was not necessary.