### PR TITLE
fix #3601 - fails to modify or delete namespaces using RBAC

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -150,6 +150,10 @@ func (a *APIClient) CanI(ns string, gvr *GVR, name string, verbs []string) (auth
 	if !a.getConnOK() {
 		return false, errors.New("ACCESS -- No API server connection")
 	}
+	if gvr == NsGVR {
+		// The name of the namespace is required to check permissions in some cases
+		ns = name
+	}
 	if IsClusterWide(ns) {
 		ns = BlankNamespace
 	}

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -519,9 +519,6 @@ func editRes(app *App, gvr *client.GVR, path string) error {
 	if client.IsClusterScoped(ns) {
 		ns = client.BlankNamespace
 	}
-	if gvr == client.NsGVR {
-		n = ns
-	}
 	if ok, err := app.Conn().CanI(ns, gvr, n, client.PatchAccess); !ok || err != nil {
 		return fmt.Errorf("current user can't edit resource %s", gvr)
 	}

--- a/internal/watch/factory.go
+++ b/internal/watch/factory.go
@@ -201,11 +201,7 @@ func (f *Factory) isClusterWide() bool {
 
 // CanForResource return an informer is user has access.
 func (f *Factory) CanForResource(ns string, gvr *client.GVR, verbs []string) (informers.GenericInformer, error) {
-	var resName string
-	if gvr == client.NsGVR {
-		resName = ns
-	}
-	auth, err := f.Client().CanI(ns, gvr, resName, verbs)
+	auth, err := f.Client().CanI(ns, gvr, "", verbs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With RBACs provided by @EricPE69 in the issue #3601, it was still not possible to delete/update a namespace on which user had edit and delete permissions.

This PR fixes the issue.