### PR TITLE
Don't use cleaned resource in RBAC rows

### DIFF
--- a/internal/render/rbac.go
+++ b/internal/render/rbac.go
@@ -64,7 +64,7 @@ func (r Rbac) Render(o interface{}, ns string, ro *model1.Row) error {
 	ro.ID = p.Resource
 	ro.Fields = make(model1.Fields, 0, len(r.Header(ns)))
 	ro.Fields = append(ro.Fields,
-		cleanseResource(p.Resource),
+		p.Resource,
 		p.Group,
 	)
 	ro.Fields = append(ro.Fields, asVerbs(p.Verbs)...)


### PR DESCRIPTION
As mentioned #3138, this PR removes the usage of the cleansedResource method for RBAC rows in order to display the subresources correctly.