### PR TITLE
feat: Add reconcile plugin for Flux instances

### DIFF
--- a/plugins/flux.yaml
+++ b/plugins/flux.yaml
@@ -219,6 +219,22 @@ plugins:
         --kube-context $CONTEXT
         -n $NAMESPACE $NAME
         | less -K
+  reconcile-fluxinstance:
+    shortCut: Shift-R
+    confirm: false
+    description: Flux reconcile
+    scopes:
+      - fluxinstances
+    command: bash
+    background: false
+    args:
+      - -c
+      - >-
+        flux-operator
+        reconcile instance
+        --kube-context $CONTEXT
+        -n $NAMESPACE $NAME
+        | less -K
   trace:
     shortCut: Shift-Q
     confirm: false


### PR DESCRIPTION
## Summary
- Adds a new plugin `reconcile-fluxinstance` to enable reconciliation of Flux instances via k9s
- Uses `Shift-R` shortcut (consistent with other Flux reconcile plugins)
- Scopes to `fluxinstances` resource type

## Details
This PR adds support for reconciling Flux instances using the `flux-operator reconcile instance` command, following the same pattern as existing Flux reconcile plugins (ResourceSet, ResourceSetInputProvider, etc.).

The new plugin allows users to trigger reconciliation of Flux instances directly from k9s using the `Shift-R` shortcut when viewing Flux instance resources.

## Test plan
- Plugin follows the same pattern as existing Flux reconcile plugins
- Uses flux-operator CLI which is consistent with other operator-based plugins in the file
- Shortcut `Shift-R` is appropriate for reconciliation operations