### PR TITLE
refactor: use b.Loop() to simplify the code and improve performance

### DIFF
--- a/internal/client/metrics_test.go
+++ b/internal/client/metrics_test.go
@@ -102,9 +102,8 @@ func BenchmarkPodsMetrics(b *testing.B) {
 	}
 	mmx := make(client.PodsMetrics, 3)
 
-	b.ResetTimer()
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		m.PodsMetrics(&metrics, mmx)
 	}
 }
@@ -204,9 +203,8 @@ func BenchmarkNodesMetrics(b *testing.B) {
 	m := client.NewMetricsServer(nil)
 	mmx := make(client.NodesMetrics)
 
-	b.ResetTimer()
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		m.NodesMetrics(&nodes, &metrics, mmx)
 	}
 }
@@ -288,9 +286,9 @@ func BenchmarkClusterLoad(b *testing.B) {
 
 	m := client.NewMetricsServer(nil)
 	var mx client.ClusterMetrics
-	b.ResetTimer()
+
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		_ = m.ClusterLoad(&nodes, &metrics, &mx)
 	}
 }

--- a/internal/dao/log_item_test.go
+++ b/internal/dao/log_item_test.go
@@ -110,9 +110,8 @@ func BenchmarkLogItemRenderTS(b *testing.B) {
 	i := dao.NewLogItem(s)
 	i.Pod, i.Container = "fred", "blee"
 
-	b.ResetTimer()
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		bb := bytes.NewBuffer(make([]byte, 0, i.Size()))
 		i.Render("yellow", true, bb)
 	}
@@ -123,9 +122,8 @@ func BenchmarkLogItemRenderNoTS(b *testing.B) {
 	i := dao.NewLogItem(s)
 	i.Pod, i.Container = "fred", "blee"
 
-	b.ResetTimer()
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		bb := bytes.NewBuffer(make([]byte, 0, i.Size()))
 		i.Render("yellow", false, bb)
 	}

--- a/internal/model/log_int_test.go
+++ b/internal/model/log_int_test.go
@@ -49,8 +49,8 @@ func BenchmarkUpdateLogs(b *testing.B) {
 	item := dao.NewLogItem([]byte("\033[0;38m2018-12-14T10:36:43.326972-07:00 \033[0;32mblee line"))
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		c <- item
 	}
 	close(c)

--- a/internal/model1/helpers_test.go
+++ b/internal/model1/helpers_test.go
@@ -129,8 +129,8 @@ func BenchmarkDurationToSecond(b *testing.B) {
 	t := "2d22h3m50s"
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		durationToSeconds(t)
 	}
 }

--- a/internal/model1/row_test.go
+++ b/internal/model1/row_test.go
@@ -17,8 +17,8 @@ func BenchmarkRowCustomize(b *testing.B) {
 	row := model1.Row{ID: "fred", Fields: model1.Fields{"f1", "f2", "f3"}}
 	cols := []int{0, 1, 2}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		_ = row.Customize(cols)
 	}
 }

--- a/internal/render/alias_test.go
+++ b/internal/render/alias_test.go
@@ -88,9 +88,8 @@ func BenchmarkAlias(b *testing.B) {
 	}
 	var a render.Alias
 
-	b.ResetTimer()
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		var r model1.Row
 		_ = a.Render(o, "ns-1", &r)
 	}

--- a/internal/render/container_test.go
+++ b/internal/render/container_test.go
@@ -68,8 +68,8 @@ func BenchmarkContainerRender(b *testing.B) {
 	)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		_ = c.Render(cres, "blee", &r)
 	}
 }

--- a/internal/render/dp_test.go
+++ b/internal/render/dp_test.go
@@ -28,9 +28,8 @@ func BenchmarkDpRender(b *testing.B) {
 		o = load(b, "dp")
 	)
 
-	b.ResetTimer()
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		_ = c.Render(o, "", &r)
 	}
 }

--- a/internal/render/helpers_test.go
+++ b/internal/render/helpers_test.go
@@ -330,8 +330,8 @@ func BenchmarkMapToStr(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		mapToStr(ll)
 	}
 }
@@ -371,8 +371,8 @@ func BenchmarkRunesToNum(b *testing.B) {
 	rr := []rune("5465")
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		runesToNum(rr)
 	}
 }
@@ -423,9 +423,9 @@ func TestIntToStr(t *testing.T) {
 
 func BenchmarkIntToStr(b *testing.B) {
 	v := 10
-	b.ResetTimer()
+
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		IntToStr(v)
 	}
 }

--- a/internal/render/node_test.go
+++ b/internal/render/node_test.go
@@ -40,9 +40,8 @@ func BenchmarkNodeRender(b *testing.B) {
 		}
 	)
 
-	b.ResetTimer()
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		_ = no.Render(&pom, "", &r)
 	}
 }

--- a/internal/render/pod_test.go
+++ b/internal/render/pod_test.go
@@ -177,8 +177,8 @@ func BenchmarkPodRender(b *testing.B) {
 	r := model1.NewRow(12)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		_ = po.Render(&pom, "", &r)
 	}
 }

--- a/internal/render/svc_test.go
+++ b/internal/render/svc_test.go
@@ -28,9 +28,8 @@ func BenchmarkSvcRender(b *testing.B) {
 		s   = load(b, "svc")
 	)
 
-	b.ResetTimer()
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		_ = svc.Render(s, "", &r)
 	}
 }

--- a/internal/ui/padding_test.go
+++ b/internal/ui/padding_test.go
@@ -143,8 +143,8 @@ func BenchmarkMaxColumn(b *testing.B) {
 	pads := make(MaxyPad, table.HeaderCount())
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		ComputeMaxColumns(pads, "A", table)
 	}
 }

--- a/internal/view/log_indicator_test.go
+++ b/internal/view/log_indicator_test.go
@@ -39,8 +39,8 @@ func BenchmarkLogIndicatorRefresh(b *testing.B) {
 	v := view.NewLogIndicator(config.NewConfig(nil), defaults, true)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		v.Refresh()
 	}
 }

--- a/internal/view/log_test.go
+++ b/internal/view/log_test.go
@@ -77,8 +77,8 @@ func BenchmarkLogFlush(b *testing.B) {
 	items.Lines(0, false, ll)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		v.Flush(ll)
 	}
 }


### PR DESCRIPTION
These changes use b.Loop() to simplify the code and improve performance

Supported by Go Team, more info: https://go.dev/blog/testing-b-loop

More info can see https://go.dev/issue/73137.

Before this change:

```shell
 go test -run=^$ -bench=. ./internal/view -timeout=1h  
goos: darwin
goarch: arm64
pkg: github.com/derailed/k9s/internal/view
cpu: Apple M4
BenchmarkLogIndicatorRefresh-10    	  737971	      1556 ns/op	    1253 B/op	       6 allocs/op
BenchmarkLogFlush-10               	 2252066	       533.0 ns/op	     318 B/op	       0 allocs/op
PASS
ok  	github.com/derailed/k9s/internal/view	3.757s
```


after:

```shell
 go test -run=^$ -bench=. ./internal/view -timeout=1h  
goos: darwin
goarch: arm64
pkg: github.com/derailed/k9s/internal/view
cpu: Apple M4
BenchmarkLogIndicatorRefresh-10    	  722742	      1552 ns/op	    1252 B/op	       6 allocs/op
BenchmarkLogFlush-10               	 2277140	       525.9 ns/op	     317 B/op	       0 allocs/op
PASS
ok  	github.com/derailed/k9s/internal/view	3.179s

```