### PR TITLE
feat: add NodeClaim navigation support for Karpenter (#3658)

### DIFF
--- a/internal/client/gvrs.go
+++ b/internal/client/gvrs.go
@@ -71,14 +71,17 @@ var (
 	HmhGVR = NewGVR("helm-history")
 
 	// RBAC...
-	RbacGVR = NewGVR("rbac")
-	PolGVR  = NewGVR("policy")
-	UsrGVR  = NewGVR("users")
-	GrpGVR  = NewGVR("groups")
-	CrGVR   = NewGVR("rbac.authorization.k8s.io/v1/clusterroles")
-	CrbGVR  = NewGVR("rbac.authorization.k8s.io/v1/clusterrolebindings")
-	RoGVR   = NewGVR("rbac.authorization.k8s.io/v1/roles")
-	RobGVR  = NewGVR("rbac.authorization.k8s.io/v1/rolebindings")
+	RbacGVR  = NewGVR("rbac")
+	PolGVR   = NewGVR("policy")
+	UsrGVR   = NewGVR("users")
+	GrpGVR   = NewGVR("groups")
+	CrGVR    = NewGVR("rbac.authorization.k8s.io/v1/clusterroles")
+	CrbGVR   = NewGVR("rbac.authorization.k8s.io/v1/clusterrolebindings")
+	RoGVR    = NewGVR("rbac.authorization.k8s.io/v1/roles")
+	RobGVR   = NewGVR("rbac.authorization.k8s.io/v1/rolebindings")
+
+	// Karpenter...
+	NodeClaimGVR = NewGVR("karpenter.sh/v1/nodeclaims")
 )
 
 var reservedGVRs = sets.New(

--- a/internal/view/nodeclaim.go
+++ b/internal/view/nodeclaim.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"context"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/dao"
+	"github.com/derailed/k9s/internal/ui"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// NodeClaim represents a nodeclaim view.
+type NodeClaim struct {
+	ResourceViewer
+}
+
+// NewNodeClaim returns a new nodeclaim view.
+func NewNodeClaim(gvr *client.GVR) ResourceViewer {
+	n := NodeClaim{
+		ResourceViewer: NewBrowser(gvr),
+	}
+	n.GetTable().SetEnterFn(n.showNode)
+
+	return &n
+}
+
+func (n *NodeClaim) showNode(app *App, _ ui.Tabular, gvr *client.GVR, fqn string) {
+	nodeName, err := n.getNodeName(fqn)
+	if err != nil {
+		app.Flash().Err(err)
+		return
+	}
+	if nodeName == "" {
+		app.Flash().Warn("NodeClaim does not have an associated node")
+		return
+	}
+	app.gotoResource(client.NodeGVR.String(), nodeName, false, true)
+}
+
+func (n *NodeClaim) getNodeName(fqn string) (string, error) {
+	res, err := dao.AccessorFor(n.App().factory, n.GVR())
+	if err != nil {
+		return "", err
+	}
+
+	o, err := res.Get(context.Background(), fqn)
+	if err != nil {
+		return "", err
+	}
+
+	return extractNodeName(o), nil
+}
+
+// extractNodeName extracts the nodeName from a NodeClaim object.
+// NodeClaim is a Karpenter CRD with status.nodeName field.
+func extractNodeName(obj interface{}) string {
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return ""
+	}
+
+	// Get status.nodeName
+	status, ok := u.Object["status"]
+	if !ok {
+		return ""
+	}
+
+	statusMap, ok := status.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	nodeName, ok := statusMap["nodeName"]
+	if !ok {
+		return ""
+	}
+
+	name, ok := nodeName.(string)
+	if !ok {
+		return ""
+	}
+
+	return name
+}

--- a/internal/view/registrar.go
+++ b/internal/view/registrar.go
@@ -16,6 +16,7 @@ func loadCustomViewers() MetaViewers {
 	batchViewers(m)
 	crdViewers(m)
 	helmViewers(m)
+	karpenterViewers(m)
 
 	return m
 }
@@ -143,5 +144,11 @@ func batchViewers(vv MetaViewers) {
 func crdViewers(vv MetaViewers) {
 	vv[client.CrdGVR] = MetaViewer{
 		viewerFn: NewCRD,
+	}
+}
+
+func karpenterViewers(vv MetaViewers) {
+	vv[client.NodeClaimGVR] = MetaViewer{
+		viewerFn: NewNodeClaim,
 	}
 }


### PR DESCRIPTION
Implement custom Enter key handler for Karpenter NodeClaim resources to
navigate directly to the associated node. Previously, pressing Enter on a
NodeClaim would only show its YAML description. Now it extracts the nodeName
from status.nodeName and navigates to the corresponding node view.

Resolves #3658

## Changes

- **feat(client/gvrs.go)**: Add NodeClaimGVR constant for karpenter.sh/v1/nodeclaims
- **feat(view/nodeclaim.go)**: Create NodeClaim view with custom showNode handler
- **feat(view/registrar.go)**: Register NodeClaim viewer in the custom viewers registry

The implementation extracts nodeName from NodeClaim status using unstructured access and follows the same navigation pattern as other resources (e.g., Deployment → Pods).