### PR TITLE
fix: use full path of date to avoid conflict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PACKAGE    := github.com/derailed/$(NAME)
 GIT_REV    ?= $(shell git rev-parse --short HEAD)
 SOURCE_DATE_EPOCH ?= $(shell date +%s)
 ifeq ($(shell uname), Darwin)
-DATE       ?= $(shell TZ=UTC date -j -f "%s" ${SOURCE_DATE_EPOCH} +"%Y-%m-%dT%H:%M:%SZ")
+DATE       ?= $(shell TZ=UTC /bin/date -j -f "%s" ${SOURCE_DATE_EPOCH} +"%Y-%m-%dT%H:%M:%SZ")
 else
 DATE       ?= $(shell date -u -d @${SOURCE_DATE_EPOCH} +"%Y-%m-%dT%H:%M:%SZ")
 endif


### PR DESCRIPTION
### Motivation

Users may installed the `coreutils` package which also contains the `date` take precedence over the builtin `date`, and he former has very different parameters than latter.

Actually now I need to change to `/bin/date` whenever build the K9s locally, otherwise can have following errors:

```
date: invalid option -- 'j'
Try 'date --help' for more information.
```

### Modifications

This change won't break anyone without `coreutils` packaged installed, since they can always build with full path.