### PR TITLE
update regex to allow '%' and '/' in column names

### DIFF
--- a/internal/render/cust_col.go
+++ b/internal/render/cust_col.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/get"
 )
 
-var fullRX = regexp.MustCompile(`\A([\w\s-]+)\:?([^\|]*)\|?([T|N|W|L|R|H]{0,3})\b`)
+var fullRX = regexp.MustCompile(`\A([\w\s%/\-]+)\:?([^\|]*)\|?([T|N|W|L|R|H]{0,3})\b`)
 
 type colAttr byte
 


### PR DESCRIPTION
This pull request includes a small change to the `internal/render/cust_col.go` file. The change updates the regular expression pattern used by the `fullRX` variable to include additional characters.

* [`internal/render/cust_col.go`](diffhunk://#diff-231779a6c0d5a95866379f6a89ff5c328dfda2e7d53f685df5a5081c0c44e347L15-R15): Modified the `fullRX` regular expression pattern to include `%` and `/` characters.


Issue: https://github.com/derailed/k9s/issues/3119