### PR TITLE
bugfix: fix panic in BenchmarkPodRender by using NewPod() constructor

### DIFF
--- a/internal/render/pod_test.go
+++ b/internal/render/pod_test.go
@@ -173,7 +173,7 @@ func BenchmarkPodRender(b *testing.B) {
 		Raw: load(b, "po"),
 		MX:  makePodMX("nginx", "10m", "10Mi"),
 	}
-	var po render.Pod
+	po := render.NewPod()
 	r := model1.NewRow(12)
 
 	b.ReportAllocs()


### PR DESCRIPTION
In `BenchmarkPodRender`, an incorrect initialization method ultimately leads to a panic.


```shell
BenchmarkPodRender-10          	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x1057cfeac]

goroutine 11 [running]:
github.com/derailed/k9s/internal/render.(*Pod).Render(0x14000089e18, {0x1069840c0?, 0x140013ec000?}, {0x4?, 0x140000ad618?}, 0x14000089df0)
	/Users/project/k9s/internal/render/pod.go:140 +0x6c
github.com/derailed/k9s/internal/render_test.BenchmarkPodRender(0x14000d04b08)
	/Users/project/k9s/internal/render/pod_test.go:182 +0x190
testing.(*B).runN(0x14000d04b08, 0x1)
	/usr/local/go/src/testing/benchmark.go:219 +0x184
testing.(*B).run1.func1()
	/usr/local/go/src/testing/benchmark.go:245 +0x4c
created by testing.(*B).run1 in goroutine 1
	/usr/local/go/src/testing/benchmark.go:238 +0x88
exit status 2
FAIL	github.com/derailed/k9s/internal/render	10.459s
FAIL
```



Initialize Pod instance using NewPod() constructor instead of zero-value declaration to ensure the Base field is properly allocated. This prevents a nil pointer dereference when accessing p.specs in the Render method.


After change:
```shell
BenchmarkPodRender-10          	   70501	     16829 ns/op	    9603 B/op	     181 allocs/op
```