### PR TITLE
fix: `debug-container` plugin when KUBECONFIG has multiple files

### DIFF
--- a/plugins/debug-container.yaml
+++ b/plugins/debug-container.yaml
@@ -12,4 +12,4 @@ plugins:
     confirm: true
     args:
       - -c
-      - "kubectl --kubeconfig=$KUBECONFIG debug -it --context $CONTEXT -n=$NAMESPACE $POD --target=$NAME --image=nicolaka/netshoot:v0.13 --share-processes -- bash"
+      - "kubectl debug -it --context $CONTEXT -n=$NAMESPACE $POD --target=$NAME --image=nicolaka/netshoot:v0.14 --profile=sysadmin --share-processes -- bash"


### PR DESCRIPTION
Also,
- bump netshoot image
- add `--profile=sysadmin` to create a privileged pod