### PR TITLE
fix: Avoid false positive matches in enableRegion (#3093)

### DIFF
--- a/internal/view/yaml.go
+++ b/internal/view/yaml.go
@@ -20,6 +20,7 @@ import (
 var (
 	keyValRX = regexp.MustCompile(`\A(\s*)([\w|\-|\.|\/|\s]+):\s(.+)\z`)
 	keyRX    = regexp.MustCompile(`\A(\s*)([\w|\-|\.|\/|\s]+):\s*\z`)
+	searchRX = regexp.MustCompile(`<<<("search_\d+")>>>(.+)<<<"">>>`)
 )
 
 const (
@@ -60,7 +61,7 @@ func colorizeYAML(style config.Yaml, raw string) string {
 }
 
 func enableRegion(str string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(str, "<<<", "["), ">>>", "]")
+	return searchRX.ReplaceAllString(str, `[$1]$2[""]`)
 }
 
 func saveYAML(dir, name, raw string) (string, error) {

--- a/internal/view/yaml_test.go
+++ b/internal/view/yaml_test.go
@@ -56,6 +56,10 @@ func TestYaml(t *testing.T) {
 			"Message: Pod The node was low on resource: [DiskPressure].",
 			"[#4682b4::b]Message[#ffffff::-]: [#ffefd5::]Pod The node was low on resource: [DiskPressure[].",
 		},
+		{
+			`data: "<<<"`,
+			`[#4682b4::b]data[#ffffff::-]: [#ffefd5::]"<<<"`,
+		},
 	}
 
 	s := config.NewStyles()


### PR DESCRIPTION
Tentative fix for issue #3093.

 Make enableRegion a bit more stringent on what it replaces by matching the full search result instead of replacing only the `<<<` and `>>>` markers.