### PR TITLE
feat(app): history navigation preserves filters

### DIFF
--- a/internal/model/history.go
+++ b/internal/model/history.go
@@ -12,10 +12,15 @@ const MaxHistory = 20
 
 // History represents a command history.
 type History struct {
-	commands             []string
+	commands             []FilteredCommand
 	limit                int
 	activeCommandIndex   int
 	previousCommandIndex int
+}
+
+type FilteredCommand struct {
+	Command string
+	Filter  string
 }
 
 // NewHistory returns a new instance.
@@ -99,19 +104,19 @@ func (h *History) PopN(n int) bool {
 }
 
 // List returns the current command history.
-func (h *History) List() []string {
+func (h *History) List() []FilteredCommand {
 	return h.commands
 }
 
 // Push adds a new item.
-func (h *History) Push(c string) {
+func (h *History) Push(c, f string) {
 	if c == "" {
 		return
 	}
 
 	c = strings.ToLower(c)
 	if len(h.commands) < h.limit {
-		h.commands = append(h.commands, c)
+		h.commands = append(h.commands, FilteredCommand{c, f})
 		h.previousCommandIndex = h.activeCommandIndex
 		h.activeCommandIndex = len(h.commands) - 1
 		return

--- a/internal/model/history_test.go
+++ b/internal/model/history_test.go
@@ -14,10 +14,23 @@ import (
 func TestHistory(t *testing.T) {
 	h := model.NewHistory(3)
 	for i := 1; i < 5; i++ {
-		h.Push(fmt.Sprintf("cmd%d", i))
+		h.Push(fmt.Sprintf("cmd%d", i), fmt.Sprintf("filter%d", i))
 	}
 
-	assert.Equal(t, []string{"cmd1", "cmd2", "cmd3"}, h.List())
+	assert.Equal(t, []model.FilteredCommand{
+		{
+			Command: "cmd1",
+			Filter:  "filter1",
+		},
+		{
+			Command: "cmd2",
+			Filter:  "filter2",
+		},
+		{
+			Command: "cmd3",
+			Filter:  "filter3",
+		},
+	}, h.List())
 	h.Clear()
 	assert.True(t, h.Empty())
 }
@@ -25,10 +38,25 @@ func TestHistory(t *testing.T) {
 func TestHistoryDups(t *testing.T) {
 	h := model.NewHistory(3)
 	for i := 1; i < 4; i++ {
-		h.Push(fmt.Sprintf("cmd%d", i))
+		h.Push(fmt.Sprintf("cmd%d", i), fmt.Sprintf("filter%d", i))
 	}
-	h.Push("cmd1")
-	h.Push("")
+	h.Push("cmd1", "filter1")
+	h.Push("cmd1", "")
+	h.Push("cmd1", "")
+	h.Push("", "")
 
-	assert.Equal(t, []string{"cmd1", "cmd2", "cmd3"}, h.List())
+	assert.Equal(t, []model.FilteredCommand{
+		{
+			Command: "cmd1",
+			Filter:  "filter1",
+		},
+		{
+			Command: "cmd2",
+			Filter:  "filter2",
+		},
+		{
+			Command: "cmd3",
+			Filter:  "filter3",
+		},
+	}, h.List())
 }

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -126,15 +126,19 @@ func (b *Browser) InCmdMode() bool {
 
 func (b *Browser) suggestFilter() model.SuggestionFunc {
 	return func(s string) (entries sort.StringSlice) {
+		fh := []string{}
+		for _, fc := range b.App().cmdHistory.List() {
+			fh = append(fh, fc.Filter)
+		}
 		if s == "" {
-			if b.App().filterHistory.Empty() {
+			if len(fh) == 0 {
 				return
 			}
-			return b.App().filterHistory.List()
+			return fh
 		}
 
 		s = strings.ToLower(s)
-		for _, h := range b.App().filterHistory.List() {
+		for _, h := range fh {
 			if s == h {
 				continue
 			}
@@ -237,7 +241,7 @@ func (b *Browser) BufferActive(state bool, _ model.BufferKind) {
 		defer b.setUpdating(false)
 		b.UpdateUI(cdata, mdata)
 		if b.GetRowCount() > 1 {
-			b.App().filterHistory.Push(b.CmdBuff().GetText())
+			b.App().cmdHistory.Push(b.command.GetLine(), b.CmdBuff().GetText())
 		}
 	})
 }

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -386,6 +386,8 @@ func (b *Browser) resetCmd(evt *tcell.EventKey) *tcell.EventKey {
 		if hasFilter {
 			b.GetModel().SetLabelSelector(labels.Everything())
 			b.Refresh()
+			b.App().cmdHistory.Push(b.command.Cmd(), "")
+			b.App().cmdHistory.Forward()
 		}
 		return b.App().PrevCmd(evt)
 	}

--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -332,7 +332,7 @@ func (c *Command) exec(p *cmd.Interpreter, gvr *client.GVR, comp model.Component
 
 			ci := cmd.NewInterpreter(podCmd)
 			cmds := c.app.cmdHistory.List()
-			currentCommand := cmds[c.app.cmdHistory.CurrentIndex()]
+			currentCommand := cmds[c.app.cmdHistory.CurrentIndex()].Command
 			if currentCommand != podCmd {
 				ci = ci.Reset(currentCommand)
 			}
@@ -353,7 +353,7 @@ func (c *Command) exec(p *cmd.Interpreter, gvr *client.GVR, comp model.Component
 		return err
 	}
 	if pushCmd {
-		c.app.cmdHistory.Push(p.GetLine())
+		c.app.cmdHistory.Push(p.GetLine(), "")
 	}
 	slog.Debug("History", slogs.Stack, c.app.cmdHistory.List())
 


### PR DESCRIPTION
previously, when navigating the history using `[`, `]` and `-`, filters were not saved, so if you went to pods, filtered for `/nginx`, then went to services and then back to pods, the `/nginx` filter would not be used and the default pod view would be shown. now, that filter is saved.

closes #3220