### PR TITLE
fix(coloring): invalid color application for rows with VALID column

### DIFF
--- a/internal/model1/helpers.go
+++ b/internal/model1/helpers.go
@@ -50,7 +50,7 @@ func IsValid(ns string, h Header, r Row) bool {
 		return true
 	}
 
-	return strings.TrimSpace(r.Fields[idx]) == ""
+	return strings.ToLower(strings.TrimSpace(r.Fields[idx])) == "true"
 }
 
 func sortLabels(m map[string]string) (keys, vals []string) {

--- a/internal/model1/helpers.go
+++ b/internal/model1/helpers.go
@@ -50,7 +50,7 @@ func IsValid(ns string, h Header, r Row) bool {
 		return true
 	}
 
-	return strings.ToLower(strings.TrimSpace(r.Fields[idx])) == "true"
+	return strings.TrimSpace(r.Fields[idx]) == "" || strings.ToLower(strings.TrimSpace(r.Fields[idx])) == "true"
 }
 
 func sortLabels(m map[string]string) (keys, vals []string) {

--- a/internal/model1/helpers_test.go
+++ b/internal/model1/helpers_test.go
@@ -53,6 +53,55 @@ func TestLabelize(t *testing.T) {
 	}
 }
 
+func TestIsValid(t *testing.T) {
+
+	uu := map[string]struct {
+		ns string
+		h  Header
+		r  Row
+		e  bool
+	}{
+		"empty": {
+			ns: "blee",
+			h:  Header{},
+			r:  Row{},
+			e:  true,
+		},
+		"valid": {
+			ns: "blee",
+			h:  Header{HeaderColumn{Name: "VALID"}},
+			r:  Row{Fields: Fields{"true"}},
+			e:  true,
+		},
+		"invalid": {
+			ns: "blee",
+			h:  Header{HeaderColumn{Name: "VALID"}},
+			r:  Row{Fields: Fields{"false"}},
+			e:  false,
+		},
+		"valid_capital_case": {
+			ns: "blee",
+			h:  Header{HeaderColumn{Name: "VALID"}},
+			r:  Row{Fields: Fields{"True"}},
+			e:  true,
+		},
+		"valid_all_caps": {
+			ns: "blee",
+			h:  Header{HeaderColumn{Name: "VALID"}},
+			r:  Row{Fields: Fields{"TRUE"}},
+			e:  true,
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			valid := IsValid(u.ns, u.h, u.r)
+			assert.Equal(t, u.e, valid)
+		})
+	}
+
+}
+
 func TestDurationToSecond(t *testing.T) {
 	uu := map[string]struct {
 		s string

--- a/internal/render/pod_test.go
+++ b/internal/render/pod_test.go
@@ -45,7 +45,7 @@ func TestPodColorer(t *testing.T) {
 			re: model1.RowEvent{
 				Kind: model1.EventAdd,
 				Row: model1.Row{
-					Fields: model1.Fields{"blee", "fred", "1/1", "0", render.Running, "true"},
+					Fields: model1.Fields{"blee", "fred", "1/1", "0", render.Running, ""},
 				},
 			},
 			e: model1.StdColor,
@@ -115,7 +115,7 @@ func TestPodColorer(t *testing.T) {
 			re: model1.RowEvent{
 				Kind: model1.EventAdd,
 				Row: model1.Row{
-					Fields: model1.Fields{"blee", "fred", "1/1", "0", "blee", "true"},
+					Fields: model1.Fields{"blee", "fred", "1/1", "0", "blee", ""},
 				},
 			},
 			e: model1.AddColor,

--- a/internal/render/pod_test.go
+++ b/internal/render/pod_test.go
@@ -45,7 +45,7 @@ func TestPodColorer(t *testing.T) {
 			re: model1.RowEvent{
 				Kind: model1.EventAdd,
 				Row: model1.Row{
-					Fields: model1.Fields{"blee", "fred", "1/1", "0", render.Running, ""},
+					Fields: model1.Fields{"blee", "fred", "1/1", "0", render.Running, "true"},
 				},
 			},
 			e: model1.StdColor,
@@ -115,7 +115,7 @@ func TestPodColorer(t *testing.T) {
 			re: model1.RowEvent{
 				Kind: model1.EventAdd,
 				Row: model1.Row{
-					Fields: model1.Fields{"blee", "fred", "1/1", "0", "blee", ""},
+					Fields: model1.Fields{"blee", "fred", "1/1", "0", "blee", "true"},
 				},
 			},
 			e: model1.AddColor,


### PR DESCRIPTION
During usage of k9s we saw one specific CRD of ours always show up in an error color despite it being fully ready an healthy
<img width="1095" alt="Screenshot 2025-02-18 at 19 56 00" src="https://github.com/user-attachments/assets/9e880c6b-1d59-4fe1-8b63-afdbbde8b455" />

After some investigation I found, that the error color is applied by the default `ColoringFunc` in case the resource is deemed not valid. After finding the code for this, I figured that the logic in case a "VALID" column seems to be incorrect, as it deems the resource invalid if its something else than an empty string.

I tried fixing it in this PR and also added some tests to this previously untested helper function

With the adjusted logic, the rendering seems to be correct!

<img width="1244" alt="Screenshot 2025-02-18 at 20 07 09" src="https://github.com/user-attachments/assets/48a7d900-929d-484a-9af2-062272e7ca17" />
