### PR TITLE
fix: pre-check for get permissions only on port-forward

### DIFF
--- a/internal/dao/port_forwarder.go
+++ b/internal/dao/port_forwarder.go
@@ -141,7 +141,7 @@ func (p *PortForwarder) Start(path string, tt port.PortTunnel) (*portforward.Por
 		return nil, fmt.Errorf("unable to forward port because pod is not running. Current status=%v", pod.Status.Phase)
 	}
 
-	auth, err = p.Client().CanI(ns, client.PodGVR.WithSubResource("portforward"), "", []string{client.CreateVerb})
+	auth, err = p.Client().CanI(ns, client.PodGVR.WithSubResource("portforward"), "", []string{client.GetVerb})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To port-forward, you only need `get` permission on the port-forward subresource, which can be proven through a simple kubectl test.

This changes the pre-check to check for `get` permission instead of `create`.