### PR TITLE
fix(shell): set linux when OS detection fails

### DIFF
--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -410,7 +410,8 @@ func resumeShellIn(a *App, c model.Component, path, co string) {
 func shellIn(a *App, fqn, co string) error {
 	platform, err := getPodOS(a.factory, fqn)
 	if err != nil {
-		return err
+		slog.Warn("OS detection failed (assuming linux)", slogs.Error, err)
+		platform = "linux"
 	}
 
 	args := computeShellArgs(fqn, co, a.Conn().Config().Flags(), platform)


### PR DESCRIPTION
If getPodOS() blows up, we used to log "assuming linux" and then bail,
so computeShellArgs() got an empty platform.

Now we keep the warning and actually set platform="linux"
(lowercase, same as `go tool dist list`) so shell selection behaves.

Verified: built with `make build` and confirmed the shell selection works
as expected with the linux fallback.

- No behavior change when OS detection succeeds
- No tests added

Fixes #3583
Refs #3588
