### PR TITLE
fix: update time format in logging to 24-hour format

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
-	"time"
 
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/color"
@@ -104,7 +103,7 @@ func run(*cobra.Command, []string) error {
 
 	slog.SetDefault(slog.New(tint.NewHandler(logFile, &tint.Options{
 		Level:      parseLevel(*k9sFlags.LogLevel),
-		TimeFormat: time.Kitchen,
+		TimeFormat: "15:04:05",
 	})))
 
 	cfg, err := loadConfiguration()


### PR DESCRIPTION
This pull request makes minor adjustments to the logging configuration in `cmd/root.go`. The changes include modifying the time format for log entries and removing an unused import.

### Logging configuration changes:

* Updated the `TimeFormat` in the `slog` logger configuration from `time.Kitchen` to `"15:04:05"` for more precise time formatting. (`cmd/root.go`, [cmd/root.goL107-R106](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL107-R106))

### Code cleanup:

* Removed the unused `time` package import to streamline the codebase. (`cmd/root.go`, [cmd/root.goL13](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL13))

GitHub issue: https://github.com/derailed/k9s/issues/3295