### PR TITLE
fix: truncate label selector input to max length

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -562,6 +562,8 @@ func (t *Table) styleTitle() string {
 	if internal.IsLabelSelector(buff) {
 		sel, err := TrimLabelSelector(buff)
 		if err != nil {
+			buff = render.Truncate(buff, maxTruncate)
+		} else if sel != nil {
 			buff = render.Truncate(sel.String(), maxTruncate)
 		}
 	} else if l := t.GetModel().GetLabelSelector(); l != nil && !l.Empty() {


### PR DESCRIPTION
This pull request introduces a small change to the `styleTitle` method in `internal/ui/table.go`. The change ensures that when there is an error in `TrimLabelSelector`, the buffer (`buff`) is truncated using `render.Truncate` with a maximum length (`maxTruncate`).

GitHub issue: https://github.com/derailed/k9s/issues/3299