### PR TITLE
fix: update busybox image version to 1.37.0 in configuration files

### DIFF
--- a/internal/config/json/testdata/k9s/cool.yaml
+++ b/internal/config/json/testdata/k9s/cool.yaml
@@ -15,7 +15,7 @@ k9s:
   skipLatestRevCheck: false
   disablePodCounting: false
   shellPod:
-    image: busybox:1.35.0
+    image: busybox:1.37.0
     namespace: default
     limits:
       cpu: 100m

--- a/internal/config/json/testdata/k9s/toast.yaml
+++ b/internal/config/json/testdata/k9s/toast.yaml
@@ -8,7 +8,7 @@ k9s:
   skipLatestRevCheck: false
   disablePodCounting: false
   shellPods:
-    image: busybox:1.35.0
+    image: busybox:1.37.0
     namespace: default
     limits:
       cpu: 100m

--- a/internal/config/shell_pod.go
+++ b/internal/config/shell_pod.go
@@ -7,7 +7,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-const defaultDockerShellImage = "busybox:1.35.0"
+const defaultDockerShellImage = "busybox:1.37.0"
 
 // Limits represents resource limits.
 type Limits map[v1.ResourceName]string

--- a/internal/config/testdata/configs/default.yaml
+++ b/internal/config/testdata/configs/default.yaml
@@ -21,7 +21,7 @@ k9s:
   skipLatestRevCheck: false
   disablePodCounting: false
   shellPod:
-    image: busybox:1.35.0
+    image: busybox:1.37.0
     namespace: default
     limits:
       cpu: 100m

--- a/internal/config/testdata/configs/expected.yaml
+++ b/internal/config/testdata/configs/expected.yaml
@@ -22,7 +22,7 @@ k9s:
   skipLatestRevCheck: false
   disablePodCounting: false
   shellPod:
-    image: busybox:1.35.0
+    image: busybox:1.37.0
     namespace: default
     limits:
       cpu: 100m

--- a/internal/config/testdata/configs/k9s.yaml
+++ b/internal/config/testdata/configs/k9s.yaml
@@ -21,7 +21,7 @@ k9s:
   skipLatestRevCheck: false
   disablePodCounting: false
   shellPod:
-    image: busybox:1.35.0
+    image: busybox:1.37.0
     namespace: default
     limits:
       cpu: 100m

--- a/internal/config/testdata/configs/k9s_toast.yaml
+++ b/internal/config/testdata/configs/k9s_toast.yaml
@@ -15,7 +15,7 @@ k9s:
   skipLatestRevCheck: yes
   disablePodCounts: false
   shellPods:
-    image: busybox:1.35.0
+    image: busybox:1.37.0
     namespace: default
     limits:
       cpu: 100m


### PR DESCRIPTION
This pull request updates the default shell pod image version from `busybox:1.35.0` to `busybox:1.37.0` throughout the codebase and test configuration files to ensure consistency and use the latest available image.

Shell pod image version updates:

* Updated the `defaultDockerShellImage` constant in `internal/config/shell_pod.go` to use `busybox:1.37.0` instead of `busybox:1.35.0`.
* Changed the shell pod image version to `busybox:1.37.0` in the following test configuration files:
  * `internal/config/json/testdata/k9s/cool.yaml`
  * `internal/config/json/testdata/k9s/toast.yaml`
  * `internal/config/testdata/configs/default.yaml`
  * `internal/config/testdata/configs/expected.yaml`
  * `internal/config/testdata/configs/k9s.yaml`
  * `internal/config/testdata/configs/k9s_toast.yaml`