### PR TITLE
fsupport core group resources in k9s/plugins/watch-events.yaml

### DIFF
--- a/plugins/watch-events.yaml
+++ b/plugins/watch-events.yaml
@@ -12,4 +12,4 @@ plugins:
     background: false
     args:
     - -c
-    - "kubectl events --context $CONTEXT --namespace $NAMESPACE --for $RESOURCE_NAME.$RESOURCE_GROUP/$NAME --watch"
+    - "kubectl events --context $CONTEXT --namespace $NAMESPACE --for $RESOURCE_NAME.${RESOURCE_GROUP:+.RESOURCE_GROUP}/$NAME --watch"


### PR DESCRIPTION
The watch-events plugin fails when the resource group is empty. Fix it by using the alternate value expansion of shell variables: https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_06

Relates to : #1678 