### PR TITLE
feat: add native support for pod eviction

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ K9s uses aliases to navigate most K8s resources.
 | To view all saved resources                                                     | `:`screendump or sd⏎          |                                                                        |
 | To delete a resource (TAB and ENTER to confirm)                                 | `ctrl-d`                      |                                                                        |
 | To kill a resource (no confirmation dialog, equivalent to kubectl delete --now) | `ctrl-k`                      |                                                                        |
+| To evict a pod (no confirmation dialog)                                         | `ctrl-v`                      |                                                                        |
 | Launch pulses view                                                              | `:`pulses or pu⏎              |                                                                        |
 | Launch XRay view                                                                | `:`xray RESOURCE [NAMESPACE]⏎ | RESOURCE can be one of po, svc, dp, rs, sts, ds, NAMESPACE is optional |
 | Launch Popeye view                                                              | `:`popeye or pop⏎             | See [popeye](#popeye)                                                  |

--- a/internal/dao/pod.go
+++ b/internal/dao/pod.go
@@ -21,6 +21,7 @@ import (
 	"github.com/derailed/k9s/internal/watch"
 	"github.com/derailed/tview"
 	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -74,6 +75,35 @@ func (p *Pod) shouldStopRetrying(path string) bool {
 	}
 
 	return false
+}
+
+func (p *Pod) Evict(ctx context.Context, path string) error {
+	ns, n := client.Namespaced(path)
+	auth, err := p.Client().CanI(ns, client.NewGVR(client.PodGVR.String()+":eviction"), n, []string{client.CreateVerb})
+	if err != nil {
+		return err
+	}
+
+	if !auth {
+		return fmt.Errorf("user is not authorized to evict %s", path)
+	}
+
+	dial, err := p.Client().Dial()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.Client().Config().CallTimeout())
+	defer cancel()
+
+	err = dial.CoreV1().Pods(ns).EvictV1(ctx, &policyv1.Eviction{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      n,
+			Namespace: ns,
+		},
+	})
+
+	return err
 }
 
 // Get returns a resource instance if found, else an error.

--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -136,6 +136,12 @@ type Nuker interface {
 	Delete(context.Context, string, *metav1.DeletionPropagation, Grace) error
 }
 
+// Evictable represents an evictable resource.
+type Evictable interface {
+	// Evict evicts a resource (pod) from the node it's running on.
+	Evict(context.Context, string) error
+}
+
 // Switchable represents a switchable resource.
 type Switchable interface {
 	// Switch changes the active context.

--- a/internal/view/help_test.go
+++ b/internal/view/help_test.go
@@ -25,7 +25,7 @@ func TestHelp(t *testing.T) {
 	v := view.NewHelp(app)
 
 	require.NoError(t, v.Init(ctx))
-	assert.Equal(t, 29, v.GetRowCount())
+	assert.Equal(t, 30, v.GetRowCount())
 	assert.Equal(t, 8, v.GetColumnCount())
 	assert.Equal(t, "<a>", strings.TrimSpace(v.GetCell(1, 0).Text))
 	assert.Equal(t, "Attach", strings.TrimSpace(v.GetCell(1, 1).Text))

--- a/internal/view/pod_test.go
+++ b/internal/view/pod_test.go
@@ -20,7 +20,7 @@ func TestPodNew(t *testing.T) {
 
 	require.NoError(t, po.Init(makeCtx(t)))
 	assert.Equal(t, "Pods", po.Name())
-	assert.Len(t, po.Hints(), 28)
+	assert.Len(t, po.Hints(), 29)
 }
 
 // Helpers...


### PR DESCRIPTION
This adds a new key binding `Ctrl+v` for pod eviction. I think it's useful to have that functionality as a form of less dangerous deletion in restricted environments.

There is no kubectl command for it, but there are some plugins arounds such as: (https://github.com/rajatjindal/kubectl-evict-pod and https://github.com/ueokande/kubectl-evict). Using one of these kubectl plugins within a k9s binding plugin however won't make multi-selection available for eviction, and the user will be restricted to evict pod one by one.

Since this is a somewhat safe operation, I've opted not to have a confirmation dialog for it similar to kill. But I'm open to having it.