### PR TITLE
Fix boom on Jumping Owner in rare cases

### DIFF
--- a/internal/ui/dialog/selection.go
+++ b/internal/ui/dialog/selection.go
@@ -19,7 +19,6 @@ func ShowSelection(styles *config.Dialog, pages *ui.Pages, title string, options
 
 	for _, option := range options {
 		list.AddItem(option, "", 0, nil)
-		list.AddItem(option, "", 0, nil)
 	}
 
 	modal := ui.NewModalList("<"+title+">", list)


### PR DESCRIPTION
Fixes `Boom!! runtime error: index out of range` when navigating to one of resource owners, when there are many.</br> This issue is triggered when, say, a Pod has multiple owners — like in the case of Stackgres, where a db instance Pod is controlled by StatefulSet  but is also owned by so called SGCluster — each owner is added twice and it messes up selection by index.