### PR TITLE
feat: add substring and fuzzy suggestion mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,11 @@ You can now override the context portForward default address configuration by se
       disableAutoscroll: false
       # Toggles log line timestamp info. Default false
       showTime: false
+    # Define how suggestions are made.
+    # "PREFIX": typed text is considered a prefix, sorts suggestions alphabetically. Default mode.
+    # "LONGEST_PREFIX": typed text is considered a prefix, sorts suggestions by how much of the typed text they match; if equal, it falls back to alphabetical order.
+    # "LONGEST_PREFIX": typed text is considered a substring, sorts suggestions by how much of the typed text they match; if equal, it falls back to alphabetical order.
+    suggestionMode: PREFIX
     # Provide shell pod customization when nodeShell feature gate is enabled!
     shellPod:
       # The shell pod image to use.

--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ You can now override the context portForward default address configuration by se
       showTime: false
     # Define how suggestions are made.
     # "PREFIX": typed text is considered a prefix, sorts suggestions alphabetically. Default mode.
+    # "FUZZY": typed text is fuzzy-matched against suggestions, sorted by Levenshtein distance (but only character additions are considered as possible string edits).
     # "LONGEST_PREFIX": typed text is considered a prefix, sorts suggestions by how much of the typed text they match; if equal, it falls back to alphabetical order.
     # "LONGEST_SUBSTRING": typed text is considered a substring, sorts suggestions by how much of the typed text they match; if equal, it falls back to alphabetical order.
     suggestionMode: PREFIX

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ You can now override the context portForward default address configuration by se
     # Define how suggestions are made.
     # "PREFIX": typed text is considered a prefix, sorts suggestions alphabetically. Default mode.
     # "LONGEST_PREFIX": typed text is considered a prefix, sorts suggestions by how much of the typed text they match; if equal, it falls back to alphabetical order.
-    # "LONGEST_PREFIX": typed text is considered a substring, sorts suggestions by how much of the typed text they match; if equal, it falls back to alphabetical order.
+    # "LONGEST_SUBSTRING": typed text is considered a substring, sorts suggestions by how much of the typed text they match; if equal, it falls back to alphabetical order.
     suggestionMode: PREFIX
     # Provide shell pod customization when nodeShell feature gate is enabled!
     shellPod:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -257,6 +257,12 @@ func initK9sFlags() {
 		"",
 		"Sets a path to a dir for a screen dumps",
 	)
+	rootCmd.Flags().StringVar(
+		k9sFlags.SuggestionMode,
+		"suggestion-mode",
+		string(config.DefaultSuggestionMode),
+		"Set autocompletion suggestion mode (PREFIX, LONGEST_PREFIX, LONGEST_SUBSTRING)",
+	)
 	rootCmd.Flags()
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -261,7 +261,7 @@ func initK9sFlags() {
 		k9sFlags.SuggestionMode,
 		"suggestion-mode",
 		string(config.DefaultSuggestionMode),
-		"Set autocompletion suggestion mode (PREFIX, LONGEST_PREFIX, LONGEST_SUBSTRING)",
+		"Set autocompletion suggestion mode (PREFIX, FUZZY, LONGEST_PREFIX, LONGEST_SUBSTRING)",
 	)
 	rootCmd.Flags()
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fvbommel/sortorder v1.1.0
 	github.com/go-errors/errors v1.5.1
 	github.com/itchyny/gojq v0.12.17
+	github.com/lithammer/fuzzysearch v1.1.8
 	github.com/lmittmann/tint v1.0.7
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-runewidth v0.0.16

--- a/go.sum
+++ b/go.sum
@@ -1372,6 +1372,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
+github.com/lithammer/fuzzysearch v1.1.8 h1:/HIuJnjHuXS8bKaiTMeeDlW2/AyIWk2brx1V8LFgLN4=
+github.com/lithammer/fuzzysearch v1.1.8/go.mod h1:IdqeyBClc3FFqSzYq/MXESsS4S0FsZ5ajtkr5xPLts4=
 github.com/lmittmann/tint v1.0.7 h1:D/0OqWZ0YOGZ6AyC+5Y2kD8PBEzBk6rFHVSfOqCkF9Y=
 github.com/lmittmann/tint v1.0.7/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
 github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -12,39 +12,44 @@ const (
 
 	// DefaultCommand represents the default command to run.
 	DefaultCommand = ""
+
+	// DefaultSuggestionMode represents the default suggestion mode to use, which is `PREFIX`.
+	DefaultSuggestionMode = SuggestionModePrefix
 )
 
 // Flags represents K9s configuration flags.
 type Flags struct {
-	RefreshRate   *float32
-	LogLevel      *string
-	LogFile       *string
-	Headless      *bool
-	Logoless      *bool
-	Command       *string
-	AllNamespaces *bool
-	ReadOnly      *bool
-	Write         *bool
-	Crumbsless    *bool
-	Splashless    *bool
-	ScreenDumpDir *string
+	RefreshRate    *float32
+	LogLevel       *string
+	LogFile        *string
+	Headless       *bool
+	Logoless       *bool
+	Command        *string
+	AllNamespaces  *bool
+	ReadOnly       *bool
+	Write          *bool
+	Crumbsless     *bool
+	Splashless     *bool
+	ScreenDumpDir  *string
+	SuggestionMode *string
 }
 
 // NewFlags returns new configuration flags.
 func NewFlags() *Flags {
 	return &Flags{
-		RefreshRate:   float32Ptr(DefaultRefreshRate),
-		LogLevel:      strPtr(DefaultLogLevel),
-		LogFile:       strPtr(AppLogFile),
-		Headless:      boolPtr(false),
-		Logoless:      boolPtr(false),
-		Command:       strPtr(DefaultCommand),
-		AllNamespaces: boolPtr(false),
-		ReadOnly:      boolPtr(false),
-		Write:         boolPtr(false),
-		Crumbsless:    boolPtr(false),
-		Splashless:    boolPtr(false),
-		ScreenDumpDir: strPtr(AppDumpsDir),
+		RefreshRate:    float32Ptr(DefaultRefreshRate),
+		LogLevel:       strPtr(DefaultLogLevel),
+		LogFile:        strPtr(AppLogFile),
+		Headless:       boolPtr(false),
+		Logoless:       boolPtr(false),
+		Command:        strPtr(DefaultCommand),
+		AllNamespaces:  boolPtr(false),
+		ReadOnly:       boolPtr(false),
+		Write:          boolPtr(false),
+		Crumbsless:     boolPtr(false),
+		Splashless:     boolPtr(false),
+		ScreenDumpDir:  strPtr(AppDumpsDir),
+		SuggestionMode: strPtr(string(DefaultSuggestionMode)),
 	}
 }
 

--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -29,6 +29,7 @@
         "disablePodCounting": { "type": "boolean" },
         "defaultView": { "type": "string" },
         "portForwardAddress": { "type": "string" },
+        "suggestionMode": { "type": "string" },
         "ui": {
           "type": "object",
           "additionalProperties": false,

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -50,6 +50,7 @@ type K9s struct {
 	Logger              Logger     `json:"logger" yaml:"logger"`
 	Thresholds          Threshold  `json:"thresholds" yaml:"thresholds"`
 	DefaultView         string     `json:"defaultView" yaml:"defaultView"`
+	SuggestionMode      string     `json:"suggestionMode" yaml:"suggestionMode,omitempty"`
 	manualRefreshRate   float32
 	manualReadOnly      *bool
 	manualCommand       *string
@@ -77,6 +78,7 @@ func NewK9s(conn client.Connection, ks data.KubeSettings) *K9s {
 		PortForwardAddress: defaultPFAddress(),
 		ShellPod:           NewShellPod(),
 		ImageScans:         NewImageScans(),
+		SuggestionMode:     string(DefaultSuggestionMode),
 		dir:                data.NewDir(AppContextsDir),
 		conn:               conn,
 		ks:                 ks,
@@ -152,6 +154,7 @@ func (k *K9s) Merge(k1 *K9s) {
 	if k1.Thresholds != nil {
 		k.Thresholds = k1.Thresholds
 	}
+	k.SuggestionMode = k1.SuggestionMode
 }
 
 // AppScreenDumpDir fetch screen dumps dir.
@@ -332,6 +335,9 @@ func (k *K9s) Override(k9sFlags *Flags) {
 	}
 	k.manualCommand = k9sFlags.Command
 	k.manualScreenDumpDir = k9sFlags.ScreenDumpDir
+	if k9sFlags.SuggestionMode != nil && *k9sFlags.SuggestionMode != string(DefaultSuggestionMode) {
+		k.SuggestionMode = *k9sFlags.SuggestionMode
+	}
 }
 
 // IsHeadless returns headless setting.

--- a/internal/config/testdata/configs/default.yaml
+++ b/internal/config/testdata/configs/default.yaml
@@ -46,3 +46,4 @@ k9s:
       critical: 90
       warn: 70
   defaultView: ""
+  suggestionMode: PREFIX

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -18,6 +18,7 @@ type SuggestionMode string
 
 const (
 	SuggestionModePrefix           SuggestionMode = "PREFIX"
+	SuggestionModeFuzzy            SuggestionMode = "FUZZY"
 	SuggestionModeLongestPrefix    SuggestionMode = "LONGEST_PREFIX"
 	SuggestionModeLongestSubstring SuggestionMode = "LONGEST_SUBSTRING"
 )

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -14,6 +14,14 @@ const (
 	MEM = "memory"
 )
 
+type SuggestionMode string
+
+const (
+	SuggestionModePrefix           SuggestionMode = "PREFIX"
+	SuggestionModeLongestPrefix    SuggestionMode = "LONGEST_PREFIX"
+	SuggestionModeLongestSubstring SuggestionMode = "LONGEST_SUBSTRING"
+)
+
 // UI tracks ui specific configs.
 type UI struct {
 	// EnableMouse toggles mouse support.

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -234,6 +234,37 @@ func (p *Prompt) update(text, suggestion string) {
 	p.write(text, suggestion)
 }
 
+func (p *Prompt) getSuggestionCharIdxRanges(lastWord, suggest string) [][]int {
+	switch p.app.Config.K9s.SuggestionMode {
+	case string(config.SuggestionModeFuzzy):
+		idxRanges := make([][]int, 0, len(lastWord))
+		latestIdx := -1
+		for _, char := range lastWord {
+			// Find the character within the suggest, but only starting after where the last character was found.
+			foundIdx := strings.IndexRune(suggest[latestIdx+1:], char)
+			// This should never happen if we reached here, but just guarding.
+			if foundIdx == -1 {
+				return nil
+			}
+			// Offset by the cutoff length of the string from previous iterations.
+			foundIdx += latestIdx + 1
+			idxRanges = append(idxRanges, []int{foundIdx, foundIdx + 1})
+			latestIdx = foundIdx
+		}
+		return idxRanges
+	default:
+		// Get indices of where the last word of text lie within the suggestion.
+		// Could be anywhere if LONGEST_SUBSTRING mode suggestion is used.
+		// Otherwise at 0 for PREFIX/LONGEST_PREFIX suggestion modes.
+		startIdx := strings.Index(suggest, lastWord)
+		endIdx := startIdx + len(lastWord)
+		if startIdx == -1 {
+			return nil
+		}
+		return [][]int{{startIdx, endIdx}}
+	}
+}
+
 func (p *Prompt) write(text, suggest string) {
 	p.mx.Lock()
 	defer p.mx.Unlock()
@@ -250,20 +281,18 @@ func (p *Prompt) write(text, suggest string) {
 			written = strings.Join(words[0:len(words)-1], " ") + " "
 			lastWord := words[len(words)-1]
 
-			// Get indices of where the last word of text lie within the suggestion.
-			// Could be anywhere if LONGEST_SUBSTRING mode suggestion is used.
-			// Otherwise at 0 for PREFIX/LONGEST_PREFIX suggestion modes.
-			startIdx := strings.Index(suggest, lastWord)
-			endIdx := startIdx + len(lastWord)
-
-			if startIdx != -1 {
-				written += fmt.Sprintf("[%s::-]%s[%s::-]%s[%s::-]%s",
-					p.styles.Prompt().SuggestColor, suggest[0:startIdx],
-					p.styles.Prompt().FgColor, suggest[startIdx:endIdx],
-					p.styles.Prompt().SuggestColor, suggest[endIdx:],
-				)
+			if idxRanges := p.getSuggestionCharIdxRanges(lastWord, suggest); idxRanges != nil {
+				written += fmt.Sprintf("[%s::-]%s", p.styles.Prompt().SuggestColor, suggest[0:idxRanges[0][0]])
+				for i, idxRange := range idxRanges {
+					if i > 0 {
+						written += fmt.Sprintf("[%s::-]%s", p.styles.Prompt().SuggestColor, suggest[idxRanges[i-1][1]:idxRanges[i][0]])
+					}
+					written += fmt.Sprintf("[%s::-]%s", p.styles.Prompt().FgColor, suggest[idxRange[0]:idxRange[1]])
+				}
+				written += fmt.Sprintf("[%s::-]%s", p.styles.Prompt().SuggestColor, suggest[idxRanges[len(idxRanges)-1][1]:])
 			} else {
-				// `lastWord` isn't found within suggest. Just append `lastWord` again.
+				// `lastWord` isn't found within suggest as per the configured
+				// `SuggestionMode`. Just append `lastWord` again.
 				written += lastWord
 			}
 

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -221,8 +221,9 @@ func (a *App) suggestCommand() model.SuggestionFunc {
 			entries = append(entries, k)
 		}
 
-		// PREFIX suggestion mode:, all weights are set to 0, sort strings normally.
-		// LONGEST_PREFIX,LONGEST_SUBSTRING suggestion modes: sort based on weights and fallback to string sorting for equal weights.
+		// PREFIX suggestion mode: all weights are set to 0, sort strings normally.
+		// FUZZY,LONGEST_PREFIX,LONGEST_SUBSTRING suggestion modes: sort based on weights
+		// and fallback to string sorting for equal weights.
 		sort.SliceStable(entries, func(i, j int) bool {
 			if entriesMap[entries[i]] == entriesMap[entries[j]] {
 				return entries[i] < entries[j]

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -198,10 +198,12 @@ func (a *App) suggestCommand() model.SuggestionFunc {
 			return a.cmdHistory.List()
 		}
 
+		entriesMap := make(map[string]float64)
+
 		ls := strings.ToLower(s)
 		for alias := range maps.Keys(a.command.alias.Alias) {
-			if suggest, ok := cmd.ShouldAddSuggest(ls, alias); ok {
-				entries = append(entries, suggest)
+			if weight := cmd.ShouldAddSuggest(a.Config.K9s.SuggestionMode, ls, alias); weight != -1 {
+				entriesMap[alias] = weight
 			}
 		}
 
@@ -209,11 +211,25 @@ func (a *App) suggestCommand() model.SuggestionFunc {
 		if err != nil {
 			slog.Error("Failed to obtain list of namespaces", slogs.Error, err)
 		}
-		entries = append(entries, cmd.SuggestSubCommand(s, namespaceNames, contextNames)...)
-		if len(entries) == 0 {
+		maps.Copy(entriesMap, cmd.SuggestSubCommand(a.Config.K9s.SuggestionMode, s, namespaceNames, contextNames))
+		if len(entriesMap) == 0 {
 			return nil
 		}
-		entries.Sort()
+
+		entries = make([]string, 0, len(entriesMap))
+		for k := range entriesMap {
+			entries = append(entries, k)
+		}
+
+		// PREFIX suggestion mode:, all weights are set to 0, sort strings normally.
+		// LONGEST_PREFIX,LONGEST_SUBSTRING suggestion modes: sort based on weights and fallback to string sorting for equal weights.
+		sort.SliceStable(entries, func(i, j int) bool {
+			if entriesMap[entries[i]] == entriesMap[entries[j]] {
+				return entries[i] < entries[j]
+			}
+			return entriesMap[entries[i]] > entriesMap[entries[j]]
+		})
+
 		return
 	}
 }

--- a/internal/view/cmd/helpers.go
+++ b/internal/view/cmd/helpers.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"slices"
 	"strings"
 
 	"github.com/derailed/k9s/internal/client"
@@ -30,18 +29,32 @@ func ToLabels(s string) map[string]string {
 }
 
 // ShouldAddSuggest checks if a suggestion match the given command.
-func ShouldAddSuggest(command, suggest string) (string, bool) {
-	if command != suggest && strings.HasPrefix(suggest, command) {
-		return strings.TrimPrefix(suggest, command), true
+func ShouldAddSuggest(suggestionMode, command, suggest string) float64 {
+	var searchCondition bool
+	var weight float64 = 0
+
+	switch suggestionMode {
+	case "LONGEST_SUBSTRING":
+		searchCondition = strings.Contains(suggest, command)
+		weight = float64(len(command)) / float64(len(suggest))
+	case "LONGEST_PREFIX":
+		searchCondition = strings.HasPrefix(suggest, command)
+		weight = float64(len(command)) / float64(len(suggest))
+	default:
+		searchCondition = strings.HasPrefix(suggest, command)
 	}
 
-	return "", false
+	if command != suggest && searchCondition {
+		return weight
+	}
+
+	return -1
 }
 
 // SuggestSubCommand suggests namespaces or contexts based on current command.
-func SuggestSubCommand(command string, namespaces client.NamespaceNames, contexts []string) []string {
+func SuggestSubCommand(suggestionMode, command string, namespaces client.NamespaceNames, contexts []string) map[string]float64 {
 	p := NewInterpreter(command)
-	var suggests []string
+	var suggests map[string]float64
 	switch {
 	case p.IsCowCmd(), p.IsHelpCmd(), p.IsAliasCmd(), p.IsBailCmd(), p.IsDirCmd():
 		return nil
@@ -51,18 +64,18 @@ func SuggestSubCommand(command string, namespaces client.NamespaceNames, context
 		if !ok || ns == "" {
 			return nil
 		}
-		suggests = completeNS(ns, namespaces)
+		suggests = completeNS(suggestionMode, ns, namespaces)
 
 	case p.IsContextCmd():
 		n, ok := p.ContextArg()
 		if !ok {
 			return nil
 		}
-		suggests = completeCtx(command, n, contexts)
+		suggests = completeCtx(suggestionMode, command, n, contexts)
 
 	case p.HasNS():
 		if n, ok := p.HasContext(); ok {
-			suggests = completeCtx(command, n, contexts)
+			suggests = completeCtx(suggestionMode, command, n, contexts)
 		}
 		if len(suggests) > 0 {
 			break
@@ -72,43 +85,50 @@ func SuggestSubCommand(command string, namespaces client.NamespaceNames, context
 		if !ok {
 			return nil
 		}
-		suggests = completeNS(ns, namespaces)
+		suggests = completeNS(suggestionMode, ns, namespaces)
 
 	default:
 		if n, ok := p.HasContext(); ok {
-			suggests = completeCtx(command, n, contexts)
+			suggests = completeCtx(suggestionMode, command, n, contexts)
 		}
 	}
-	slices.Sort(suggests)
 
 	return suggests
 }
 
-func completeNS(s string, nn client.NamespaceNames) []string {
+func completeNS(suggestionMode, s string, nn client.NamespaceNames) map[string]float64 {
 	s = strings.ToLower(s)
-	var suggests []string
-	if suggest, ok := ShouldAddSuggest(s, client.NamespaceAll); ok {
-		suggests = append(suggests, suggest)
+	suggests := make(map[string]float64)
+	if weight := ShouldAddSuggest(suggestionMode, s, client.NamespaceAll); weight != -1 {
+		suggests[client.NamespaceAll] = weight
 	}
 	for ns := range nn {
-		if suggest, ok := ShouldAddSuggest(s, ns); ok {
-			suggests = append(suggests, suggest)
+		if weight := ShouldAddSuggest(suggestionMode, s, ns); weight != -1 {
+			suggests[ns] = weight
 		}
+	}
+
+	if len(suggests) == 0 {
+		return nil
 	}
 
 	return suggests
 }
 
-func completeCtx(command, s string, contexts []string) []string {
-	var suggests []string
+func completeCtx(suggestionMode, command, s string, contexts []string) map[string]float64 {
+	suggests := make(map[string]float64)
 	for _, ctxName := range contexts {
-		if suggest, ok := ShouldAddSuggest(s, ctxName); ok {
+		if weight := ShouldAddSuggest(suggestionMode, s, ctxName); weight != -1 {
 			if s == "" && !strings.HasSuffix(command, " ") {
-				suggests = append(suggests, " "+suggest)
+				suggests[" "+ctxName] = weight
 				continue
 			}
-			suggests = append(suggests, suggest)
+			suggests[ctxName] = weight
 		}
+	}
+
+	if len(suggests) == 0 {
+		return nil
 	}
 
 	return suggests

--- a/internal/view/cmd/helpers_test.go
+++ b/internal/view/cmd/helpers_test.go
@@ -58,7 +58,7 @@ func Test_toLabels(t *testing.T) {
 	}
 }
 
-func TestSuggestSubCommand(t *testing.T) {
+func TestSuggestSubCommandPrefix(t *testing.T) {
 	namespaceNames := map[string]struct{}{
 		"kube-system":   {},
 		"kube-public":   {},
@@ -69,26 +69,96 @@ func TestSuggestSubCommand(t *testing.T) {
 
 	tests := []struct {
 		Command     string
-		Suggestions []string
+		Suggestions map[string]float64
 	}{
 		{Command: "q", Suggestions: nil},
 		{Command: "xray  dp", Suggestions: nil},
 		{Command: "help  k", Suggestions: nil},
-		{Command: "ctx p", Suggestions: []string{"re", "rod"}},
-		{Command: "ctx   p", Suggestions: []string{"re", "rod"}},
-		{Command: "ctx pr", Suggestions: []string{"e", "od"}},
-		{Command: "ctx", Suggestions: []string{" develop", " pre", " prod", " test"}},
-		{Command: "ctx ", Suggestions: []string{"develop", "pre", "prod", "test"}},
-		{Command: "context   d", Suggestions: []string{"evelop"}},
-		{Command: "contexts   t", Suggestions: []string{"est"}},
+		{Command: "ctx p", Suggestions: map[string]float64{"pre": 0, "prod": 0}},
+		{Command: "ctx   p", Suggestions: map[string]float64{"pre": 0, "prod": 0}},
+		{Command: "ctx pr", Suggestions: map[string]float64{"pre": 0, "prod": 0}},
+		{Command: "ctx", Suggestions: map[string]float64{" develop": 0, " pre": 0, " prod": 0, " test": 0}},
+		{Command: "ctx ", Suggestions: map[string]float64{"develop": 0, "pre": 0, "prod": 0, "test": 0}},
+		{Command: "context   d", Suggestions: map[string]float64{"develop": 0}},
+		{Command: "contexts   t", Suggestions: map[string]float64{"test": 0}},
 		{Command: "po ", Suggestions: nil},
 		{Command: "po  x", Suggestions: nil},
-		{Command: "po k", Suggestions: []string{"ube-public", "ube-system"}},
-		{Command: "po  kube-", Suggestions: []string{"public", "system"}},
+		{Command: "po k", Suggestions: map[string]float64{"kube-public": 0, "kube-system": 0}},
+		{Command: "po  kube-", Suggestions: map[string]float64{"kube-public": 0, "kube-system": 0}},
 	}
 
 	for _, tt := range tests {
-		got := SuggestSubCommand(tt.Command, namespaceNames, contextNames)
+		got := SuggestSubCommand("PREFIX", tt.Command, namespaceNames, contextNames)
+		assert.Equal(t, tt.Suggestions, got)
+	}
+}
+
+func TestSuggestSubCommandLongestPrefix(t *testing.T) {
+	namespaceNames := map[string]struct{}{
+		"kube-system":   {},
+		"kube-public":   {},
+		"default":       {},
+		"nginx-ingress": {},
+	}
+	contextNames := []string{"develop", "test", "pre", "prod"}
+
+	tests := []struct {
+		Command     string
+		Suggestions map[string]float64
+	}{
+		{Command: "q", Suggestions: nil},
+		{Command: "xray  dp", Suggestions: nil},
+		{Command: "help  k", Suggestions: nil},
+		{Command: "ctx p", Suggestions: map[string]float64{"pre": 1.0 / 3.0, "prod": 1.0 / 4.0}},
+		{Command: "ctx   p", Suggestions: map[string]float64{"pre": 1.0 / 3.0, "prod": 1.0 / 4.0}},
+		{Command: "ctx pr", Suggestions: map[string]float64{"pre": 2.0 / 3.0, "prod": 2.0 / 4.0}},
+		{Command: "ctx", Suggestions: map[string]float64{" develop": 0, " pre": 0, " prod": 0, " test": 0}},
+		{Command: "ctx ", Suggestions: map[string]float64{"develop": 0, "pre": 0, "prod": 0, "test": 0}},
+		{Command: "context   d", Suggestions: map[string]float64{"develop": 1.0 / 7.0}},
+		{Command: "contexts   t", Suggestions: map[string]float64{"test": 1.0 / 4.0}},
+		{Command: "po ", Suggestions: nil},
+		{Command: "po  x", Suggestions: nil},
+		{Command: "po k", Suggestions: map[string]float64{"kube-public": 1.0 / 11.0, "kube-system": 1.0 / 11.0}},
+		{Command: "po  kube-", Suggestions: map[string]float64{"kube-public": 5.0 / 11.0, "kube-system": 5.0 / 11.0}},
+	}
+
+	for _, tt := range tests {
+		got := SuggestSubCommand("LONGEST_PREFIX", tt.Command, namespaceNames, contextNames)
+		assert.Equal(t, tt.Suggestions, got)
+	}
+}
+
+func TestSuggestSubCommandLongestSubstring(t *testing.T) {
+	namespaceNames := map[string]struct{}{
+		"kube-system":   {},
+		"kube-public":   {},
+		"default":       {},
+		"nginx-ingress": {},
+	}
+	contextNames := []string{"develop", "test", "pre", "prod"}
+
+	tests := []struct {
+		Command     string
+		Suggestions map[string]float64
+	}{
+		{Command: "q", Suggestions: nil},
+		{Command: "xray  dp", Suggestions: nil},
+		{Command: "help  k", Suggestions: nil},
+		{Command: "ctx p", Suggestions: map[string]float64{"develop": 1.0 / 7.0, "pre": 1.0 / 3.0, "prod": 1.0 / 4.0}},
+		{Command: "ctx   p", Suggestions: map[string]float64{"develop": 1.0 / 7.0, "pre": 1.0 / 3.0, "prod": 1.0 / 4.0}},
+		{Command: "ctx pr", Suggestions: map[string]float64{"pre": 2.0 / 3.0, "prod": 2.0 / 4.0}},
+		{Command: "ctx", Suggestions: map[string]float64{" develop": 0, " pre": 0, " prod": 0, " test": 0}},
+		{Command: "ctx ", Suggestions: map[string]float64{"develop": 0, "pre": 0, "prod": 0, "test": 0}},
+		{Command: "context   d", Suggestions: map[string]float64{"develop": 1.0 / 7.0, "prod": 1.0 / 4.0}},
+		{Command: "contexts   t", Suggestions: map[string]float64{"test": 1.0 / 4.0}},
+		{Command: "po ", Suggestions: nil},
+		{Command: "po  x", Suggestions: map[string]float64{"nginx-ingress": 1.0 / 13.0}},
+		{Command: "po k", Suggestions: map[string]float64{"kube-public": 1.0 / 11.0, "kube-system": 1.0 / 11.0}},
+		{Command: "po  kube-", Suggestions: map[string]float64{"kube-public": 5.0 / 11.0, "kube-system": 5.0 / 11.0}},
+	}
+
+	for _, tt := range tests {
+		got := SuggestSubCommand("LONGEST_SUBSTRING", tt.Command, namespaceNames, contextNames)
 		assert.Equal(t, tt.Suggestions, got)
 	}
 }


### PR DESCRIPTION
This adds other modes of suggestion making and makes it configurable:

* `LONGEST_SUBSTRING` for (longest) substring matching.

  This is similar to, for example, the way ctrl+r in bash works, and can be very convenient for people that have naming convention for resources where they share certain prefixes.

  Simple example: for the two namespaces `kube-system` `kube-public`, to select the latter, with prefix you'd have to write `kube-p`, with substring you can just write `pub` or `-pu` (depending if other namespaces have similar substring matches).

   Two example screenshots:

     * Text typed is "pods -system", suggestion is "kube-system":

     <img width="705" height="140" alt="Screenshot 2025-09-02 at 1 07 21 PM" src="https://github.com/user-attachments/assets/a83f658a-cda4-4c1b-a0c7-8fdbfbbd41ce" />

     * Text typed is "moni", suggestion is "podmonitor":
     <img width="661" height="140" alt="Screenshot 2025-09-02 at 1 09 08 PM" src="https://github.com/user-attachments/assets/7afc5b52-95b0-42e7-9c49-b874b8a18448" />

* `FUZZY` for fuzzy matching. This uses [lithammer/fuzzysearch](https://github.com/lithammer/fuzzysearch) which considers only character additions in computing the Levenshtein distance. To me this seems good enough in general, and especially good for: less computational overhead, and it fits nicely within how we render the suggestion text across all modes. So we don't have to render a list of possible suggestions, just the highest one in weight (less distance) with the typed characters highlighted within it.

   Two example screenshots:

     * Text typed is "ago", suggestion is "argo-rollouts":
     <img width="812" height="145" alt="Screenshot 2025-09-09 at 1 44 17 AM" src="https://github.com/user-attachments/assets/2d3371c0-d602-40c5-aa56-7ac90fe02ba9" />

     * Text typed is "dly", suggestion is "deploy" (then "deployment", "deployments", and others):
     <img width="809" height="145" alt="Screenshot 2025-09-09 at 1 46 14 AM" src="https://github.com/user-attachments/assets/6a292031-be22-4dc6-89cf-ddba5df86083" />


* `LONGEST_PREFIX` is added just for consistency and differs from `PREFIX` in the sorting. The first sorts two suggestions based on which constitutes a bigger part of the typed text, and if both are equal, they are sorted alphabetically. The second just directly sorts alphabetically, which is the current behavior.

* `PREFIX` is the current behavior, and is kept as the default one.

This is controlled via configuration. Commandline flag `--suggestion-mode` and config file `suggestionMode` control that. The default is left to be the current behavior: prefix matching.

We can later extend this to have another mode based on historical usage.

---

Also a side note for the sake of being complete: I've adjusted the condition in `ShouldAddSuggest` to remove the part `command != suggest`.
This may have worked well with the original prefix mode, but it'll be confusing if a user types `ns` for example in `FUZZY` and gets "nodes" as a suggestion (with no indication that "ns" is by itself a valid thing). See the screenshot below for how it'd have looked like:
<img width="818" height="136" alt="Screenshot 2025-09-09 at 2 19 48 AM" src="https://github.com/user-attachments/assets/72442cdd-9bc2-4724-85c4-48505c117493" />

