### PR TITLE
allow skin to be selected via K9S_SKIN env var

### DIFF
--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -195,7 +195,14 @@ func (c *Configurator) activeSkin() (string, bool) {
 		return skin, false
 	}
 
-	if ct, err := c.Config.K9s.ActiveContext(); err == nil && ct.Skin != "" {
+	if env_skin := os.Getenv("K9S_SKIN"); env_skin != "" {
+		if _, err := os.Stat(config.SkinFileFromName(env_skin)); err == nil {
+			skin = env_skin
+			slog.Debug("Loading env skin", slogs.Skin, skin)
+		}
+	}
+
+	if ct, err := c.Config.K9s.ActiveContext(); err == nil && skin == "" && ct.Skin != "" {
 		if _, err := os.Stat(config.SkinFileFromName(ct.Skin)); err == nil {
 			skin = ct.Skin
 			slog.Debug("Loading context skin",


### PR DESCRIPTION
minimal code change to allow the skin to be overriden by an environment variable `K9S_SKIN`.

config.ui.skin overwrites the default, context.skin overwrites the config setting, and K9S_SKIN overwrites the context setting. all of these are optional.

among others, this enables a use case where the active shell session can influence the k9s skin to distinguish between different clusters, without having to manually manage many per-cluster, per-context config files.

this solves https://github.com/derailed/k9s/issues/1909 and a couple related issues.

i have verified functionality and it works as desired.

@derailed please let me know if there are any changes required to get this merged, thanks!