### PR TITLE
fetchContainers(allContainers=false) returns sidecars and ephemeral

### DIFF
--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -516,12 +516,12 @@ func fetchContainers(meta *metav1.ObjectMeta, spec *v1.PodSpec, allContainers bo
 			nn = append(nn, spec.Containers[i].Name)
 		}
 	}
-	if !allContainers {
-		return nn
-	}
 
 	for i := range spec.InitContainers {
-		nn = append(nn, spec.InitContainers[i].Name)
+		isSidecar := spec.InitContainers[i].RestartPolicy != nil && *spec.InitContainers[i].RestartPolicy == v1.ContainerRestartPolicyAlways
+		if allContainers || isSidecar {
+			nn = append(nn, spec.InitContainers[i].Name)
+		}
 	}
 	for i := range spec.EphemeralContainers {
 		nn = append(nn, spec.EphemeralContainers[i].Name)


### PR DESCRIPTION
**Issue**: 
When calling exec / attach / transfer on a pod with sidecar containers or ephemeral containers, those are not presented as potential targets to exec / attach / transfer.
This is because the fetchContainers method when called with allContainers=false only returns the main containers

**Proposed solution:** 
I'm proposing to change the behavior of the method to return any sidecar container and ephemeral container when called with allContainers=false. 
Since there is no other caller using that parameter set to false, so we won't break other call sites