### PR TITLE
fix: consider readinessGates + ready condition in diagnose

### DIFF
--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -165,7 +165,6 @@ func (p *Pod) defaultRow(pwm *PodWithMetrics, row *model1.Row) error {
 	iReady, iTerminated, iRestarts := p.initContainerStats(spec.InitContainers, st.InitContainerStatuses)
 	cReady += iReady
 	allCounts := len(spec.Containers) + iTerminated
-
 	rgr, rgt := p.readinessGateStats(spec, &st)
 	ready := hasPodReadyCondition(st.Conditions)
 	

--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -167,7 +167,7 @@ func (p *Pod) defaultRow(pwm *PodWithMetrics, row *model1.Row) error {
 	allCounts := len(spec.Containers) + iTerminated
 	rgr, rgt := p.readinessGateStats(spec, &st)
 	ready := hasPodReadyCondition(st.Conditions)
-	
+
 	var ccmx []mv1beta1.ContainerMetrics
 	if pwm.MX != nil {
 		ccmx = pwm.MX.Containers

--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -166,6 +166,9 @@ func (p *Pod) defaultRow(pwm *PodWithMetrics, row *model1.Row) error {
 	cReady += iReady
 	allCounts := len(spec.Containers) + iTerminated
 
+	rgt, rgr := p.readinessGateStats(spec, &st)
+	ready := hasPodReadyCondition(st.Conditions)
+	
 	var ccmx []mv1beta1.ContainerMetrics
 	if pwm.MX != nil {
 		ccmx = pwm.MX.Containers
@@ -201,7 +204,7 @@ func (p *Pod) defaultRow(pwm *PodWithMetrics, row *model1.Row) error {
 		asReadinessGate(spec, &st),
 		p.mapQOS(st.QOSClass),
 		mapToStr(pwm.Raw.GetLabels()),
-		AsStatus(p.diagnose(phase, cReady, allCounts)),
+		AsStatus(p.diagnose(phase, cReady, allCounts, ready, rgr, rgt)),
 		ToAge(pwm.Raw.GetCreationTimestamp()),
 	}
 
@@ -234,15 +237,24 @@ func (p *Pod) Healthy(_ context.Context, o any) error {
 	cr += icr
 	ct += ict
 
-	return p.diagnose(phase, cr, ct)
+	ready := hasPodReadyCondition(st.Conditions)
+	rgr, rgt := p.readinessGateStats(spec, &st)
+
+	return p.diagnose(phase, cr, ct, ready, rgr, rgt)
 }
 
-func (*Pod) diagnose(phase string, cr, ct int) error {
+func (*Pod) diagnose(phase string, cr, ct int, ready bool, rgr, rgt int) error {
 	if phase == Completed {
 		return nil
 	}
 	if cr != ct || ct == 0 {
 		return fmt.Errorf("container ready check failed: %d of %d", cr, ct)
+	}
+	if rgt > 0 && rgr != rgt {
+		return fmt.Errorf("readiness gate check failed: %d of %d", rgr, rgt)
+	}
+	if !ready {
+		return fmt.Errorf("pod condition ready is false")
 	}
 	if phase == Terminating {
 		return fmt.Errorf("pod is terminating")
@@ -424,6 +436,20 @@ func (*Pod) initContainerStats(cc []v1.Container, cos []v1.ContainerStatus) (rea
 			ready++
 		}
 		restart += int(cos[i].RestartCount)
+	}
+	return
+}
+
+func (*Pod) readinessGateStats(spec *v1.PodSpec, st *v1.PodStatus) (ready, total int) {
+	total = len(spec.ReadinessGates)
+	for _, readinessGate := range spec.ReadinessGates {
+		for _, condition := range st.Conditions {
+			if condition.Type == readinessGate.ConditionType {
+				if condition.Status == "True" {
+					ready++
+				}
+			}
+		}
 	}
 	return
 }

--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -166,7 +166,7 @@ func (p *Pod) defaultRow(pwm *PodWithMetrics, row *model1.Row) error {
 	cReady += iReady
 	allCounts := len(spec.Containers) + iTerminated
 
-	rgt, rgr := p.readinessGateStats(spec, &st)
+	rgr, rgt := p.readinessGateStats(spec, &st)
 	ready := hasPodReadyCondition(st.Conditions)
 	
 	var ccmx []mv1beta1.ContainerMetrics

--- a/internal/render/pod_int_test.go
+++ b/internal/render/pod_int_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/derailed/k9s/internal/client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	res "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -765,7 +766,7 @@ func Test_diagnose(t *testing.T) {
 			if u.err == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), u.err)
 			}
 		})


### PR DESCRIPTION
Now that readiness gates are supported, those should be considered when displaying a pod healthiness

Additionally consider the pod ready condition status. It should match the && of the containers' ready condition and readiness gates but if a node goes down, the pods ready condition will be updated to false (by the node lifecycle controller) but the container conditions will be left in the state they were before the node went down.