### PR TITLE
Allow metrics cache expiry to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,8 @@ You can now override the context portForward default address configuration by se
     screenDumpDir: /tmp/dumps
     # Represents ui poll intervals. Default 2secs
     refreshRate: 2
+    # How often metrics data will be cached for e.g. CPU and memory usage. Default 60s
+    metricsCacheExpiry: 60
     # Number of retries once the connection to the api-server is lost. Default 15.
     maxConnRetry: 5
     # Indicates whether modification commands like delete/kill/edit are disabled. Default is false
@@ -966,6 +968,7 @@ k9s:
   liveViewAutoRefresh: false
   screenDumpDir: /tmp/dumps
   refreshRate: 2
+  metricsCacheExpiry: 60
   maxConnRetry: 5
   readOnly: false
   noExitOnCtrlC: false

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,7 +138,8 @@ func loadConfiguration() (*config.Config, error) {
 		errs = errors.Join(errs, err)
 	}
 
-	conn, err := client.InitConnection(k8sCfg)
+	options := client.NewOptions(k9sCfg.K9s.MetricsCacheExpiry)
+	conn, err := client.InitConnection(k8sCfg, options)
 
 	if err != nil {
 		errs = errors.Join(errs, err)
@@ -376,7 +377,7 @@ func initK8sFlagCompletion() {
 
 	_ = rootCmd.RegisterFlagCompletionFunc("namespace", func(cmd *cobra.Command, args []string, s string) ([]string, cobra.ShellCompDirective) {
 		conn := client.NewConfig(k8sFlags)
-		if c, err := client.InitConnection(conn); err == nil {
+		if c, err := client.InitConnection(conn, client.Options{}); err == nil {
 			if nss, err := c.ValidNamespaceNames(); err == nil {
 				return filterFlagCompletions(nss, s)
 			}

--- a/internal/client/metrics_test.go
+++ b/internal/client/metrics_test.go
@@ -5,6 +5,7 @@ package client_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/derailed/k9s/internal/client"
 	"github.com/stretchr/testify/assert"
@@ -72,7 +73,7 @@ func TestPodsMetrics(t *testing.T) {
 		},
 	}
 
-	m := client.NewMetricsServer(nil)
+	m := makeMetricsServer()
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
@@ -91,7 +92,7 @@ func TestPodsMetrics(t *testing.T) {
 }
 
 func BenchmarkPodsMetrics(b *testing.B) {
-	m := client.NewMetricsServer(nil)
+	m := makeMetricsServer()
 
 	metrics := v1beta1.PodMetricsList{
 		Items: []v1beta1.PodMetrics{
@@ -168,7 +169,7 @@ func TestNodesMetrics(t *testing.T) {
 		},
 	}
 
-	m := client.NewMetricsServer(nil)
+	m := makeMetricsServer()
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
@@ -201,7 +202,7 @@ func BenchmarkNodesMetrics(b *testing.B) {
 		},
 	}
 
-	m := client.NewMetricsServer(nil)
+	m := makeMetricsServer()
 	mmx := make(client.NodesMetrics)
 
 	b.ResetTimer()
@@ -261,7 +262,7 @@ func TestClusterLoad(t *testing.T) {
 		},
 	}
 
-	m := client.NewMetricsServer(nil)
+	m := makeMetricsServer()
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
@@ -287,7 +288,7 @@ func BenchmarkClusterLoad(b *testing.B) {
 		},
 	}
 
-	m := client.NewMetricsServer(nil)
+	m := makeMetricsServer()
 	var mx client.ClusterMetrics
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -298,6 +299,10 @@ func BenchmarkClusterLoad(b *testing.B) {
 
 // ----------------------------------------------------------------------------
 // Helpers...
+
+func makeMetricsServer() *client.MetricsServer {
+	return client.NewMetricsServer(nil, 1*time.Minute)
+}
 
 func makeMxPod(name, cpu, mem string) *v1beta1.PodMetrics {
 	return &v1beta1.PodMetrics{

--- a/internal/client/options.go
+++ b/internal/client/options.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package client
+
+type Options struct {
+	MetricsCacheExpiry int
+}
+
+func NewOptions(metricsCacheExpiry int) Options {
+	return Options{MetricsCacheExpiry: metricsCacheExpiry}
+}

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -102,6 +102,9 @@ type Connection interface {
 	// DialLogs connects to api server for logs.
 	DialLogs() (kubernetes.Interface, error)
 
+	// DialMetrics connects to metrics server.
+	DialMetrics() *MetricsServer
+
 	// SwitchContext switches cluster based on context.
 	SwitchContext(ctx string) error
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -537,6 +537,7 @@ func TestConfigLoad(t *testing.T) {
 
 	assert.Nil(t, cfg.Load("testdata/configs/k9s.yaml", true))
 	assert.Equal(t, 2, cfg.K9s.RefreshRate)
+	assert.Equal(t, 60, cfg.K9s.MetricsCacheExpiry)
 	assert.Equal(t, int64(200), cfg.K9s.Logger.TailCount)
 	assert.Equal(t, 2000, cfg.K9s.Logger.BufferSize)
 }
@@ -553,6 +554,7 @@ func TestConfigSaveFile(t *testing.T) {
 	assert.Nil(t, cfg.Load("testdata/configs/k9s.yaml", true))
 
 	cfg.K9s.RefreshRate = 100
+	cfg.K9s.MetricsCacheExpiry = 100
 	cfg.K9s.ReadOnly = true
 	cfg.K9s.Logger.TailCount = 500
 	cfg.K9s.Logger.BufferSize = 800

--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -10,6 +10,7 @@
         "liveViewAutoRefresh": { "type": "boolean" },
         "screenDumpDir": {"type": "string"},
         "refreshRate": { "type": "integer" },
+        "metricsCacheExpiry": { "type": "integer" },
         "maxConnRetry": { "type": "integer" },
         "readOnly": { "type": "boolean" },
         "noExitOnCtrlC": { "type": "boolean" },

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -23,6 +23,7 @@ type K9s struct {
 	LiveViewAutoRefresh bool       `json:"liveViewAutoRefresh" yaml:"liveViewAutoRefresh"`
 	ScreenDumpDir       string     `json:"screenDumpDir" yaml:"screenDumpDir,omitempty"`
 	RefreshRate         int        `json:"refreshRate" yaml:"refreshRate"`
+	MetricsCacheExpiry  int        `json:"metricsCacheExpiry" yaml:"metricsCacheExpiry"`
 	MaxConnRetry        int        `json:"maxConnRetry" yaml:"maxConnRetry"`
 	ReadOnly            bool       `json:"readOnly" yaml:"readOnly"`
 	NoExitOnCtrlC       bool       `json:"noExitOnCtrlC" yaml:"noExitOnCtrlC"`
@@ -51,16 +52,17 @@ type K9s struct {
 // NewK9s create a new K9s configuration.
 func NewK9s(conn client.Connection, ks data.KubeSettings) *K9s {
 	return &K9s{
-		RefreshRate:   defaultRefreshRate,
-		MaxConnRetry:  defaultMaxConnRetry,
-		ScreenDumpDir: AppDumpsDir,
-		Logger:        NewLogger(),
-		Thresholds:    NewThreshold(),
-		ShellPod:      NewShellPod(),
-		ImageScans:    NewImageScans(),
-		dir:           data.NewDir(AppContextsDir),
-		conn:          conn,
-		ks:            ks,
+		RefreshRate:        defaultRefreshRate,
+		MetricsCacheExpiry: defaultMetricsCacheExpiry,
+		MaxConnRetry:       defaultMaxConnRetry,
+		ScreenDumpDir:      AppDumpsDir,
+		Logger:             NewLogger(),
+		Thresholds:         NewThreshold(),
+		ShellPod:           NewShellPod(),
+		ImageScans:         NewImageScans(),
+		dir:                data.NewDir(AppContextsDir),
+		conn:               conn,
+		ks:                 ks,
 	}
 }
 
@@ -98,6 +100,7 @@ func (k *K9s) Merge(k1 *K9s) {
 	k.LiveViewAutoRefresh = k1.LiveViewAutoRefresh
 	k.ScreenDumpDir = k1.ScreenDumpDir
 	k.RefreshRate = k1.RefreshRate
+	k.MetricsCacheExpiry = k1.MetricsCacheExpiry
 	k.MaxConnRetry = k1.MaxConnRetry
 	k.ReadOnly = k1.ReadOnly
 	k.NoExitOnCtrlC = k1.NoExitOnCtrlC
@@ -343,6 +346,9 @@ func (k *K9s) IsReadOnly() bool {
 func (k *K9s) Validate(c client.Connection, ks data.KubeSettings) {
 	if k.RefreshRate <= 0 {
 		k.RefreshRate = defaultRefreshRate
+	}
+	if k.MetricsCacheExpiry <= 0 {
+		k.MetricsCacheExpiry = defaultMetricsCacheExpiry
 	}
 	if k.MaxConnRetry <= 0 {
 		k.MaxConnRetry = defaultMaxConnRetry

--- a/internal/config/k9s_test.go
+++ b/internal/config/k9s_test.go
@@ -88,6 +88,7 @@ func TestK9sMerge(t *testing.T) {
 				LiveViewAutoRefresh: false,
 				ScreenDumpDir:       "",
 				RefreshRate:         0,
+				MetricsCacheExpiry:  0,
 				MaxConnRetry:        0,
 				ReadOnly:            false,
 				NoExitOnCtrlC:       false,
@@ -102,12 +103,14 @@ func TestK9sMerge(t *testing.T) {
 			k2: &config.K9s{
 				LiveViewAutoRefresh: true,
 				MaxConnRetry:        100,
+				MetricsCacheExpiry:  100,
 				ShellPod:            config.NewShellPod(),
 			},
 			ek: &config.K9s{
 				LiveViewAutoRefresh: true,
 				ScreenDumpDir:       "",
 				RefreshRate:         0,
+				MetricsCacheExpiry:  100,
 				MaxConnRetry:        100,
 				ReadOnly:            false,
 				NoExitOnCtrlC:       false,

--- a/internal/config/mock/test_helpers.go
+++ b/internal/config/mock/test_helpers.go
@@ -136,6 +136,9 @@ func (m mockConnection) Dial() (kubernetes.Interface, error) {
 func (m mockConnection) DialLogs() (kubernetes.Interface, error) {
 	return nil, nil
 }
+func (m mockConnection) DialMetrics() *client.MetricsServer {
+	return nil
+}
 func (m mockConnection) SwitchContext(ctx string) error {
 	return nil
 }

--- a/internal/config/testdata/configs/default.yaml
+++ b/internal/config/testdata/configs/default.yaml
@@ -2,6 +2,7 @@ k9s:
   liveViewAutoRefresh: false
   screenDumpDir: /tmp/k9s-test/screen-dumps
   refreshRate: 2
+  metricsCacheExpiry: 60
   maxConnRetry: 5
   readOnly: false
   noExitOnCtrlC: false

--- a/internal/config/testdata/configs/expected.yaml
+++ b/internal/config/testdata/configs/expected.yaml
@@ -2,6 +2,7 @@ k9s:
   liveViewAutoRefresh: true
   screenDumpDir: /tmp/k9s-test/screen-dumps
   refreshRate: 100
+  metricsCacheExpiry: 100
   maxConnRetry: 5
   readOnly: true
   noExitOnCtrlC: false

--- a/internal/config/testdata/configs/k9s.yaml
+++ b/internal/config/testdata/configs/k9s.yaml
@@ -2,6 +2,7 @@ k9s:
   liveViewAutoRefresh: true
   screenDumpDir: /tmp/k9s-test/screen-dumps
   refreshRate: 2
+  metricsCacheExpiry: 60
   maxConnRetry: 5
   readOnly: false
   noExitOnCtrlC: false

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -4,8 +4,9 @@
 package config
 
 const (
-	defaultRefreshRate  = 2
-	defaultMaxConnRetry = 5
+	defaultRefreshRate        = 2
+	defaultMetricsCacheExpiry = 60
+	defaultMaxConnRetry       = 5
 )
 
 // UI tracks ui specific configs.

--- a/internal/dao/container.go
+++ b/internal/dao/container.go
@@ -46,7 +46,7 @@ func (c *Container) List(ctx context.Context, _ string) ([]runtime.Object, error
 		err error
 	)
 	if withMx, ok := ctx.Value(internal.KeyWithMetrics).(bool); ok && withMx {
-		cmx, _ = client.DialMetrics(c.Client()).FetchContainersMetrics(ctx, fqn)
+		cmx, _ = c.Client().DialMetrics().FetchContainersMetrics(ctx, fqn)
 	}
 
 	po, err := c.fetchPod(fqn)

--- a/internal/dao/container_test.go
+++ b/internal/dao/container_test.go
@@ -48,6 +48,7 @@ func makeConn() *conn {
 func (c *conn) Config() *client.Config                                { return nil }
 func (c *conn) Dial() (kubernetes.Interface, error)                   { return nil, nil }
 func (c *conn) DialLogs() (kubernetes.Interface, error)               { return nil, nil }
+func (c *conn) DialMetrics() *client.MetricsServer                    { return nil }
 func (c *conn) ConnectionOK() bool                                    { return true }
 func (c *conn) SwitchContext(ctx string) error                        { return nil }
 func (c *conn) CachedDiscovery() (*disk.CachedDiscoveryClient, error) { return nil, nil }

--- a/internal/dao/node.go
+++ b/internal/dao/node.go
@@ -141,7 +141,7 @@ func (n *Node) Get(ctx context.Context, path string) (runtime.Object, error) {
 
 	var nmx *mv1beta1.NodeMetrics
 	if withMx, ok := ctx.Value(internal.KeyWithMetrics).(bool); ok && withMx {
-		nmx, _ = client.DialMetrics(n.Client()).FetchNodeMetrics(ctx, path)
+		nmx, _ = n.Client().DialMetrics().FetchNodeMetrics(ctx, path)
 	}
 
 	return &render.NodeWithMetrics{Raw: raw, MX: nmx}, nil
@@ -156,7 +156,7 @@ func (n *Node) List(ctx context.Context, ns string) ([]runtime.Object, error) {
 
 	var nmx client.NodesMetricsMap
 	if withMx, ok := ctx.Value(internal.KeyWithMetrics).(bool); withMx || !ok {
-		nmx, _ = client.DialMetrics(n.Client()).FetchNodesMetricsMap(ctx)
+		nmx, _ = n.Client().DialMetrics().FetchNodesMetricsMap(ctx)
 	}
 
 	shouldCountPods, _ := ctx.Value(internal.KeyPodCounting).(bool)

--- a/internal/dao/pod.go
+++ b/internal/dao/pod.go
@@ -61,7 +61,7 @@ func (p *Pod) Get(ctx context.Context, path string) (runtime.Object, error) {
 
 	var pmx *mv1beta1.PodMetrics
 	if withMx, ok := ctx.Value(internal.KeyWithMetrics).(bool); ok && withMx {
-		pmx, _ = client.DialMetrics(p.Client()).FetchPodMetrics(ctx, path)
+		pmx, _ = p.Client().DialMetrics().FetchPodMetrics(ctx, path)
 	}
 
 	return &render.PodWithMetrics{Raw: u, MX: pmx}, nil
@@ -86,7 +86,7 @@ func (p *Pod) List(ctx context.Context, ns string) ([]runtime.Object, error) {
 
 	var pmx client.PodsMetricsMap
 	if withMx, ok := ctx.Value(internal.KeyWithMetrics).(bool); ok && withMx {
-		pmx, _ = client.DialMetrics(p.Client()).FetchPodsMetricsMap(ctx, ns)
+		pmx, _ = p.Client().DialMetrics().FetchPodsMetricsMap(ctx, ns)
 	}
 	sel, _ := ctx.Value(internal.KeyFields).(string)
 	fsel, err := labels.ConvertSelectorToLabelsMap(sel)

--- a/internal/model/cluster.go
+++ b/internal/model/cluster.go
@@ -50,7 +50,7 @@ type (
 func NewCluster(f dao.Factory) *Cluster {
 	return &Cluster{
 		factory: f,
-		mx:      client.DialMetrics(f.Client()),
+		mx:      f.Client().DialMetrics(),
 		cache:   cache.NewLRUExpireCache(clusterCacheSize),
 	}
 }

--- a/internal/model/pulse_health.go
+++ b/internal/model/pulse_health.go
@@ -63,7 +63,7 @@ func (h *PulseHealth) List(ctx context.Context, ns string) ([]runtime.Object, er
 }
 
 func (h *PulseHealth) checkMetrics(ctx context.Context) (health.Checks, error) {
-	dial := client.DialMetrics(h.factory.Client())
+	dial := h.factory.Client().DialMetrics()
 
 	nn, err := dao.FetchNodes(ctx, h.factory, "")
 	if err != nil {


### PR DESCRIPTION
* Allow the metrics cache expiry to be configured so it can be set to a lower value if users wish to see the resource metrics e.g. CPU and memory update more frequently
* Default to 60 seconds so no breaking changes

**Example:**

```yaml
k9s:
  metricsCacheExpiry: 30
  ...
```

closes https://github.com/derailed/k9s/issues/2209