### PR TITLE
browser: do not prevent redraw when connection unavailable

### DIFF
--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -330,7 +330,7 @@ func (b *Browser) TableDataChanged(mdata *model1.TableData) {
 	cancel = b.cancelFn
 	b.mx.RUnlock()
 
-	if !b.app.ConOK() || cancel == nil || !b.app.IsRunning() {
+	if cancel == nil || !b.app.IsRunning() {
 		return
 	}
 


### PR DESCRIPTION
tl;dr; This MR makes it that the table redraw is no longer short-circuited when there's no active connection to a k8s cluster.

**Context**

To reproduce: use the `context` switcher is used to select a different cluster/context, without a valid authentication. This will cause the UI to error and show `Dial K8s Toast [1/5]`. 

If then `context` is requested again, we end up with an empty table, which result in an unusable k9s, as there is no way to get an active connection back.