### PR TITLE
Allow context switching when the name contains spaces

### DIFF
--- a/internal/view/cmd/args.go
+++ b/internal/view/cmd/args.go
@@ -57,7 +57,7 @@ func newArgs(p *Interpreter, aa []string) args {
 		default:
 			switch {
 			case p.IsContextCmd():
-				arguments[contextKey] = a
+				arguments[contextKey] = strings.Join(aa, " ")
 			case p.IsDirCmd():
 				if _, ok := arguments[topicKey]; !ok {
 					arguments[topicKey] = a

--- a/internal/view/cmd/args_test.go
+++ b/internal/view/cmd/args_test.go
@@ -111,6 +111,11 @@ func TestFlagsNew(t *testing.T) {
 			aa: []string{"Dev"},
 			ll: args{contextKey: "Dev"},
 		},
+		"human readable ctx name": {
+			i:  NewInterpreter("ctx"),
+			aa: []string{"Dev", "Env"},
+			ll: args{contextKey: "Dev Env"},
+		},
 		"bork": {
 			i:  NewInterpreter("apply -f"),
 			ll: args{},


### PR DESCRIPTION
refs #3302 