### PR TITLE
fix: Don't log error for not finding header when running in headless mode

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -123,10 +123,12 @@ func (a *App) StylesChanged(s *config.Styles) {
 	a.Main.SetBackgroundColor(s.BgColor())
 	if f, ok := a.Main.GetPrimitive("main").(*tview.Flex); ok {
 		f.SetBackgroundColor(s.BgColor())
-		if h, ok := f.ItemAt(0).(*tview.Flex); ok {
-			h.SetBackgroundColor(s.BgColor())
-		} else {
-			log.Error().Msgf("Header not found")
+		if !a.Config.K9s.IsHeadless() {
+			if h, ok := f.ItemAt(0).(*tview.Flex); ok {
+				h.SetBackgroundColor(s.BgColor())
+			} else {
+				log.Error().Msgf("Header not found")
+			}
 		}
 	} else {
 		log.Error().Msgf("Main not found")


### PR DESCRIPTION
This fixes the error message in k9s.log when `headless: true` is configured:

![image](https://github.com/user-attachments/assets/0fa227ba-2102-4007-8a53-38c86ea51b1f)
