### PR TITLE
fix(table): use the table cursorBgColor to highlight selected unmarked rows

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -426,10 +426,8 @@ func (t *Table) buildRow(r int, re, ore model1.RowEvent, h model1.Header, pads M
 			} else {
 				bgColor = t.styles.Table().CursorBgColor.Color()
 			}
-		} else {
-			if marked {
-				fgColor = t.styles.Table().MarkColor.Color()
-			}
+		} else if marked {
+			fgColor = t.styles.Table().MarkColor.Color()
 		}
 		cell.SetTextColor(fgColor)
 		cell.SetBackgroundColor(bgColor)


### PR DESCRIPTION
In the table, a selected row has foreground: `cursorFgColor` and the background is the normal foreground color for the line. Updating the logic to use the `cursorBgColor` for selected, unmarked rows.

- tested by setting `cursorBgColor: green` in the stock skin
- added fields to SelectTable for the `markColor`, the unselected `fgColor` and `bgColor`, and the `lastSelectedRow`, to allow `selectionChanged` to update the unselected row
- removed SetSelectedStyle call from ToggleMark, I think it is not needed with this change
- changed the buildRow SetReference call to every column, to prevent a delay in updating unselected cells after the first column