### PR TITLE
docs: Add installation method with gah

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Binaries for Linux, Windows and Mac are available as tarballs in the [release pa
   pkgx k9s
   ```
 
+* Via [gah](https://github.com/marverix/gah) for Linux and macOS
+
+  ```shell
+  gah install k9s
+  ```
+
 * Via [Webi](https://webinstall.dev) for Windows
 
   ```shell


### PR DESCRIPTION
Hello!
This PR adds to the documentation installation method using [gah](https://github.com/marverix/gah):
> gah is an GitHub Releases app installer, that DOES NOT REQUIRE SUDO! It is a simple bash script that downloads the latest release of an app from GitHub and installs it in ~/.local/bin. It is designed to be used with apps that are distributed as a single binary file.