### PR TITLE
fix: allow absolute paths for the 'dir' command

### DIFF
--- a/internal/view/cmd/args.go
+++ b/internal/view/cmd/args.go
@@ -40,7 +40,13 @@ func newArgs(p *Interpreter, aa []string) args {
 			}
 
 		case strings.Index(a, filterFlag) == 0:
-			args[filterKey] = strings.ToLower(a[1:])
+			if p.IsDirCmd() {
+				if _, ok := args[topicKey]; !ok {
+					args[topicKey] = a
+				}
+			} else {
+				args[filterKey] = strings.ToLower(a[1:])
+			}
 
 		case strings.Contains(a, labelFlag):
 			if ll := ToLabels(a); len(ll) != 0 {

--- a/internal/view/cmd/interpreter_test.go
+++ b/internal/view/cmd/interpreter_test.go
@@ -242,10 +242,17 @@ func TestDirCmd(t *testing.T) {
 		"toast-nodir": {
 			cmd: "dir",
 		},
+
 		"caps": {
 			cmd: "dir DirName",
 			ok:  true,
 			dir: "DirName",
+		},
+
+		"abs": {
+			cmd: "dir /tmp",
+			ok:  true,
+			dir: "/tmp",
 		},
 	}
 


### PR DESCRIPTION
This fixes a regression from the prompt enhancements in https://github.com/derailed/k9s/pull/2361 where entering `:dir /tmp` results in an error:
```
Invalid command. Use `dir xxx`"
```