### PR TITLE
fix(history): handle cases where special commands add their command their command to the history

### DIFF
--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -645,7 +645,7 @@ func (a *App) cowCmd(msg string) {
 	dialog.ShowError(a.Styles.Dialog(), a.Content.Pages, msg)
 }
 
-func (a *App) dirCmd(path string) error {
+func (a *App) dirCmd(path string, pushCmd bool) error {
 	log.Debug().Msgf("DIR PATH %q", path)
 	_, err := os.Stat(path)
 	if err != nil {
@@ -657,7 +657,9 @@ func (a *App) dirCmd(path string) error {
 			path = dir
 		}
 	}
-	a.cmdHistory.Push("dir " + path)
+	if pushCmd {
+		a.cmdHistory.Push("dir " + path)
+	}
 
 	return a.inject(NewDir(path), true)
 }

--- a/internal/view/cmd/types.go
+++ b/internal/view/cmd/types.go
@@ -47,8 +47,9 @@ var (
 		"help": {},
 	}
 	aliasCmd = map[string]struct{}{
-		"a":     {},
-		"alias": {},
+		"a":       {},
+		"alias":   {},
+		"aliases": {},
 	}
 	xrayCmd = map[string]struct{}{
 		"x":    {},


### PR DESCRIPTION
Fixes #3166

Throughout the code, pushCmd is used for when a command is being executed (switched to) to conditionally add the new command onto the history. The history commands (keybinds `[`, `]`, `-`) only navigate through the stack with indices and therefore should never manipulate the stack -- however with some special commands (specialCmd), navigating to those commands previously unconditionally added the command to the stack unlike "typical" commands like `pods`, `svc`.

Here we pass in the pushCmd boolean to all appropriate special commands so that if the stack should not be manipulated, they do not push their command onto the stack.

The original issue reported issues with Aliases, but there were unreported bugs with Namespaces and Contexts as well. Notably, RBAC commands and Dir commands were not modified as they do not push their command onto the history stack, functioning more as "virtual" commands that will not appear in the history.