### PR TITLE
Rel v0.50.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME            := k9s
-VERSION         ?= v0.50.12
+VERSION         ?= v0.50.13
 PACKAGE         := github.com/derailed/$(NAME)
 OUTPUT_BIN      ?= execs/${NAME}
 GO_FLAGS        ?=

--- a/change_logs/release_v0.50.13.md
+++ b/change_logs/release_v0.50.13.md
@@ -1,0 +1,32 @@
+<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/k9s.png" align="center" width="800" height="auto"/>
+
+# Release v0.50.13
+
+## Notes
+
+Thank you to all that contributed with flushing out issues and enhancements for K9s!
+I'll try to mark some of these issues as fixed. But if you don't mind grab the latest rev
+and see if we're happier with some of the fixes!
+If you've filed an issue please help me verify and close.
+
+Your support, kindness and awesome suggestions to make K9s better are, as ever, very much noted and appreciated!
+Also big thanks to all that have allocated their own time to help others on both slack and on this repo!!
+
+As you may know, K9s is not pimped out by corps with deep pockets, thus if you feel K9s is helping your Kubernetes journey,
+please consider joining our [sponsorship program](https://github.com/sponsors/derailed) and/or make some noise on social! [@kitesurfer](https://twitter.com/kitesurfer)
+
+On Slack? Please join us [K9slackers](https://join.slack.com/t/k9sers/shared_invite/zt-3360a389v-ElLHrb0Dp1kAXqYUItSAFA)
+
+## Maintenance Release!
+
+## Resolved Issues
+
+* [#3587](https://github.com/derailed/k9s/issues/3587) UI doesn't show any updates when restarting a Deployment
+* [#3585](https://github.com/derailed/k9s/issues/3585) abbreviation sec for secret not working
+* [#3584](https://github.com/derailed/k9s/issues/3584) Show managed fields doesn't show them
+* [#3583](https://github.com/derailed/k9s/issues/3583) Cannot open shell to pods without node read access as of 0.50.12
+* [#3577](https://github.com/derailed/k9s/issues/3577) Log view is broken as of v0.50.10
+* [#3574](https://github.com/derailed/k9s/issues/3574) Aliases for pods with label filters not working
+
+---
+<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/imhotep_logo.png" width="32" height="auto"/> © 2025 Imhotep Software LLC. All materials licensed under [Apache v2.0](http://www.apache.org/licenses/LICENSE-2.0)#

--- a/internal/client/gvr.go
+++ b/internal/client/gvr.go
@@ -88,7 +88,7 @@ func (g *GVR) IsCommand() bool {
 }
 
 func (g *GVR) IsK8sRes() bool {
-	return g != nil && ((strings.Contains(g.raw, "/") && !strings.Contains(g.raw, " /")) || reservedGVRs.Has(g))
+	return g != nil && ((!strings.Contains(g.raw, " ") && strings.Contains(g.raw, "/") && !strings.Contains(g.raw, " /")) || reservedGVRs.Has(g))
 }
 
 // WithSubResource builds a new gvr with a sub resource.

--- a/internal/config/alias.go
+++ b/internal/config/alias.go
@@ -159,10 +159,14 @@ func (a *Aliases) LoadFile(path string) error {
 	}
 
 	a.mx.Lock()
-	defer a.mx.Unlock()
 	if err := yaml.Unmarshal(bb, a); err != nil {
 		return err
 	}
+
+	for k, v := range a.Alias {
+		a.Alias[k] = client.NewGVR(v.String())
+	}
+	defer a.mx.Unlock()
 
 	return nil
 }

--- a/internal/dao/pod.go
+++ b/internal/dao/pod.go
@@ -71,9 +71,9 @@ func (p *Pod) shouldStopRetrying(path string) bool {
 	switch pod.Status.Phase {
 	case v1.PodSucceeded, v1.PodFailed:
 		return true
+	default:
+		return false
 	}
-
-	return false
 }
 
 // Get returns a resource instance if found, else an error.

--- a/internal/render/dp.go
+++ b/internal/render/dp.go
@@ -100,7 +100,7 @@ func (d Deployment) defaultRow(raw *unstructured.Unstructured, r *model1.Row) er
 		strconv.Itoa(int(dp.Status.UpdatedReplicas)),
 		strconv.Itoa(int(dp.Status.AvailableReplicas)),
 		mapToStr(dp.Labels),
-		AsStatus(d.diagnose(desired, dp.Status.AvailableReplicas)),
+		AsStatus(d.diagnose(dp.Status.Replicas, dp.Status.AvailableReplicas)),
 		ToAge(dp.GetCreationTimestamp()),
 	}
 

--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -348,7 +348,7 @@ func sshIn(a *App, fqn, co string) error {
 	cfg := a.Config.K9s.ShellPod
 	platform, err := getPodOS(a.factory, fqn)
 	if err != nil {
-		return fmt.Errorf("os detect failed: %w", err)
+		slog.Warn("os detect failed", slogs.Error, err)
 	}
 
 	args := buildShellArgs("exec", fqn, co, a.Conn().Config().Flags())

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: k9s
 base: core22
-version: 'v0.50.12'
+version: 'v0.50.13'
 summary: K9s is a CLI to view and manage your Kubernetes clusters.
 description: |
   K9s is a CLI to view and manage your Kubernetes clusters. By leveraging a terminal UI, you can easily traverse Kubernetes resources and view the state of your clusters in a single powerful session.


### PR DESCRIPTION
## Resolved Issues

* [#3587](https://github.com/derailed/k9s/issues/3587) UI doesn't show any updates when restarting a Deployment
* [#3585](https://github.com/derailed/k9s/issues/3585) abbreviation sec for secret not working
* [#3584](https://github.com/derailed/k9s/issues/3584) Show managed fields doesn't show them
* [#3583](https://github.com/derailed/k9s/issues/3583) Cannot open shell to pods without node read access as of 0.50.12
* [#3577](https://github.com/derailed/k9s/issues/3577) Log view is broken as of v0.50.10
* [#3574](https://github.com/derailed/k9s/issues/3574) Aliases for pods with label filters not working
