### PR TITLE
Fix: support batch/v1beta1/cronjobs as a view

### DIFF
--- a/internal/client/gvrs.go
+++ b/internal/client/gvrs.go
@@ -24,8 +24,9 @@ var (
 	HpaGVR = NewGVR("autoscaling/v1/horizontalpodautoscalers")
 
 	// Batch...
-	CjGVR  = NewGVR("batch/v1/cronjobs")
-	JobGVR = NewGVR("batch/v1/jobs")
+	CjBetaGVR = NewGVR("batch/v1beta1/cronjobs")
+	CjGVR     = NewGVR("batch/v1/cronjobs")
+	JobGVR    = NewGVR("batch/v1/jobs")
 
 	// Misc...
 	CrdGVR = NewGVR("apiextensions.k8s.io/v1/customresourcedefinitions")

--- a/internal/view/registrar.go
+++ b/internal/view/registrar.go
@@ -135,6 +135,9 @@ func batchViewers(vv MetaViewers) {
 	vv[client.CjGVR] = MetaViewer{
 		viewerFn: NewCronJob,
 	}
+	vv[client.CjBetaGVR] = MetaViewer{
+		viewerFn: NewCronJob,
+	}
 	vv[client.JobGVR] = MetaViewer{
 		viewerFn: NewJob,
 	}


### PR DESCRIPTION
Fix for #3284.

Adds support for (deprecated) `batch/v1beta1/cronjobs` to render as a regular `CronJob` View, because otherwise it won't show the `BindKeys` for this specific Workload type.