### PR TITLE
fix: Restore icon for readonly view

### DIFF
--- a/internal/view/cluster_info.go
+++ b/internal/view/cluster_info.go
@@ -111,9 +111,13 @@ func (c *ClusterInfo) warnCell(s string, w bool) string {
 // ClusterInfoChanged notifies the cluster meta was changed.
 func (c *ClusterInfo) ClusterInfoChanged(prev, curr model.ClusterMeta) {
 	c.app.QueueUpdateDraw(func() {
+		ic := " ✏️"
+		if c.app.Config.K9s.IsReadOnly() {
+			ic = " 🔒"
+		}
 		c.Clear()
 		c.layout()
-		row := c.setCell(0, curr.Context)
+		row := c.setCell(0, curr.Context+ic)
 		row = c.setCell(row, curr.Cluster)
 		row = c.setCell(row, curr.User)
 		if curr.K9sLatest != "" {


### PR DESCRIPTION
I was experimenting with readonly mode, and when looking through open issues I found https://github.com/derailed/k9s/issues/2794. Doing some git bisecting on the v0.32.0 release, I found that commit https://github.com/derailed/k9s/commit/4e4b25d9dab18e520f42cb7ad8bab80b48fd072d (now squashed into https://github.com/derailed/k9s/commit/0d165310) removed these lines of code alongside otherwise refactoring work.

Given the nature of the commit message, I'm assuming this was deleted by accident during some WIP refactor, but if it's intentional, sorry for that assumption!