### PR TITLE
Document how to install on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Binaries for Linux, Windows and Mac are available as tarballs in the [release pa
   wget https://github.com/derailed/k9s/releases/latest/download/k9s_linux_amd64.deb && apt install ./k9s_linux_amd64.deb && rm k9s_linux_amd64.deb
   ```
 
+* On Fedora (42+)
+
+  ```shell
+  dnf install k9s
+  ```
+
 * Via [Winget](https://github.com/microsoft/winget-cli) for Windows
 
   ```shell


### PR DESCRIPTION
I introduced `k9s` recently into Fedora and users can now install it directly from the official Fedora repository.