### PR TITLE
feat(plugins): add plugin kubectl-ai, Integration for Intelligent Operations operations

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -4,16 +4,17 @@ K9s plugins extend the tool to provide additional functionality via actions to f
 
 Following is an example of some of plugin files in this directory. Other files are not listed in this table.
 
-| Plugin-Name        | Description                                                      | Available on Views | Shortcut | Kubectl plugin, external dependencies                                                 |
-|--------------------|------------------------------------------------------------------|--------------------|----------|---------------------------------------------------------------------------------------|
+| Plugin-Name        | Description                                                | Available on Views | Shortcut | Kubectl plugin, external dependencies                                                 |
+|--------------------|------------------------------------------------------------|--------------------|----------|---------------------------------------------------------------------------------------|
 | debug-container.yml| Add [ephemeral debug container][1]<br>([nicolaka/netshoot][2]) | containers         | Shift-d  |                                                                                       |
-| dive.yml           | Dive image layers                                                | containers         | d        | [Dive](https://github.com/wagoodman/dive)                                             |
-| get-all.yml        | get all resources in a namespace                                 | all                | g        | [Krew](https://krew.sigs.k8s.io/), [ketall](https://github.com/corneliusweig/ketall/) |
-| job_suspend.yml    | Suspends a running cronjob                                       | cronjobs           | Ctrl-s   |                                                                                       |
-| k3d_root_shell.yml | Root shell to k3d container                                      | containers         | Shift-s  | [jq](https://stedolan.github.io/jq/)                                                  |
-| log_stern.yml      | View resource logs using stern                                   | pods               | Ctrl-l   |                                                                                       |
-| log_jq.yml         | View resource logs using jq                                      | pods               | Ctrl-j   | kubectl-plugins/kubectl-jq                                                            |
-| log_full.yml       | get full logs from pod/container                                 | pods/containers    | Ctrl-l   |                                                                                       |
+| dive.yml           | Dive image layers                                          | containers         | d        | [Dive](https://github.com/wagoodman/dive)                                             |
+| get-all.yml        | get all resources in a namespace                           | all                | g        | [Krew](https://krew.sigs.k8s.io/), [ketall](https://github.com/corneliusweig/ketall/) |
+| job_suspend.yml    | Suspends a running cronjob                                 | cronjobs           | Ctrl-s   |                                                                                       |
+| k3d_root_shell.yml | Root shell to k3d container                                | containers         | Shift-s  | [jq](https://stedolan.github.io/jq/)                                                  |
+| log_stern.yml      | View resource logs using stern                             | pods               | Ctrl-l   |                                                                                       |
+| log_jq.yml         | View resource logs using jq                                | pods               | Ctrl-j   | kubectl-plugins/kubectl-jq                                                            |
+| log_full.yml       | get full logs from pod/container                           | pods/containers    | Ctrl-l   |                                                                                       |
+| kubectl_ai.yml     | Integrate kubectl-ai to implement intelligent operations using LLM (The intelligent capabilities and security depend on the LLM model already used by the kubectl-ai project, which is currently not mature, please do not use in production environments)                            | all                | Ctrl-v   | [kubectl-ai](https://github.com/GoogleCloudPlatform/kubectl-ai)                                                                        |
 
 [1]: https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container
 [2]: https://github.com/nicolaka/netshoot

--- a/plugins/kubectl_ai.yaml
+++ b/plugins/kubectl_ai.yaml
@@ -1,0 +1,13 @@
+plugin:
+  kubectl-ai:
+    shortCut: Ctrl-V
+    description: Kubectl AI
+    scopes:
+      - all
+    command: bash
+    background: false
+    args:
+      - -c
+      - |
+        export OPENAI_API_KEY=xxxx
+        kubectl-ai --kubeconfig="$KUBECONFIG" --llm-provider=openai --model=gpt-4.1


### PR DESCRIPTION
# Overview

This PR integrates [kubectl-ai](https://github.com/GoogleCloudPlatform/kubectl-ai) functionality into k9s, bringing LLM-powered intelligent Kubernetes operations to the terminal UI experience.

# What is kubectl-ai?

kubectl-ai is an AI-powered Kubernetes assistant that leverages Large Language Models (LLMs) to translate natural language requests into kubectl commands and execute Kubernetes operations [11](https://github.com/GoogleCloudPlatform/kubectl-ai)[16](https://www.ewere.tech/blog/what-is-kubectl-ai-in-kubernetes/). It acts as an intelligent interface between users and Kubernetes clusters, eliminating the need to manually craft complex kubectl commands.

# Features Added

- Natural Language Interface: Users can describe operations in plain English within k9s
- Smart Command Translation: AI automatically converts natural language to appropriate kubectl commands.

# Example Usage

``` bash

  Hey there, what can I help you with today?


>>> list all finished job in ops namespace
  Running: kubectl get jobs -n ops --field-selector status.successful=1 -o jsonpath='{range .items[?(@.status.succeeded==1)]}{.metadata.name}\n{end}'


  Here is the list of all finished (successful) jobs in the "ops" namespace:

  • auto-pause-29189260
  • cleanup-29189260  
  ...
  • superset-init-db

    Let me know if you need any more details! 😊


>>> cleanup those jobs which name start with 'cleanup'
  Running: kubectl delete jobs -n ops -l job-name-prefix=cleanup --field-selector metadata.name=cleanup

  Do you want to proceed ?
  1) Yes
  2) Yes, and don't ask me again
  3) No
  Enter your choice (1,2,3): 2

  The command to delete jobs with names starting with "cleanup" using the
  label selector did not find any resources because those jobs don't have such
  a label. I will delete the jobs based on name prefix using a different
  approach by listing and deleting them explicitly. Proceeding with this now.


  Running: kubectl get jobs -n ops -o jsonpath='{.items[?(@.metadata.name.startsWith("cleanup"))].metadata.name}' | xargs -r -n 1 kubectl delete job -n ops


  The JSONPath expression I used to filter jobs by prefix is invalid. I will
  try another approach: first list the jobs with name starting with "cleanup"
  in the "ops" namespace, then delete them one by one. I will do this in two
  steps.


  Running: kubectl get jobs -n ops -o jsonpath='{range .items[?(@.metadata.name =~ /^cleanup/)]}{.metadata.name}\n{end}'


  The jsonpath filter for regex match is not supported by kubectl. I will use
  a different approach: get all jobs in the ops namespace, then filter the
  names starting with "cleanup" using shell commands, and delete those jobs.
  Proceeding with this approach now.


  Running: kubectl get jobs -n ops -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep '^cleanup' | xargs -r -n 1 kubectl delete job -n ops


  All jobs in the "ops" namespace with names starting with "cleanup" have been
  deleted successfully. If you need any further assistance, feel free to ask!
  😊

>>> list jobs in ops platform
  Running: kubectl get jobs -n ops


  Here is the list of jobs in the "ops" namespace:

  • auto-pause-29189260
  ...
  • superset-init-db

>>>
```

# Security & Production Readiness

***⚠️ Important Notice***: 

The intelligent capabilities and security depend on the LLM model used by the kubectl-ai project. As this technology is still maturing, please ***DO NOT USE*** in production environments.

# Dependencies

Requires kubectl-ai to be installed and configured

# Breaking Changes

None. This is an additive feature that doesn't modify existing k9s functionality.