### PR TITLE
fix: update TestLogAutoScroll to expect 18 hints

### DIFF
--- a/internal/view/log_int_test.go
+++ b/internal/view/log_int_test.go
@@ -27,7 +27,7 @@ func TestLogAutoScroll(t *testing.T) {
 	v.GetModel().Set(ii)
 	v.GetModel().Notify()
 
-	assert.Len(t, v.Hints(), 17)
+	assert.Len(t, v.Hints(), 18)
 
 	v.toggleAutoScrollCmd(nil)
 	assert.Equal(t, "Autoscroll:Off     ColumnLock:Off     FullScreen:Off     Timestamps:Off     Wrap:Off", v.Indicator().GetText(true))


### PR DESCRIPTION
## Description
   This PR fixes a failing test in `TestLogAutoScroll`.

   ## Problem
   After PR #3663 (commit b216f368) added the 'Q' key as an alternative to ESC for "Back", the test started failing because it expected 17 keyboard hints but there are now 18.

   ## Solution
   Update the assertion in `internal/view/log_int_test.go` to expect 18 hints instead of 17.

   ## Testing
   ```bash
   go test -v ./internal/view -run TestLogAutoScroll
   ```

   The test now passes with this change:
   ```
   === RUN   TestLogAutoScroll
   --- PASS: TestLogAutoScroll (0.00s)
   PASS
   ok      github.com/derailed/k9s/internal/view   0.038s
   ```