### PR TITLE
feat: Add GPU usage to pod view

### DIFF
--- a/internal/model/table_int_test.go
+++ b/internal/model/table_int_test.go
@@ -36,7 +36,7 @@ func TestTableReconcile(t *testing.T) {
 	err := ta.reconcile(ctx)
 	require.NoError(t, err)
 	data := ta.Peek()
-	assert.Equal(t, 25, data.HeaderCount())
+	assert.Equal(t, 26, data.HeaderCount())
 	assert.Equal(t, 1, data.RowCount())
 	assert.Equal(t, client.NamespaceAll, data.GetNamespace())
 }

--- a/internal/model/table_test.go
+++ b/internal/model/table_test.go
@@ -37,7 +37,7 @@ func TestTableRefresh(t *testing.T) {
 	ctx = context.WithValue(ctx, internal.KeyWithMetrics, false)
 	require.NoError(t, ta.Refresh(ctx))
 	data := ta.Peek()
-	assert.Equal(t, 25, data.HeaderCount())
+	assert.Equal(t, 26, data.HeaderCount())
 	assert.Equal(t, 1, data.RowCount())
 	assert.Equal(t, client.NamespaceAll, data.GetNamespace())
 	assert.Equal(t, 1, l.count)

--- a/internal/render/helpers_test.go
+++ b/internal/render/helpers_test.go
@@ -56,7 +56,7 @@ func TestTableHydrate(t *testing.T) {
 	re := NewPod()
 	require.NoError(t, model1.Hydrate("blee", oo, rr, re))
 	assert.Len(t, rr, 1)
-	assert.Len(t, rr[0].Fields, 25)
+	assert.Len(t, rr[0].Fields, 26)
 }
 
 func TestToAge(t *testing.T) {

--- a/internal/render/node.go
+++ b/internal/render/node.go
@@ -216,8 +216,8 @@ func (n *NodeWithMetrics) DeepCopyObject() runtime.Object {
 }
 
 type metric struct {
-	cpu, mem   int64
-	lcpu, lmem int64
+	cpu, mem, gpu    int64
+	lcpu, lmem, lgpu int64
 }
 
 func gatherNodeMX(no *v1.Node, mx *mv1beta1.NodeMetrics) (c, a metric) {

--- a/internal/render/pod_test.go
+++ b/internal/render/pod_test.go
@@ -164,8 +164,8 @@ func TestPodRender(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "default/nginx", r.ID)
-	e := model1.Fields{"default", "nginx", "0", "●", "1/1", "Running", "0", "<unknown>", "100", "50", "100:0", "70:170", "100", "n/a", "71", "29", "172.17.0.6", "minikube", "default", "<none>"}
-	assert.Equal(t, e, r.Fields[:20])
+	e := model1.Fields{"default", "nginx", "0", "●", "1/1", "Running", "0", "<unknown>", "100", "50", "100:0", "70:170", "100", "n/a", "71", "29", "0", "172.17.0.6", "minikube", "default", "<none>"}
+	assert.Equal(t, e, r.Fields[:21])
 }
 
 func BenchmarkPodRender(b *testing.B) {
@@ -195,8 +195,8 @@ func TestPodInitRender(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "default/nginx", r.ID)
-	e := model1.Fields{"default", "nginx", "0", "●", "1/1", "Init:0/1", "0", "<unknown>", "10", "10", "100:0", "70:170", "10", "n/a", "14", "5", "172.17.0.6", "minikube", "default", "<none>"}
-	assert.Equal(t, e, r.Fields[:20])
+	e := model1.Fields{"default", "nginx", "0", "●", "1/1", "Init:0/1", "0", "<unknown>", "10", "10", "100:0", "70:170", "10", "n/a", "14", "5", "0", "172.17.0.6", "minikube", "default", "<none>"}
+	assert.Equal(t, e, r.Fields[:21])
 }
 
 func TestPodSidecarRender(t *testing.T) {
@@ -211,8 +211,8 @@ func TestPodSidecarRender(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "default/sleep", r.ID)
-	e := model1.Fields{"default", "sleep", "0", "●", "2/2", "Running", "0", "<unknown>", "100", "40", "50:250", "50:80", "200", "40", "80", "50", "10.244.0.8", "kind-control-plane", "default", "<none>"}
-	assert.Equal(t, e, r.Fields[:20])
+	e := model1.Fields{"default", "sleep", "0", "●", "2/2", "Running", "0", "<unknown>", "100", "40", "50:250", "50:80", "200", "40", "80", "50", "0", "10.244.0.8", "kind-control-plane", "default", "<none>"}
+	assert.Equal(t, e, r.Fields[:21])
 }
 
 func TestCheckPodStatus(t *testing.T) {


### PR DESCRIPTION
## Description
Adds a GPU column to the pods view that displays the total number of GPUs requested by each pod.

## Motivation
When managing GPU workloads in Kubernetes clusters, it's useful to quickly see which pods are consuming GPU resources directly in the k9s interface without having to describe each pod individually.

![image](https://github.com/user-attachments/assets/bb42cdea-75c1-4e17-97ab-62c48e766c4c)
