### PR TITLE
fix: get-all command in get all plugin

### DIFF
--- a/plugins/get-all.yaml
+++ b/plugins/get-all.yaml
@@ -10,7 +10,7 @@ plugins:
     background: false
     args:
       - -c
-      - "kubectl get-all --context $CONTEXT -n $NAME | less -K"
+      - "kubectl get all --context $CONTEXT -n $NAME | less -K"
   get-all-other:
     shortCut: g
     confirm: false
@@ -21,4 +21,4 @@ plugins:
     background: false
     args:
       - -c
-      - "kubectl get-all --context $CONTEXT -n $NAMESPACE | less -K"
+      - "kubectl get all --context $CONTEXT -n $NAMESPACE | less -K"


### PR DESCRIPTION
Running the `get-all` command presented me with an error

```
error: unknown command "get-all" for "kubectl"
```

After testing I changed this too `get all` which then presented me with all resources