### PR TITLE
Resource recommendation  plugin enhancements

### DIFF
--- a/plugins/resource-recommendations.yaml
+++ b/plugins/resource-recommendations.yaml
@@ -26,3 +26,22 @@ plugins:
         break
         fi
         done
+  krr-ns:
+    shortCut: Shift-K
+    description: Get krr
+    scopes:
+      - namespaces
+    command: bash
+    background: false
+    confirm: false
+    args:
+      - -c
+      - |
+        krr simple --cluster $CONTEXT -n $RESOURCE_NAME
+        echo "Press 'q' to exit"
+        while : ; do
+        read -n 1 k <&1
+        if [[ $k = q ]] ; then
+        break
+        fi
+        done

--- a/plugins/resource-recommendations.yaml
+++ b/plugins/resource-recommendations.yaml
@@ -11,6 +11,7 @@ plugins:
       - deployments
       - daemonsets
       - statefulsets
+      - cronjobs
     command: bash
     background: false
     confirm: false


### PR DESCRIPTION
The resource recommendation plugin based on [Robusta krr](https://github.com/robusta-dev/krr) works great!

The tool provides recommendations for `CronJob` objects and for specific namespaces, now supported in the k9s plugin. Refer to their docs for further info:
- https://github.com/robusta-dev/krr?tab=readme-ov-file#usage