### PR TITLE
Fixes flickering/jumping issue in context suggestions caused by inconsistent spacing behavior

### DIFF
--- a/internal/view/cmd/helpers.go
+++ b/internal/view/cmd/helpers.go
@@ -58,11 +58,11 @@ func SuggestSubCommand(command string, namespaces client.NamespaceNames, context
 		if !ok {
 			return nil
 		}
-		suggests = completeCtx(n, contexts)
+		suggests = completeCtx(command, n, contexts)
 
 	case p.HasNS():
 		if n, ok := p.HasContext(); ok {
-			suggests = completeCtx(n, contexts)
+			suggests = completeCtx(command, n, contexts)
 		}
 		if len(suggests) > 0 {
 			break
@@ -76,7 +76,7 @@ func SuggestSubCommand(command string, namespaces client.NamespaceNames, context
 
 	default:
 		if n, ok := p.HasContext(); ok {
-			suggests = completeCtx(n, contexts)
+			suggests = completeCtx(command, n, contexts)
 		}
 	}
 	slices.Sort(suggests)
@@ -99,11 +99,11 @@ func completeNS(s string, nn client.NamespaceNames) []string {
 	return suggests
 }
 
-func completeCtx(s string, contexts []string) []string {
+func completeCtx(command, s string, contexts []string) []string {
 	var suggests []string
 	for _, ctxName := range contexts {
 		if suggest, ok := ShouldAddSuggest(s, ctxName); ok {
-			if s == "" {
+			if s == "" && !strings.HasSuffix(command, " ") {
 				suggests = append(suggests, " "+suggest)
 				continue
 			}

--- a/internal/view/cmd/helpers_test.go
+++ b/internal/view/cmd/helpers_test.go
@@ -77,6 +77,8 @@ func TestSuggestSubCommand(t *testing.T) {
 		{Command: "ctx p", Suggestions: []string{"re", "rod"}},
 		{Command: "ctx   p", Suggestions: []string{"re", "rod"}},
 		{Command: "ctx pr", Suggestions: []string{"e", "od"}},
+		{Command: "ctx", Suggestions: []string{" develop", " pre", " prod", " test"}},
+		{Command: "ctx ", Suggestions: []string{"develop", "pre", "prod", "test"}},
 		{Command: "context   d", Suggestions: []string{"evelop"}},
 		{Command: "contexts   t", Suggestions: []string{"est"}},
 		{Command: "po ", Suggestions: nil},


### PR DESCRIPTION
## Summary
Fixes flickering/jumping issue in context suggestions caused by inconsistent spacing behavior.

## Problem
The original context suggestion fix in #2791 introduced a flickering issue:
- Typing `ctx` displays `ctx <context>`
- Typing `ctx ` (extra space) displays `ctx  <context>`  (2 spaces)
- Typing `ctx p` displays `ctx prod` (extra space disappears)

This inconsistent spacing causes suggestions to flicker and jump as users type.

## Solution
- Improved context suggestion logic to handle spacing consistently
- Prevents flickering when transitioning between suggestion states
- Maintains stable visual behavior regardless of extra spaces

## Changes
- `internal/view/cmd/helpers.go`: Enhanced suggestion spacing logic to prevent flickering
- `internal/view/cmd/helpers_test.go`: Added tests for consistent spacing behavior

## Testing
- [x] No flickering when typing with extra spaces
- [x] Consistent spacing behavior across all input patterns
- [x] Smooth transition between suggestion and typed text
- [x] Context selection functionality preserved

Resolves the visual instability introduced in #2791 while maintaining the original fix's benefits.