### PR TITLE
revert: #3322

### DIFF
--- a/internal/dao/port_forwarder.go
+++ b/internal/dao/port_forwarder.go
@@ -141,7 +141,7 @@ func (p *PortForwarder) Start(path string, tt port.PortTunnel) (*portforward.Por
 		return nil, fmt.Errorf("unable to forward port because pod is not running. Current status=%v", pod.Status.Phase)
 	}
 
-	auth, err = p.Client().CanI(ns, client.PodGVR.WithSubResource("portforward"), "", []string{client.GetVerb})
+	auth, err = p.Client().CanI(ns, client.PodGVR.WithSubResource("portforward"), "", []string{client.CreateVerb})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
PR https://github.com/derailed/k9s/pull/3322 changed the permission check for pods/portforward from `create` to `get`. However, Kubernetes requires the `create` verb for that subresource — using `get` results in an access denied error for users without elevated privileges.

This explains why it works for cluster-admins but breaks for users with more restricted RBAC.

