### PR TITLE
(Suggestion) Show containers picker on shell action even if default-container is specified

### DIFF
--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -372,11 +372,6 @@ func containerShellIn(a *App, comp model.Component, path, co string) error {
 	if err != nil {
 		return err
 	}
-	if dco, ok := dao.GetDefaultContainer(&pod.ObjectMeta, &pod.Spec); ok {
-		resumeShellIn(a, comp, path, dco)
-		return nil
-	}
-
 	cc := fetchContainers(&pod.ObjectMeta, &pod.Spec, false)
 	if len(cc) == 1 {
 		resumeShellIn(a, comp, path, cc[0])


### PR DESCRIPTION
Currently, if we start pods with a `default-container` configured, pressing the `s` key to open a shell session will automatically connect to the default container **without showing the container picker**.
This behavior is inconsistent with the `a` (attach) key, which does present a container picker when multiple containers exist.

example:
```yaml
spec:
  template:
    metadata:
      annotations:
        kubectl.kubernetes.io/default-container: nginx
```

**AS-IS**

* Pressing `s` always opens a shell in the default container (if configured).
* There is **no way to open a shell in a non-default container** from the UI.

**TO-BE**

* Pressing `s` invokes the container picker when multiple containers are available.
  The default container is shown at the top of the list.

