### PR TITLE
fix: sort duration based string values separately

### DIFF
--- a/internal/model1/helpers_test.go
+++ b/internal/model1/helpers_test.go
@@ -134,3 +134,37 @@ func BenchmarkDurationToSecond(b *testing.B) {
 		durationToSeconds(t)
 	}
 }
+
+func TestIsDurationFormat(t *testing.T) {
+	uu := map[string]struct {
+		s        string
+		expected bool
+	}{
+		"empty string":              {s: "", expected: false},
+		"na value":                  {s: NAValue, expected: false},
+		"simple seconds":            {s: "30s", expected: true},
+		"simple minutes":            {s: "15m", expected: true},
+		"simple hours":              {s: "2h", expected: true},
+		"simple days":               {s: "7d", expected: true},
+		"simple years":              {s: "1y", expected: true},
+		"combined duration":         {s: "1h30m5s", expected: true},
+		"full mixed duration":       {s: "2y3d4h5m6s", expected: true},
+		"missing unit after number": {s: "30", expected: false},
+		"letters without numbers":   {s: "hms", expected: false},
+		"invalid characters":        {s: "30x", expected: false},
+		"multiple parts (space)":    {s: "1h 30m", expected: false},
+		"starting with letter":      {s: "h30m", expected: false},
+		"ending with number":        {s: "30m5", expected: false},
+		"only number":               {s: "123", expected: false},
+		"unit without number":       {s: "h", expected: false},
+		"zero seconds":              {s: "0s", expected: true},
+		"multiple zeros":            {s: "0h0m0s", expected: true},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.expected, isDurationFormat(u.s))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3294

This is my first PR here.

A few things to note:

1. While debugging, I found that K8s API returns columns like "LAST SEEN", "FIRST SEEN", "AGE" in string format. Initially I had thought that it might be a data-misrepresentation issue on the client side.
<img width="1066" alt="Screenshot 2025-04-26 at 6 36 35 pm" src="https://github.com/user-attachments/assets/f4da9b4c-bdec-48a0-a2eb-af0d21b9028b" />

2. I don't know if this is a good fix. Should we intercept the response obtained from the API, change the data format there or is it okay to detect duration and sort it separately?