### PR TITLE
Fix: plugin external-secrets.yaml context

### DIFF
--- a/plugins/external-secrets.yaml
+++ b/plugins/external-secrets.yaml
@@ -9,7 +9,7 @@ plugins:
     background: false
     args:
       - -c
-      - "kubectl annotate externalsecrets.external-secrets.io -n $NAMESPACE $NAME force-sync=$(date +%s) --overwrite"
+      - "kubectl annotate externalsecrets.external-secrets.io --context $CONTEXT -n $NAMESPACE $NAME force-sync=$(date +%s) --overwrite"
   refresh-push-secrets:
     shortCut: Shift-R
     confirm: false
@@ -20,4 +20,4 @@ plugins:
     background: false
     args:
       - -c
-      - "kubectl annotate pushsecrets.external-secrets.io -n $NAMESPACE $NAME force-sync=$(date +%s) --overwrite"
+      - "kubectl annotate pushsecrets.external-secrets.io --context $CONTEXT -n $NAMESPACE $NAME force-sync=$(date +%s) --overwrite"


### PR DESCRIPTION
- Fix context handling in external-secrets.yaml plugin when context differs between bash and k9s