### PR TITLE
fix: Pass grv on gotoResource as a String to fix non-default apiGroup list

### DIFF
--- a/internal/view/alias.go
+++ b/internal/view/alias.go
@@ -67,7 +67,7 @@ func (a *Alias) gotoCmd(evt *tcell.EventKey) *tcell.EventKey {
 		return evt
 	}
 	gvr := client.NewGVR(path)
-	a.App().gotoResource(gvr.AsResourceName(), "", true, true)
+	a.App().gotoResource(gvr.String(), "", true, true)
 
 	return nil
 }


### PR DESCRIPTION
Hello! Regarding this issue #3146 that I also encountered this morning, I propose this fix if it would be okay to directly pass the `gvr` as a string so I can parse it properly and fix the problem, let me know if it would be okay! 

Bests Regards,
Fabio