### PR TITLE
fix: do not error out of shellIn if OS detection fails

### DIFF
--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -410,7 +410,7 @@ func resumeShellIn(a *App, c model.Component, path, co string) {
 func shellIn(a *App, fqn, co string) error {
 	platform, err := getPodOS(a.factory, fqn)
 	if err != nil {
-		return err
+		slog.Warn("OS detection failed (assuming linux)", slogs.Error, err)
 	}
 
 	args := computeShellArgs(fqn, co, a.Conn().Config().Flags(), platform)

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -411,6 +411,7 @@ func shellIn(a *App, fqn, co string) error {
 	platform, err := getPodOS(a.factory, fqn)
 	if err != nil {
 		slog.Warn("OS detection failed (assuming linux)", slogs.Error, err)
+        platform = "linux"
 	}
 
 	args := computeShellArgs(fqn, co, a.Conn().Config().Flags(), platform)


### PR DESCRIPTION
This patch restores the original behavior that emitted a warning if OS detection failed but would try to shell in anyway.

The detection can fail for multiple reasons:
- Label not applied to pod
- Label not readable (e.g. nodes cannot be listed by normal users on OpenShift)

The new version of the warning also states that it assumes `linux`. Note that this is not a typo, it is to be consistent with how it is written in Go's supported platform list. It can be obtained using `go tool dist list`.

Fixes #3583 