### PR TITLE
History forward truncate

### DIFF
--- a/internal/model/history.go
+++ b/internal/model/history.go
@@ -110,11 +110,20 @@ func (h *History) Push(c string) {
 	}
 
 	c = strings.ToLower(c)
+
+	// If we're not at the end, truncate forward history
+	if h.activeCommandIndex < len(h.commands)-1 {
+		h.commands = h.commands[:h.activeCommandIndex+1]
+	}
+
+	// Enforce history limit
 	if len(h.commands) < h.limit {
 		h.commands = append(h.commands, c)
-		h.previousCommandIndex = h.activeCommandIndex
 		h.activeCommandIndex = len(h.commands) - 1
-		return
+	} else {
+		// Remove the oldest entry and append the new one
+		h.commands = append(h.commands[1:], c)
+		h.activeCommandIndex = len(h.commands) - 1
 	}
 }
 

--- a/internal/model/history_test.go
+++ b/internal/model/history_test.go
@@ -17,7 +17,7 @@ func TestHistory(t *testing.T) {
 		h.Push(fmt.Sprintf("cmd%d", i))
 	}
 
-	assert.Equal(t, []string{"cmd1", "cmd2", "cmd3"}, h.List())
+	assert.Equal(t, []string{"cmd2", "cmd3", "cmd4"}, h.List())
 	h.Clear()
 	assert.True(t, h.Empty())
 }
@@ -30,5 +30,5 @@ func TestHistoryDups(t *testing.T) {
 	h.Push("cmd1")
 	h.Push("")
 
-	assert.Equal(t, []string{"cmd1", "cmd2", "cmd3"}, h.List())
+	assert.Equal(t, []string{"cmd2", "cmd3", "cmd1"}, h.List())
 }

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -184,7 +184,6 @@ func (p *Pod) showNode(evt *tcell.EventKey) *tcell.EventKey {
 	}
 	no := NewNode(client.NodeGVR)
 	no.SetInstance(pod.Spec.NodeName)
-
 	if err := p.App().inject(no, false); err != nil {
 		p.App().Flash().Err(err)
 	}

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -184,6 +184,7 @@ func (p *Pod) showNode(evt *tcell.EventKey) *tcell.EventKey {
 	}
 	no := NewNode(client.NodeGVR)
 	no.SetInstance(pod.Spec.NodeName)
+
 	if err := p.App().inject(no, false); err != nil {
 		p.App().Flash().Err(err)
 	}


### PR DESCRIPTION
This pull request introduces enhancements to the `History` functionality in the `internal/model` package, focusing on enforcing a history limit, handling forward history truncation, and updating test cases to reflect these changes.

### Updates to `History` functionality:

* [`internal/model/history.go`](diffhunk://#diff-f3de4969de9e333fbaac414e12ef99865af63bbcb57cbf9f41306677836ac57dR113-R126): Added logic to truncate forward history when a new command is pushed and the active command index is not at the end. Enforced a history limit by removing the oldest entry when the limit is exceeded.

### Updates to test cases:

* [`internal/model/history_test.go`](diffhunk://#diff-83f96e4cef92f06972015b2610939873db7739620f605bc99934e76d41b1eb63L20-R20): Updated `TestHistory` to reflect the new behavior of enforcing the history limit, ensuring the oldest command is removed when the limit is exceeded.
* [`internal/model/history_test.go`](diffhunk://#diff-83f96e4cef92f06972015b2610939873db7739620f605bc99934e76d41b1eb63L33-R33): Updated `TestHistoryDups` to verify the updated behavior of the `Push` method, ensuring commands are correctly added while respecting the history limit.

GitHub issue: https://github.com/derailed/k9s/issues/3406