### PR TITLE
fix(table): fix label display when a command + filter + label is provided

### DIFF
--- a/internal/ui/table_helper.go
+++ b/internal/ui/table_helper.go
@@ -60,12 +60,11 @@ func TrimCell(tv *SelectTable, row, col int) string {
 
 // TrimLabelSelector extracts label query.
 func TrimLabelSelector(s string) (labels.Selector, error) {
-	var selStr string
 	if strings.Index(s, "-l") == 0 {
-		selStr = strings.TrimSpace(s[2:])
+		s = strings.TrimSpace(s[2:])
 	}
 
-	return labels.Parse(selStr)
+	return labels.Parse(s)
 }
 
 // SkinTitle decorates a title.


### PR DESCRIPTION
currently, if you use `:svc -l app.kubernetes.io/instance=cert-manager` in k9s and then navigate history, when returning to the page the results are correct but the filter is not shown. here, we ensure that the table title string is not an empty string.

reported in #3404, but unrelated

bug originally introduced in #3293, which I have not reviewed for any other rippling effects.