### PR TITLE
feat: preserve filters and navigation state in command history

### DIFF
--- a/internal/model/history_test.go
+++ b/internal/model/history_test.go
@@ -80,7 +80,11 @@ func TestHistoryTop(t *testing.T) {
 
 			cmd, ok := h.Top()
 			assert.Equal(t, u.ok, ok)
-			assert.Equal(t, u.cmd, cmd)
+			if ok && cmd != nil {
+				assert.Equal(t, u.cmd, cmd.Command)
+			} else {
+				assert.Equal(t, u.cmd, "")
+			}
 		})
 	}
 }
@@ -130,7 +134,11 @@ func TestHistoryBack(t *testing.T) {
 
 			cmd, ok := h.Back()
 			assert.Equal(t, u.ok, ok)
-			assert.Equal(t, u.cmd, cmd)
+			if ok && cmd != nil {
+				assert.Equal(t, u.cmd, cmd.Command)
+			} else {
+				assert.Equal(t, u.cmd, "")
+			}
 		})
 	}
 }
@@ -183,7 +191,11 @@ func TestHistoryForward(t *testing.T) {
 
 			cmd, ok := h.Forward()
 			assert.Equal(t, u.ok, ok)
-			assert.Equal(t, u.cmd, cmd)
+			if ok && cmd != nil {
+				assert.Equal(t, u.cmd, cmd.Command)
+			} else {
+				assert.Equal(t, u.cmd, "")
+			}
 		})
 	}
 }

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -664,7 +664,8 @@ func (a *App) dirCmd(path string, pushCmd bool) error {
 		}
 	}
 	if pushCmd {
-		a.cmdHistory.Push("dir " + path)
+		state := model.NewCommandState("dir "+path, "", "")
+		a.cmdHistory.Push(state)
 	}
 
 	return a.inject(NewDir(path), true)
@@ -763,11 +764,79 @@ func (a *App) aliasCmd(*tcell.EventKey) *tcell.EventKey {
 	return nil
 }
 
-func (a *App) gotoResource(c, path string, clearStack, pushCmd bool) {
-	err := a.command.run(cmd.NewInterpreter(c), path, clearStack, pushCmd)
+func (a *App) gotoResource(target interface{}, path string, clearStack, pushCmd bool) {
+	var err error
+	var shouldRestoreState bool
+	var state *model.CommandState
+
+	switch v := target.(type) {
+	case string:
+		// Backward compatibility: simple command string
+		err = a.command.run(cmd.NewInterpreter(v), path, clearStack, pushCmd)
+	case *model.CommandState:
+		// New way: command state with filters
+		if v == nil {
+			a.App.Flash().Warn("Invalid command state")
+			return
+		}
+		state = v
+		shouldRestoreState = true
+		interpreter := cmd.NewInterpreter(v.String())
+		err = a.command.run(interpreter, path, clearStack, pushCmd)
+	default:
+		a.App.Flash().Warn("Invalid target type for navigation")
+		return
+	}
+
 	if err != nil {
 		d := a.Styles.Dialog()
 		dialog.ShowError(&d, a.Content.Pages, err.Error())
+		return
+	}
+
+	// After navigation, restore the filter state if needed
+	if shouldRestoreState && state != nil {
+		a.restoreFilterState(state)
+	}
+}
+
+// restoreFilterState restores filter state to the current view.
+func (a *App) restoreFilterState(state *model.CommandState) {
+	if state == nil || !state.HasFilters() {
+		return
+	}
+
+	top := a.Content.Top()
+	if top == nil {
+		return
+	}
+
+	// Try to cast directly to Browser first
+	if browser, ok := top.(*Browser); ok {
+		a.QueueUpdateDraw(func() {
+			if state.Labels != "" {
+				// For label selectors, set the text and apply the selector
+				browser.CmdBuff().SetText(state.Labels, "")
+				if sel, err := ui.TrimLabelSelector(state.Labels); err == nil {
+					browser.SetLabelSelector(sel)
+				}
+			} else if state.Filter != "" {
+				cmdBuff := browser.CmdBuff()
+
+				// Temporarily remove browser as listener to avoid BufferCompleted interference
+				cmdBuff.RemoveListener(browser)
+
+				// Set the filter text
+				cmdBuff.SetText(state.Filter, "")
+
+				// Add browser back as listener
+				cmdBuff.AddListener(browser)
+
+				// Now refresh to apply the filter
+				browser.Refresh()
+			}
+		})
+		return
 	}
 }
 

--- a/internal/view/cmd/args.go
+++ b/internal/view/cmd/args.go
@@ -46,7 +46,22 @@ func newArgs(p *Interpreter, aa []string) args {
 				arguments[filterKey] = strings.ToLower(a[1:])
 			}
 
-		case strings.Contains(a, labelFlag):
+		case strings.Index(a, labelFlag) == 0:
+			if a == labelFlag {
+				i++
+				if i < len(aa) {
+					if ll := ToLabels(aa[i]); len(ll) != 0 {
+						arguments[labelKey] = strings.ToLower(aa[i])
+					}
+				}
+			} else {
+				labelQuery := a[2:]
+				if ll := ToLabels(labelQuery); len(ll) != 0 {
+					arguments[labelKey] = strings.ToLower(labelQuery)
+				}
+			}
+
+		case strings.Contains(a, labelAssignment):
 			if ll := ToLabels(a); len(ll) != 0 {
 				arguments[labelKey] = strings.ToLower(a)
 			}

--- a/internal/view/cmd/types.go
+++ b/internal/view/cmd/types.go
@@ -10,13 +10,14 @@ import (
 )
 
 const (
-	cowCmd      = "cow"
-	canCmd      = "can"
-	nsFlag      = "-n"
-	filterFlag  = "/"
-	labelFlag   = "="
-	fuzzyFlag   = "-f"
-	contextFlag = "@"
+	cowCmd          = "cow"
+	canCmd          = "can"
+	nsFlag          = "-n"
+	filterFlag      = "/"
+	labelFlag       = "-l"
+	labelAssignment = "="
+	fuzzyFlag       = "-f"
+	contextFlag     = "@"
 )
 
 var (

--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -334,13 +334,12 @@ func (c *Command) exec(p *cmd.Interpreter, gvr *client.GVR, comp model.Component
 		if e := recover(); e != nil {
 			slog.Error("Failure detected during command exec", slogs.Error, e)
 			c.app.Content.Dump()
-			slog.Debug("Dumping history buffer", slogs.CmdHist, c.app.cmdHistory.List())
 			slog.Error("Dumping stack", slogs.Stack, string(debug.Stack()))
 
 			ci := cmd.NewInterpreter(podCmd)
 			currentCommand, ok := c.app.cmdHistory.Top()
-			if ok {
-				ci = ci.Reset(currentCommand)
+			if ok && currentCommand != nil {
+				ci = ci.Reset(currentCommand.Command)
 			}
 			err = c.run(ci, "", true, true)
 		}
@@ -359,7 +358,26 @@ func (c *Command) exec(p *cmd.Interpreter, gvr *client.GVR, comp model.Component
 		return err
 	}
 	if pushCmd {
-		c.app.cmdHistory.Push(p.GetLine())
+		// Extract filter and label information from the command
+		filter := ""
+		labels := ""
+		if f, ok := p.FilterArg(); ok {
+			filter = f
+		}
+		if ll, ok := p.LabelsArg(); ok {
+			// Convert labels map to string with -l prefix
+			var labelPairs []string
+			for k, v := range ll {
+				labelPairs = append(labelPairs, k+"="+v)
+			}
+			if len(labelPairs) > 0 {
+				labels = "-l " + strings.Join(labelPairs, ",")
+			}
+		}
+
+		// Create command state with preserved filters
+		state := model.NewCommandState(p.GetLine(), filter, labels)
+		c.app.cmdHistory.Push(state)
 	}
 	slog.Debug("History", slogs.Stack, strings.Join(c.app.cmdHistory.List(), "|"))
 


### PR DESCRIPTION
## Preserve Filters in History Navigation

When using `[` and `]` to navigate through command history, filters and labels are now automatically reapplied.

**Before:** Filters were lost when navigating back/forward  
**After:** Filters are preserved and restored

Improves navigation UX by maintaining filter