### PR TITLE
Fix panic on unknown commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,9 +69,7 @@ func init() {
 // Execute root command.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		if !errors.As(err, &flagError{}) {
-			panic(err)
-		}
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Running `k9s <unknown-command>` triggers a panic with full stack trace instead of exiting gracefully.

The error handling in `Execute()` only catches `flagError` types. Unknown commands return regular Cobra errors, which fall through to the panic. This means user typos cause panics with stack traces.

**Fix:** Exit cleanly for all command-line errors. Cobra already prints helpful error messages, and panics should be reserved for actual bugs.

**Before:**
```
k9s ghfgrtgert
Error: unknown command "ghfgrtgert" for "k9s"
Run 'k9s --help' for usage.
panic: unknown command "ghfgrtgert" for "k9s"

goroutine 1 [running]:
github.com/derailed/k9s/cmd.Execute()
        github.com/derailed/k9s/cmd/root.go:73 +0x76
main.main()
        github.com/derailed/k9s/main.go:45 +0xf
```

**After:**
```
k9s ghfgrtgert
Error: unknown command "ghfgrtgert" for "k9s"
Run 'k9s --help' for usage.
```

Fixes https://github.com/derailed/k9s/issues/3698