### PR TITLE
feat(node): show NotReady nodes in red even when cordoned

### DIFF
--- a/internal/render/node.go
+++ b/internal/render/node.go
@@ -192,12 +192,13 @@ func (Node) diagnose(ss []string) error {
 	}
 
 	var ready bool
+	var hasSchedulingDisabled bool
 	for _, s := range ss {
 		if s == "" {
 			continue
 		}
 		if s == "SchedulingDisabled" {
-			return cordonErr
+			hasSchedulingDisabled = true
 		}
 		if s == "Ready" {
 			ready = true
@@ -206,6 +207,10 @@ func (Node) diagnose(ss []string) error {
 
 	if !ready {
 		return notReadyErr
+	}
+
+	if hasSchedulingDisabled {
+		return cordonErr
 	}
 
 	return nil


### PR DESCRIPTION
### Problem
When a node is both NotReady and SchedulingDisabled, it’s shown in yellow (SchedulingDisabled color) now. But NotReady means node fault, which should be highlighted in red to avoid missing the critical issue.

### Change
Update status color priority: NotReady (red) > SchedulingDisabled (yellow)
- Node with NotReady + SchedulingDisabled: Show red (emphasize fault), keep SchedulingDisabled label
- Node with only SchedulingDisabled: Still show yellow (no impact on original logic)

## Testing
- Verified with minikube: cordon + stop kubelet → shows red
- Checked normal cordoned (Ready) nodes still show yellow

Fixes #3787