### PR TITLE
fix: include APIResource name in the aliases

### DIFF
--- a/internal/view/helpers.go
+++ b/internal/view/helpers.go
@@ -33,6 +33,7 @@ import (
 
 func aliases(m *v1.APIResource, aa sets.Set[string]) sets.Set[string] {
 	ss := sets.New(aa.UnsortedList()...)
+	ss.Insert(m.Name)
 	ss.Insert(m.ShortNames...)
 	if m.SingularName != "" {
 		ss.Insert(m.SingularName)


### PR DESCRIPTION
- fix: https://github.com/derailed/k9s/issues/3273
- add APIResource name in the aliases which was included in 0.40.x: https://github.com/derailed/k9s/commit/e55083ba271eed6fc4014674890f70c5ed6c70e0#diff-a9cb5f3d8d593310c3382a60451df4407fc387d2d7c0f54ffdaa6157e7cc5406L33-L46
