### PR TITLE
fix: Use the latest version when downloading the Ubuntu deb file

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Binaries for Linux, Windows and Mac are available as tarballs in the [release pa
 * On Ubuntu
 
   ```shell
-  wget https://github.com/derailed/k9s/releases/download/v0.32.7/k9s_linux_amd64.deb && apt install ./k9s_linux_amd64.deb && rm k9s_linux_amd64.deb
+  wget https://github.com/derailed/k9s/releases/latest/download/k9s_linux_amd64.deb && apt install ./k9s_linux_amd64.deb && rm k9s_linux_amd64.deb
   ```
 
 * Via [Winget](https://github.com/microsoft/winget-cli) for Windows


### PR DESCRIPTION
Download the latest Ubuntu deb file automatically instead of hard-coding an old version in the README.