### PR TITLE
fix: List CRDs which has k8s.io in their names

### DIFF
--- a/internal/dao/registry.go
+++ b/internal/dao/registry.go
@@ -367,7 +367,7 @@ func loadPreferred(f Factory, m ResourceMetas) error {
 }
 
 func isStandardGroup(gv string) bool {
-	return stdGroups.Has(gv) || strings.Contains(gv, "k8s.io")
+	return stdGroups.Has(gv) || strings.Contains(gv, ".k8s.io")
 }
 
 var deprecatedGVRs = sets.New[client.GVR](


### PR DESCRIPTION
When a CRD's GV contained k8s.io (e.g.
infrastructure.cluster.x-k8s.io/v1beta1), it was considered as standard resource, therefore no alias was generated in the form of "<name>.<group>", therefore the CRD list view could not open the listing of that specific CRD.

Fixes #2842 
