### PR TITLE
Add context to condition in keda-toggle plugin

### DIFF
--- a/plugins/keda-toggle.yaml
+++ b/plugins/keda-toggle.yaml
@@ -15,7 +15,7 @@ plugins:
     - |
       ANNOTATION="autoscaling.keda.sh/paused-replicas"
 
-      if kubectl get scaledobject $NAME -n $NAMESPACE -o yaml | grep -q "$ANNOTATION: \"0\""; then
+      if kubectl get scaledobject $NAME -n $NAMESPACE --context $CONTEXT -o yaml | grep -q "$ANNOTATION: \"0\""; then
         # If annotation found, remove it
         kubectl annotate scaledobject $NAME "$ANNOTATION"- -n $NAMESPACE --context $CONTEXT >/dev/null && echo "Keda autoscaling for $NAME enabled"
       else


### PR DESCRIPTION
As for me in the keda-toggle plugin the condition that the annotation is already set is never met, I propose following change:

* Adding the `--context` argument to the condition

With this, it correctly toggles for me.