### PR TITLE
fix: match column show attribute character to 'S'

### DIFF
--- a/internal/render/cust_col.go
+++ b/internal/render/cust_col.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/get"
 )
 
-var fullRX = regexp.MustCompile(`^([\w\s%\/-]+)\:?([\w\d\S\W]*?)\|?([N|T|W|V|R|L|H]{0,3})$`)
+var fullRX = regexp.MustCompile(`^([\w\s%\/-]+)\:?([\w\d\S\W]*?)\|?([N|T|W|S|L|R|H]{0,3})$`)
 
 type colAttr byte
 
@@ -22,7 +22,7 @@ const (
 	number     colAttr = 'N'
 	age        colAttr = 'T'
 	wide       colAttr = 'W'
-	show       colAttr = 'V'
+	show       colAttr = 'S'
 	alignLeft  colAttr = 'L'
 	alignRight colAttr = 'R'
 	hide       colAttr = 'H'

--- a/internal/render/cust_col_test.go
+++ b/internal/render/cust_col_test.go
@@ -57,6 +57,18 @@ func TestCustCol_parse(t *testing.T) {
 			},
 		},
 
+		"plain-show": {
+			s: "fred|S",
+			e: colDef{
+				name: "fred",
+				idx:  -1,
+				colAttrs: colAttrs{
+					align: tview.AlignLeft,
+					show:  true,
+				},
+			},
+		},
+
 		"age": {
 			s: "AGE|TR",
 			e: colDef{
@@ -198,7 +210,7 @@ func TestCustCol_parse(t *testing.T) {
 		},
 
 		"toast-no-name": {
-			s:   `:.metadata.name.fred|TW`,
+			s: ":.metadata.name.fred|TW",
 			err: errors.New(`invalid column definition ":.metadata.name.fred|TW"`),
 		},
 

--- a/internal/render/cust_col_test.go
+++ b/internal/render/cust_col_test.go
@@ -210,7 +210,7 @@ func TestCustCol_parse(t *testing.T) {
 		},
 
 		"toast-no-name": {
-			s: ":.metadata.name.fred|TW",
+			s:   ":.metadata.name.fred|TW",
 			err: errors.New(`invalid column definition ":.metadata.name.fred|TW"`),
 		},
 


### PR DESCRIPTION
https://github.com/derailed/k9s/pull/3185#pullrequestreview-2669722878

'Show' attribute character doesn't match with it from the release note, I assumed that "S for show" is the correct one.