### PR TITLE
feat: add kubectl-evict-pod plugin for safe pod eviction

### DIFF
--- a/plugins/evict-pod.yaml
+++ b/plugins/evict-pod.yaml
@@ -1,0 +1,22 @@
+plugins:
+  # kubectl-evict-pod by Rajat Jindal
+  # Evict a pod from a node safely, respecting PodDisruptionBudgets.
+  # Source: https://github.com/rajatjindal/kubectl-evict-pod
+  # Install via:
+  #   krew: `kubectl krew install evict-pod`
+  evict-pod:
+    shortCut: Shift-E
+    description: Evict pod
+    dangerous: true
+    scopes:
+      - po
+    command: kubectl
+    background: true
+    confirm: false
+    args:
+      - evict-pod
+      - $NAME
+      - --namespace
+      - $NAMESPACE
+      - --context
+      - $CONTEXT


### PR DESCRIPTION
This pull request adds a new plugin configuration for safely evicting pods from nodes, with support for PodDisruptionBudgets. The configuration enables quick access via a keyboard shortcut and is designed to run in the background without confirmation prompts.

**Plugin addition:**

* Added a new `evict-pod` plugin to `plugins/evict-pod.yaml`, providing a shortcut (`Shift-E`) to evict pods using the `kubectl-evict-pod` tool, with options for namespace and context.