### PR TITLE
fix: opening active namespace if set

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,11 +123,19 @@ func (c *Config) Refine(flags *genericclioptions.ConfigFlags, k9sFlags *Flags, c
 		ns = *flags.Namespace
 		c.ResetActiveView()
 	default:
-		nss, err := c.K9s.ActiveContextNamespace()
-		if err != nil {
-			return err
+		// Try to get namespace from kubeconfig context first
+		kubeconfigNS, err := cfg.CurrentContextNamespace()
+		// If kubeconfig has a namespace, use it
+		if err == nil && kubeconfigNS != "" && kubeconfigNS != client.BlankNamespace {
+			ns = kubeconfigNS
+		} else {
+			// Fall back to k9s cached config
+			nss, err := c.K9s.ActiveContextNamespace()
+			if err != nil {
+				return err
+			}
+			ns = nss
 		}
-		ns = nss
 	}
 	if ns == "" {
 		ns = client.DefaultNamespace

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -367,6 +367,7 @@ func TestConfigCurrentContext(t *testing.T) {
 	var (
 		cfgFile = "testdata/kubes/test.yaml"
 		ct2     = "ct-1-2"
+		ctNoNS  = "ct-no-ns"
 	)
 
 	uu := map[string]struct {
@@ -391,6 +392,15 @@ func TestConfigCurrentContext(t *testing.T) {
 			},
 			cluster:   "cl-1",
 			context:   "ct-1-1",
+			namespace: "ns-1",
+		},
+		"context-no-namespace-fallback-to-default": {
+			flags: &genericclioptions.ConfigFlags{
+				KubeConfig: &cfgFile,
+				Context:    &ctNoNS,
+			},
+			cluster:   "cl-1",
+			context:   "ct-no-ns",
 			namespace: client.DefaultNamespace,
 		},
 	}
@@ -415,6 +425,7 @@ func TestConfigRefine(t *testing.T) {
 		cfgFile       = "testdata/kubes/test.yaml"
 		cl1           = "cl-1"
 		ct2           = "ct-1-2"
+		ctNoNS        = "ct-no-ns"
 		ns1, ns2, nsx = "ns-1", "ns-2", "ns-x"
 		trueVal       = true
 	)
@@ -437,7 +448,7 @@ func TestConfigRefine(t *testing.T) {
 			},
 			cluster:   "cl-1",
 			context:   "ct-1-1",
-			namespace: client.DefaultNamespace,
+			namespace: "ns-1",
 		},
 		"override-cluster-context": {
 			flags: &genericclioptions.ConfigFlags{
@@ -456,7 +467,7 @@ func TestConfigRefine(t *testing.T) {
 			},
 			cluster:   "cl-1",
 			context:   "ct-1-1",
-			namespace: client.DefaultNamespace,
+			namespace: "ns-1",
 		},
 		"override-ns": {
 			flags: &genericclioptions.ConfigFlags{
@@ -511,6 +522,15 @@ func TestConfigRefine(t *testing.T) {
 			},
 			cluster:   "cl-1",
 			context:   "ct-1-1",
+			namespace: "ns-1",
+		},
+		"kubeconfig-no-namespace-fallback-to-default": {
+			flags: &genericclioptions.ConfigFlags{
+				KubeConfig: &cfgFile,
+				Context:    &ctNoNS,
+			},
+			cluster:   "cl-1",
+			context:   "ct-no-ns",
 			namespace: client.DefaultNamespace,
 		},
 	}

--- a/internal/config/mock/test_helpers.go
+++ b/internal/config/mock/test_helpers.go
@@ -84,6 +84,10 @@ func NewMockKubeSettings(f *genericclioptions.ConfigFlags) mockKubeSettings {
 				Cluster:   "arn:aws:eks:eu-central-1:xxx:cluster/fred-blee",
 				Namespace: client.DefaultNamespace,
 			},
+			"ct-no-ns": {
+				Cluster:   "cl-1",
+				Namespace: "",
+			},
 		},
 	}
 }

--- a/internal/config/testdata/kubes/test.yaml
+++ b/internal/config/testdata/kubes/test.yaml
@@ -25,6 +25,10 @@ contexts:
       user: user2
       namespace: ns-2
     name: ct-2-1
+  - context:
+      cluster: cl-1
+      user: user1
+    name: ct-no-ns
 current-context: ct-1-1
 preferences: {}
 users:


### PR DESCRIPTION
#3061 

When determining the active namespace, k9s now checks the kubeconfig context first, then falls back to the k9s cached config if the context has no namespace.


This respects the namespace set in the user's kubeconfig context, making k9s behavior consistent with kubectl and other Kubernetes tools.

#### Behavior
- If the kubeconfig context specifies a namespace → use it
- If the kubeconfig context has no namespace → fall back to k9s cached config
- If both are empty → default to "default"