### PR TITLE
feat(plugin): add plugin config setting to forward interrupt signals

### DIFF
--- a/internal/config/json/schemas/plugin-multi.json
+++ b/internal/config/json/schemas/plugin-multi.json
@@ -15,6 +15,7 @@
       },
       "command": { "type": "string" },
       "background": { "type": "boolean" },
+      "forwardInterrupt": { "type": "boolean" },
       "overwriteOutput": { "type": "boolean" },
       "args": {
         "type": "array",

--- a/internal/config/json/schemas/plugin.json
+++ b/internal/config/json/schemas/plugin.json
@@ -15,6 +15,7 @@
       },
       "command": { "type": "string" },
       "background": { "type": "boolean" },
+      "forwardInterrupt": { "type": "boolean" },
       "overwriteOutput": { "type": "boolean" },
       "args": {
         "type": "array",

--- a/internal/config/json/schemas/plugins.json
+++ b/internal/config/json/schemas/plugins.json
@@ -19,6 +19,7 @@
           },
           "command": { "type": "string" },
           "background": { "type": "boolean" },
+          "forwardInterrupt": { "type": "boolean" },
           "overwriteOutput": { "type": "boolean" },
           "args": {
             "type": "array",

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -29,17 +29,18 @@ type Plugins struct {
 
 // Plugin describes a K9s plugin.
 type Plugin struct {
-	Scopes          []string `yaml:"scopes"`
-	Args            []string `yaml:"args"`
-	ShortCut        string   `yaml:"shortCut"`
-	Override        bool     `yaml:"override"`
-	Pipes           []string `yaml:"pipes"`
-	Description     string   `yaml:"description"`
-	Command         string   `yaml:"command"`
-	Confirm         bool     `yaml:"confirm"`
-	Background      bool     `yaml:"background"`
-	Dangerous       bool     `yaml:"dangerous"`
-	OverwriteOutput bool     `yaml:"overwriteOutput"`
+	Scopes           []string `yaml:"scopes"`
+	Args             []string `yaml:"args"`
+	ShortCut         string   `yaml:"shortCut"`
+	Override         bool     `yaml:"override"`
+	Pipes            []string `yaml:"pipes"`
+	Description      string   `yaml:"description"`
+	Command          string   `yaml:"command"`
+	Confirm          bool     `yaml:"confirm"`
+	ForwardInterrupt bool     `yaml:"forwardInterrupt"`
+	Background       bool     `yaml:"background"`
+	Dangerous        bool     `yaml:"dangerous"`
+	OverwriteOutput  bool     `yaml:"overwriteOutput"`
 }
 
 func (p Plugin) String() string {

--- a/internal/view/actions.go
+++ b/internal/view/actions.go
@@ -190,10 +190,11 @@ func pluginAction(r Runner, p *config.Plugin) ui.ActionHandler {
 
 		cb := func() {
 			opts := shellOpts{
-				binary:     p.Command,
-				background: p.Background,
-				pipes:      p.Pipes,
-				args:       args,
+				binary:           p.Command,
+				background:       p.Background,
+				pipes:            p.Pipes,
+				args:             args,
+				forwardInterrupt: p.ForwardInterrupt,
 			}
 			suspend, errChan, statusChan := run(r.App(), &opts)
 			if !suspend {


### PR DESCRIPTION
The following adds a plugin config setting that allows plugins to define that they would like to receive the Interrupt signal. This can be usefull in cases where a plugin starts a shell (bash, fish, ...) and rather want's to handle the interrupt instead of having k9s exit the process.