### PR TITLE
Make flash delay configurable from config.yaml

### DIFF
--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -11,6 +11,7 @@
         "screenDumpDir": {"type": "string"},
         "refreshRate": { "type": "integer" },
         "maxConnRetry": { "type": "integer" },
+        "flashDelay": { "type": "integer" },
         "readOnly": { "type": "boolean" },
         "noExitOnCtrlC": { "type": "boolean" },
         "skipLatestRevCheck": { "type": "boolean" },

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -6,15 +6,16 @@ package config
 import (
 	"errors"
 	"fmt"
-	"github.com/derailed/k9s/internal/client"
-	"github.com/derailed/k9s/internal/config/data"
-	"github.com/rs/zerolog/log"
 	"io/fs"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/config/data"
+	"github.com/rs/zerolog/log"
 )
 
 // K9s tracks K9s configuration options.

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -6,16 +6,15 @@ package config
 import (
 	"errors"
 	"fmt"
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/config/data"
+	"github.com/rs/zerolog/log"
 	"io/fs"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
-
-	"github.com/derailed/k9s/internal/client"
-	"github.com/derailed/k9s/internal/config/data"
-	"github.com/rs/zerolog/log"
 )
 
 // K9s tracks K9s configuration options.
@@ -24,6 +23,7 @@ type K9s struct {
 	ScreenDumpDir       string     `json:"screenDumpDir" yaml:"screenDumpDir,omitempty"`
 	RefreshRate         int        `json:"refreshRate" yaml:"refreshRate"`
 	MaxConnRetry        int        `json:"maxConnRetry" yaml:"maxConnRetry"`
+	FlashDelay          int        `json:"flashDelay" yaml:"flashDelay"`
 	ReadOnly            bool       `json:"readOnly" yaml:"readOnly"`
 	NoExitOnCtrlC       bool       `json:"noExitOnCtrlC" yaml:"noExitOnCtrlC"`
 	UI                  UI         `json:"ui" yaml:"ui"`
@@ -53,6 +53,7 @@ func NewK9s(conn client.Connection, ks data.KubeSettings) *K9s {
 	return &K9s{
 		RefreshRate:   defaultRefreshRate,
 		MaxConnRetry:  defaultMaxConnRetry,
+		FlashDelay:    defaultFlashDelay,
 		ScreenDumpDir: AppDumpsDir,
 		Logger:        NewLogger(),
 		Thresholds:    NewThreshold(),
@@ -99,6 +100,7 @@ func (k *K9s) Merge(k1 *K9s) {
 	k.ScreenDumpDir = k1.ScreenDumpDir
 	k.RefreshRate = k1.RefreshRate
 	k.MaxConnRetry = k1.MaxConnRetry
+	k.FlashDelay = k1.FlashDelay
 	k.ReadOnly = k1.ReadOnly
 	k.NoExitOnCtrlC = k1.NoExitOnCtrlC
 	k.UI = k1.UI
@@ -346,6 +348,9 @@ func (k *K9s) Validate(c client.Connection, ks data.KubeSettings) {
 	}
 	if k.MaxConnRetry <= 0 {
 		k.MaxConnRetry = defaultMaxConnRetry
+	}
+	if k.FlashDelay <= 0 {
+		k.FlashDelay = defaultFlashDelay
 	}
 
 	if k.getActiveConfig() == nil {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -6,6 +6,7 @@ package config
 const (
 	defaultRefreshRate  = 2
 	defaultMaxConnRetry = 5
+	defaultFlashDelay   = 3
 )
 
 // UI tracks ui specific configs.

--- a/internal/model/flash.go
+++ b/internal/model/flash.go
@@ -12,9 +12,6 @@ import (
 )
 
 const (
-	// DefaultFlashDelay sets the flash clear delay.
-	DefaultFlashDelay = 3 * time.Second
-
 	// FlashInfo represents an info message.
 	FlashInfo FlashLevel = iota
 	// FlashWarn represents an warning message.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -6,6 +6,7 @@ package ui
 import (
 	"os"
 	"sync"
+	"time"
 
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/config"
@@ -36,7 +37,7 @@ func NewApp(cfg *config.Config, context string) *App {
 		actions:      NewKeyActions(),
 		Configurator: Configurator{Config: cfg, Styles: config.NewStyles()},
 		Main:         NewPages(),
-		flash:        model.NewFlash(model.DefaultFlashDelay),
+		flash:        model.NewFlash(time.Duration(cfg.K9s.FlashDelay) * time.Second),
 		cmdBuff:      model.NewFishBuff(':', model.CommandBuffer),
 	}
 


### PR DESCRIPTION
As per #3077 make the delay for the flash message configurable from the config.yaml. The value indicates how long the error message should be shown on the screen

* default = 3 seconds
* override using `config.yaml` file:

```
k9s:
  ...
  flashDelay: 10
  ...
```