### PR TITLE
feat: pass context and token flags to kubectl exec commands

### DIFF
--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -337,7 +337,8 @@ func sshIn(a *App, fqn, co string) error {
 		return fmt.Errorf("os detect failed: %w", err)
 	}
 
-	args := buildShellArgs("exec", fqn, co, a.Conn().Config().Flags().KubeConfig)
+	flags := a.Conn().Config().Flags()
+	args := buildShellArgs("exec", fqn, co, flags.KubeConfig, flags.Context, flags.BearerToken)
 	args = append(args, "--")
 	if len(cfg.Command) > 0 {
 		args = append(args, cfg.Command...)


### PR DESCRIPTION
When initializing k9s with `--kubeconfig`, `--context`, and `--token` parameters, only the `--kubeconfig` flag was being passed to `kubectl exec` when running a shell in a container. This inconsistency could lead to authentication issues or accessing the wrong cluster when using shell functionality.

This PR ensures that all relevant authentication flags (`--kubeconfig`, `--context`, and `--token`) are consistently passed to kubectl commands when executing a shell in a container.

This PR:

1. Modifies `buildShellArgs` function to accept context and token parameters
2. Updates all callers to pass these parameters from the connection configuration
3. Adds test cases to verify the new functionality