### PR TITLE
feat: add kagent integration

### DIFF
--- a/internal/client/gvrs.go
+++ b/internal/client/gvrs.go
@@ -80,6 +80,13 @@ var (
 	CrbGVR  = NewGVR("rbac.authorization.k8s.io/v1/clusterrolebindings")
 	RoGVR   = NewGVR("rbac.authorization.k8s.io/v1/roles")
 	RobGVR  = NewGVR("rbac.authorization.k8s.io/v1/rolebindings")
+
+	// kagent - AI Agents for Kubernetes...
+	KAgentGVR       = NewGVR("kagent.dev/v1alpha2/agents")
+	KModelConfigGVR = NewGVR("kagent.dev/v1alpha2/modelconfigs")
+	KToolServerGVR  = NewGVR("kagent.dev/v1alpha1/toolservers")
+	KMemoryGVR      = NewGVR("kagent.dev/v1alpha1/memories")
+	KRemoteMCPGVR   = NewGVR("kagent.dev/v1alpha2/remotemcpservers")
 )
 
 var reservedGVRs = sets.New(

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -180,6 +180,17 @@ var Registry = map[*client.GVR]ResourceMeta{
 		Renderer: &render.StorageClass{},
 	},
 
+	// kagent - AI Agents for Kubernetes...
+	client.KAgentGVR: {
+		Renderer: new(render.KAgent),
+	},
+	client.KModelConfigGVR: {
+		Renderer: new(render.KModelConfig),
+	},
+	client.KToolServerGVR: {
+		Renderer: new(render.KToolServer),
+	},
+
 	// Policy...
 	client.PdbGVR: {
 		Renderer: &render.PodDisruptionBudget{},

--- a/internal/render/kagent_agent.go
+++ b/internal/render/kagent_agent.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model1"
+	"github.com/derailed/tcell/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var defaultKAgentHeader = model1.Header{
+	model1.HeaderColumn{Name: "NAMESPACE"},
+	model1.HeaderColumn{Name: "NAME"},
+	model1.HeaderColumn{Name: "TYPE"},
+	model1.HeaderColumn{Name: "MODEL"},
+	model1.HeaderColumn{Name: "TOOLS", Attrs: model1.Attrs{Align: 1}},
+	model1.HeaderColumn{Name: "READY"},
+	model1.HeaderColumn{Name: "ACCEPTED"},
+	model1.HeaderColumn{Name: "DESCRIPTION", Attrs: model1.Attrs{Wide: true}},
+	model1.HeaderColumn{Name: "LABELS", Attrs: model1.Attrs{Wide: true}},
+	model1.HeaderColumn{Name: "VALID", Attrs: model1.Attrs{Wide: true}},
+	model1.HeaderColumn{Name: "AGE", Attrs: model1.Attrs{Time: true}},
+}
+
+// KAgent renders a kagent Agent to screen.
+type KAgent struct {
+	Base
+}
+
+// ColorerFunc colors a resource row.
+func (KAgent) ColorerFunc() model1.ColorerFunc {
+	return func(ns string, h model1.Header, re *model1.RowEvent) tcell.Color {
+		c := model1.DefaultColorer(ns, h, re)
+		if c == model1.ErrColor {
+			return c
+		}
+
+		readyIdx, ok := h.IndexOf("READY", true)
+		if ok && readyIdx < len(re.Row.Fields) {
+			switch strings.ToLower(re.Row.Fields[readyIdx]) {
+			case "true":
+				return tcell.ColorMediumSpringGreen
+			case "false":
+				return tcell.ColorOrangeRed
+			}
+		}
+
+		return c
+	}
+}
+
+// Header returns a header row.
+func (a KAgent) Header(_ string) model1.Header {
+	return a.doHeader(defaultKAgentHeader)
+}
+
+// Render renders a K8s resource to screen.
+func (a KAgent) Render(o any, _ string, row *model1.Row) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("expected Unstructured, but got %T", o)
+	}
+	if err := a.defaultRow(raw, row); err != nil {
+		return err
+	}
+	if a.specs.isEmpty() {
+		return nil
+	}
+	cols, err := a.specs.realize(raw, defaultKAgentHeader, row)
+	if err != nil {
+		return err
+	}
+	cols.hydrateRow(row)
+
+	return nil
+}
+
+func (KAgent) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
+	r.ID = client.FQN(raw.GetNamespace(), raw.GetName())
+
+	// Extract spec fields
+	spec, _, _ := unstructured.NestedMap(raw.Object, "spec")
+	agentType := extractString(spec, "type")
+	description := extractString(spec, "description")
+
+	// Extract model config and tools count from declarative spec
+	modelConfig := NAValue
+	toolsCount := "0"
+	if declarative, ok := spec["declarative"].(map[string]interface{}); ok {
+		if mc, ok := declarative["modelConfig"].(string); ok && mc != "" {
+			modelConfig = mc
+		}
+		if tools, ok := declarative["tools"].([]interface{}); ok {
+			toolsCount = fmt.Sprintf("%d", len(tools))
+		}
+	}
+
+	// Extract status conditions
+	status, _, _ := unstructured.NestedMap(raw.Object, "status")
+	ready := extractConditionStatus(status, "Ready")
+	accepted := extractConditionStatus(status, "Accepted")
+
+	r.Fields = model1.Fields{
+		raw.GetNamespace(),
+		raw.GetName(),
+		agentType,
+		modelConfig,
+		toolsCount,
+		ready,
+		accepted,
+		truncateStr(description, 50),
+		mapToStr(raw.GetLabels()),
+		AsStatus(diagnoseAgent(ready, accepted)),
+		ToAge(raw.GetCreationTimestamp()),
+	}
+
+	return nil
+}
+
+// Healthy checks component health.
+func (a KAgent) Healthy(_ context.Context, o any) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return nil
+	}
+
+	status, _, _ := unstructured.NestedMap(raw.Object, "status")
+	ready := extractConditionStatus(status, "Ready")
+	accepted := extractConditionStatus(status, "Accepted")
+
+	return diagnoseAgent(ready, accepted)
+}
+
+func diagnoseAgent(ready, accepted string) error {
+	if strings.ToLower(ready) != "true" {
+		return errors.New("agent not ready")
+	}
+	if strings.ToLower(accepted) != "true" {
+		return errors.New("agent not accepted")
+	}
+	return nil
+}
+
+// extractConditionStatus extracts a condition status from status.conditions
+func extractConditionStatus(status map[string]interface{}, conditionType string) string {
+	conditions, ok := status["conditions"].([]interface{})
+	if !ok {
+		return NAValue
+	}
+
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if t, ok := cond["type"].(string); ok && t == conditionType {
+			if s, ok := cond["status"].(string); ok {
+				return s
+			}
+		}
+	}
+	return NAValue
+}
+
+// extractString safely extracts a string from a map
+func extractString(m map[string]interface{}, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// truncateStr truncates a string to maxLen characters
+func truncateStr(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/render/kagent_modelconfig.go
+++ b/internal/render/kagent_modelconfig.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model1"
+	"github.com/derailed/tcell/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var defaultKModelConfigHeader = model1.Header{
+	model1.HeaderColumn{Name: "NAMESPACE"},
+	model1.HeaderColumn{Name: "NAME"},
+	model1.HeaderColumn{Name: "PROVIDER"},
+	model1.HeaderColumn{Name: "MODEL"},
+	model1.HeaderColumn{Name: "SECRET"},
+	model1.HeaderColumn{Name: "ACCEPTED"},
+	model1.HeaderColumn{Name: "TLS"},
+	model1.HeaderColumn{Name: "LABELS", Attrs: model1.Attrs{Wide: true}},
+	model1.HeaderColumn{Name: "VALID", Attrs: model1.Attrs{Wide: true}},
+	model1.HeaderColumn{Name: "AGE", Attrs: model1.Attrs{Time: true}},
+}
+
+// KModelConfig renders a kagent ModelConfig to screen.
+type KModelConfig struct {
+	Base
+}
+
+// ColorerFunc colors a resource row.
+func (KModelConfig) ColorerFunc() model1.ColorerFunc {
+	return func(ns string, h model1.Header, re *model1.RowEvent) tcell.Color {
+		c := model1.DefaultColorer(ns, h, re)
+		if c == model1.ErrColor {
+			return c
+		}
+
+		acceptedIdx, ok := h.IndexOf("ACCEPTED", true)
+		if ok && acceptedIdx < len(re.Row.Fields) {
+			switch strings.ToLower(re.Row.Fields[acceptedIdx]) {
+			case "true":
+				return tcell.ColorMediumSpringGreen
+			case "false":
+				return tcell.ColorOrangeRed
+			}
+		}
+
+		// Color by provider type
+		providerIdx, ok := h.IndexOf("PROVIDER", true)
+		if ok && providerIdx < len(re.Row.Fields) {
+			switch re.Row.Fields[providerIdx] {
+			case "OpenAI":
+				return tcell.ColorDodgerBlue
+			case "Anthropic":
+				return tcell.ColorSandyBrown
+			case "AzureOpenAI":
+				return tcell.ColorCornflowerBlue
+			case "Ollama":
+				return tcell.ColorMediumPurple
+			case "Gemini", "GeminiVertexAI":
+				return tcell.ColorGold
+			}
+		}
+
+		return c
+	}
+}
+
+// Header returns a header row.
+func (m KModelConfig) Header(_ string) model1.Header {
+	return m.doHeader(defaultKModelConfigHeader)
+}
+
+// Render renders a K8s resource to screen.
+func (m KModelConfig) Render(o any, _ string, row *model1.Row) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("expected Unstructured, but got %T", o)
+	}
+	if err := m.defaultRow(raw, row); err != nil {
+		return err
+	}
+	if m.specs.isEmpty() {
+		return nil
+	}
+	cols, err := m.specs.realize(raw, defaultKModelConfigHeader, row)
+	if err != nil {
+		return err
+	}
+	cols.hydrateRow(row)
+
+	return nil
+}
+
+func (KModelConfig) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
+	r.ID = client.FQN(raw.GetNamespace(), raw.GetName())
+
+	// Extract spec fields
+	spec, _, _ := unstructured.NestedMap(raw.Object, "spec")
+	provider := extractString(spec, "provider")
+	model := extractString(spec, "model")
+	apiKeySecret := extractString(spec, "apiKeySecret")
+
+	// Check TLS config
+	tlsEnabled := "No"
+	if tls, ok := spec["tls"].(map[string]interface{}); ok {
+		if disableVerify, ok := tls["disableVerify"].(bool); ok && disableVerify {
+			tlsEnabled = "Insecure"
+		} else if caCert, ok := tls["caCertSecretRef"].(string); ok && caCert != "" {
+			tlsEnabled = "Custom CA"
+		} else {
+			tlsEnabled = "Yes"
+		}
+	}
+
+	// Extract status conditions
+	status, _, _ := unstructured.NestedMap(raw.Object, "status")
+	accepted := extractConditionStatus(status, "Accepted")
+
+	r.Fields = model1.Fields{
+		raw.GetNamespace(),
+		raw.GetName(),
+		provider,
+		model,
+		apiKeySecret,
+		accepted,
+		tlsEnabled,
+		mapToStr(raw.GetLabels()),
+		AsStatus(diagnoseModelConfig(accepted)),
+		ToAge(raw.GetCreationTimestamp()),
+	}
+
+	return nil
+}
+
+// Healthy checks component health.
+func (m KModelConfig) Healthy(_ context.Context, o any) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return nil
+	}
+
+	status, _, _ := unstructured.NestedMap(raw.Object, "status")
+	accepted := extractConditionStatus(status, "Accepted")
+
+	return diagnoseModelConfig(accepted)
+}
+
+func diagnoseModelConfig(accepted string) error {
+	if strings.ToLower(accepted) != "true" {
+		return errors.New("model config not accepted")
+	}
+	return nil
+}

--- a/internal/render/kagent_toolserver.go
+++ b/internal/render/kagent_toolserver.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model1"
+	"github.com/derailed/tcell/v2"
+	"github.com/derailed/tview"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var defaultKToolServerHeader = model1.Header{
+	model1.HeaderColumn{Name: "NAMESPACE"},
+	model1.HeaderColumn{Name: "NAME"},
+	model1.HeaderColumn{Name: "TYPE"},
+	model1.HeaderColumn{Name: "URL/CMD"},
+	model1.HeaderColumn{Name: "TOOLS", Attrs: model1.Attrs{Align: tview.AlignRight}},
+	model1.HeaderColumn{Name: "STATUS"},
+	model1.HeaderColumn{Name: "DESCRIPTION", Attrs: model1.Attrs{Wide: true}},
+	model1.HeaderColumn{Name: "LABELS", Attrs: model1.Attrs{Wide: true}},
+	model1.HeaderColumn{Name: "VALID", Attrs: model1.Attrs{Wide: true}},
+	model1.HeaderColumn{Name: "AGE", Attrs: model1.Attrs{Time: true}},
+}
+
+// KToolServer renders a kagent ToolServer to screen.
+type KToolServer struct {
+	Base
+}
+
+// ColorerFunc colors a resource row.
+func (KToolServer) ColorerFunc() model1.ColorerFunc {
+	return func(ns string, h model1.Header, re *model1.RowEvent) tcell.Color {
+		c := model1.DefaultColorer(ns, h, re)
+		if c == model1.ErrColor {
+			return c
+		}
+
+		// Color by server type
+		typeIdx, ok := h.IndexOf("TYPE", true)
+		if ok && typeIdx < len(re.Row.Fields) {
+			switch strings.ToLower(re.Row.Fields[typeIdx]) {
+			case "stdio":
+				return tcell.ColorMediumAquamarine
+			case "sse":
+				return tcell.ColorDodgerBlue
+			case "streamablehttp":
+				return tcell.ColorMediumOrchid
+			}
+		}
+
+		// Color by tools count
+		toolsIdx, ok := h.IndexOf("TOOLS", true)
+		if ok && toolsIdx < len(re.Row.Fields) {
+			if re.Row.Fields[toolsIdx] == "0" {
+				return tcell.ColorGray
+			}
+		}
+
+		return c
+	}
+}
+
+// Header returns a header row.
+func (t KToolServer) Header(_ string) model1.Header {
+	return t.doHeader(defaultKToolServerHeader)
+}
+
+// Render renders a K8s resource to screen.
+func (t KToolServer) Render(o any, _ string, row *model1.Row) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("expected Unstructured, but got %T", o)
+	}
+	if err := t.defaultRow(raw, row); err != nil {
+		return err
+	}
+	if t.specs.isEmpty() {
+		return nil
+	}
+	cols, err := t.specs.realize(raw, defaultKToolServerHeader, row)
+	if err != nil {
+		return err
+	}
+	cols.hydrateRow(row)
+
+	return nil
+}
+
+func (KToolServer) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
+	r.ID = client.FQN(raw.GetNamespace(), raw.GetName())
+
+	// Extract spec fields
+	spec, _, _ := unstructured.NestedMap(raw.Object, "spec")
+	description := extractString(spec, "description")
+
+	// Extract config to determine type
+	config, _ := spec["config"].(map[string]interface{})
+	serverType := extractString(config, "type")
+	urlOrCmd := ""
+
+	// Determine URL/command based on type
+	if stdio, ok := config["stdio"].(map[string]interface{}); ok {
+		serverType = "stdio"
+		urlOrCmd = extractString(stdio, "command")
+	} else if sse, ok := config["sse"].(map[string]interface{}); ok {
+		serverType = "sse"
+		urlOrCmd = extractString(sse, "url")
+	} else if streamable, ok := config["streamableHttp"].(map[string]interface{}); ok {
+		serverType = "streamableHttp"
+		urlOrCmd = extractString(streamable, "url")
+	}
+
+	// Extract status
+	status, _, _ := unstructured.NestedMap(raw.Object, "status")
+	toolsCount := "0"
+	statusStr := "Unknown"
+
+	// Count discovered tools
+	if discoveredTools, ok := status["discoveredTools"].([]interface{}); ok {
+		toolsCount = fmt.Sprintf("%d", len(discoveredTools))
+		if len(discoveredTools) > 0 {
+			statusStr = "Ready"
+		} else {
+			statusStr = "No Tools"
+		}
+	}
+
+	// Check conditions
+	if conditions, ok := status["conditions"].([]interface{}); ok {
+		for _, c := range conditions {
+			cond, ok := c.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if t, ok := cond["type"].(string); ok && t == "Ready" {
+				if s, ok := cond["status"].(string); ok {
+					if s == "True" {
+						statusStr = "Ready"
+					} else {
+						statusStr = "NotReady"
+					}
+				}
+			}
+		}
+	}
+
+	r.Fields = model1.Fields{
+		raw.GetNamespace(),
+		raw.GetName(),
+		serverType,
+		truncateStr(urlOrCmd, 40),
+		toolsCount,
+		statusStr,
+		truncateStr(description, 50),
+		mapToStr(raw.GetLabels()),
+		AsStatus(diagnoseToolServer(statusStr, toolsCount)),
+		ToAge(raw.GetCreationTimestamp()),
+	}
+
+	return nil
+}
+
+// Healthy checks component health.
+func (t KToolServer) Healthy(_ context.Context, o any) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return nil
+	}
+
+	status, _, _ := unstructured.NestedMap(raw.Object, "status")
+	statusStr := "Unknown"
+	toolsCount := "0"
+
+	if discoveredTools, ok := status["discoveredTools"].([]interface{}); ok {
+		toolsCount = fmt.Sprintf("%d", len(discoveredTools))
+	}
+
+	if conditions, ok := status["conditions"].([]interface{}); ok {
+		for _, c := range conditions {
+			cond, ok := c.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if t, ok := cond["type"].(string); ok && t == "Ready" {
+				if s, ok := cond["status"].(string); ok {
+					if s == "True" {
+						statusStr = "Ready"
+					} else {
+						statusStr = "NotReady"
+					}
+				}
+			}
+		}
+	}
+
+	return diagnoseToolServer(statusStr, toolsCount)
+}
+
+func diagnoseToolServer(status, toolsCount string) error {
+	if status != "Ready" {
+		return fmt.Errorf("tool server not ready: %s", status)
+	}
+	if toolsCount == "0" {
+		return fmt.Errorf("no tools discovered")
+	}
+	return nil
+}

--- a/internal/view/kagent_agent.go
+++ b/internal/view/kagent_agent.go
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/tcell/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// KAgent represents a kagent Agent viewer.
+type KAgent struct {
+	ResourceViewer
+}
+
+// NewKAgent returns a new agent viewer.
+func NewKAgent(gvr *client.GVR) ResourceViewer {
+	a := KAgent{
+		ResourceViewer: NewBrowser(gvr),
+	}
+	a.AddBindKeysFn(a.bindKeys)
+	a.GetTable().SetEnterFn(a.showAgentDetails)
+
+	return &a
+}
+
+func (a *KAgent) bindKeys(aa *ui.KeyActions) {
+	aa.Bulk(ui.KeyMap{
+		ui.KeyI:        ui.NewKeyAction("Invoke", a.invokeCmd, true),
+		ui.KeyC:        ui.NewKeyAction("Chat", a.chatCmd, true),
+		ui.KeyT:        ui.NewKeyAction("Tools", a.showToolsCmd, true),
+		ui.KeyM:        ui.NewKeyAction("ModelConfig", a.showModelConfigCmd, true),
+		ui.KeyL:        ui.NewKeyAction("Logs", a.logsCmd, true),
+		tcell.KeyCtrlI: ui.NewKeyAction("Quick Invoke", a.quickInvokeCmd, true),
+	})
+}
+
+func (a *KAgent) showAgentDetails(app *App, _ ui.Tabular, gvr *client.GVR, path string) {
+	// Show YAML view by default when entering an agent
+	v := NewLiveView(app, yamlAction, model.NewYAML(gvr, path))
+	if err := app.inject(v, false); err != nil {
+		app.Flash().Err(err)
+	}
+}
+
+// invokeCmd invokes the agent with a message
+func (a *KAgent) invokeCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := a.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	ns, name := client.Namespaced(path)
+	a.App().Flash().Infof("Invoking agent %s...", name)
+
+	// Open external terminal with kagent invoke command
+	args := []string{
+		"invoke",
+		"--namespace", ns,
+		"--agent", name,
+	}
+
+	return a.runKAgentCommand(args)
+}
+
+// chatCmd starts an interactive chat session with the agent
+func (a *KAgent) chatCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := a.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	ns, name := client.Namespaced(path)
+
+	// Open embedded chat view
+	chat := NewKAgentChat(a.App(), ns, name)
+	if err := a.App().inject(chat, false); err != nil {
+		a.App().Flash().Err(err)
+	}
+
+	return nil
+}
+
+// quickInvokeCmd prompts for a message and invokes the agent
+func (a *KAgent) quickInvokeCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := a.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	ns, name := client.Namespaced(path)
+
+	// Use the command buffer to get a message
+	a.App().Flash().Infof("Enter message for agent %s (press Enter to send):", name)
+
+	// For now, just show a message - full implementation would need a dialog
+	a.App().Flash().Infof("Quick invoke: kagent invoke -n %s %s --message <your-message>", ns, name)
+
+	return nil
+}
+
+// showToolsCmd shows the tools available to this agent
+func (a *KAgent) showToolsCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := a.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	// Get the agent object to extract tool information
+	ctx := context.Background()
+	o, err := a.App().factory.Get(a.GVR(), path, true, nil)
+	if err != nil {
+		a.App().Flash().Errf("Failed to get agent: %v", err)
+		return nil
+	}
+
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		a.App().Flash().Err(fmt.Errorf("unexpected object type"))
+		return nil
+	}
+
+	// Extract tools from spec.declarative.tools
+	spec, _, _ := unstructured.NestedMap(raw.Object, "spec")
+	declarative, ok := spec["declarative"].(map[string]interface{})
+	if !ok {
+		a.App().Flash().Warn("Agent has no declarative spec or tools")
+		return nil
+	}
+
+	tools, ok := declarative["tools"].([]interface{})
+	if !ok || len(tools) == 0 {
+		a.App().Flash().Warn("Agent has no tools configured")
+		return nil
+	}
+
+	// Build tools summary
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Tools for agent %s:\n\n", raw.GetName()))
+
+	for i, t := range tools {
+		tool, ok := t.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		toolType := ""
+		if tt, ok := tool["type"].(string); ok {
+			toolType = tt
+		}
+
+		sb.WriteString(fmt.Sprintf("%d. Type: %s\n", i+1, toolType))
+
+		if toolType == "McpServer" {
+			if mcpServer, ok := tool["mcpServer"].(map[string]interface{}); ok {
+				if name, ok := mcpServer["name"].(string); ok {
+					sb.WriteString(fmt.Sprintf("   ToolServer: %s\n", name))
+				}
+				if toolNames, ok := mcpServer["toolNames"].([]interface{}); ok && len(toolNames) > 0 {
+					names := make([]string, 0, len(toolNames))
+					for _, tn := range toolNames {
+						if s, ok := tn.(string); ok {
+							names = append(names, s)
+						}
+					}
+					sb.WriteString(fmt.Sprintf("   Tools: %s\n", strings.Join(names, ", ")))
+				}
+			}
+		} else if toolType == "Agent" {
+			if agent, ok := tool["agent"].(map[string]interface{}); ok {
+				if name, ok := agent["name"].(string); ok {
+					sb.WriteString(fmt.Sprintf("   Agent: %s\n", name))
+				}
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	// Show in a details view
+	v := NewDetails(a.App(), "Agent Tools", raw.GetName(), contentTXT, true)
+	v.Update(sb.String())
+	if err := a.App().inject(v, false); err != nil {
+		a.App().Flash().Err(err)
+	}
+
+	_ = ctx // suppress unused warning
+	return nil
+}
+
+// showModelConfigCmd navigates to the associated ModelConfig
+func (a *KAgent) showModelConfigCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := a.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	// Get the agent object
+	o, err := a.App().factory.Get(a.GVR(), path, true, nil)
+	if err != nil {
+		a.App().Flash().Errf("Failed to get agent: %v", err)
+		return nil
+	}
+
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return nil
+	}
+
+	// Extract modelConfig from spec.declarative.modelConfig
+	spec, _, _ := unstructured.NestedMap(raw.Object, "spec")
+	declarative, ok := spec["declarative"].(map[string]interface{})
+	if !ok {
+		a.App().Flash().Warn("Agent has no declarative spec")
+		return nil
+	}
+
+	modelConfigName, ok := declarative["modelConfig"].(string)
+	if !ok || modelConfigName == "" {
+		a.App().Flash().Warn("Agent has no modelConfig specified")
+		return nil
+	}
+
+	// Navigate to the ModelConfig
+	mcPath := fmt.Sprintf("modelconfigs %s/%s", raw.GetNamespace(), modelConfigName)
+	a.App().gotoResource(mcPath, "", false, true)
+
+	return nil
+}
+
+// logsCmd shows logs for the agent deployment
+func (a *KAgent) logsCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := a.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	ns, name := client.Namespaced(path)
+
+	// Navigate to pods with label selector for this agent
+	podPath := fmt.Sprintf("pods -n %s -l kagent.dev/agent=%s", ns, name)
+	a.App().gotoResource(podPath, "", false, true)
+
+	return nil
+}
+
+// runKAgentCommand runs a kagent CLI command in an external terminal
+func (a *KAgent) runKAgentCommand(args []string) *tcell.EventKey {
+	// Check if kagent CLI is available
+	kagentPath, err := exec.LookPath("kagent")
+	if err != nil {
+		a.App().Flash().Errf("kagent CLI not found in PATH. Install from: https://kagent.dev")
+		return nil
+	}
+
+	// Build full command
+	cmd := exec.Command(kagentPath, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Suspend the UI and run the command
+	a.App().Halt()
+	defer a.App().Resume()
+
+	a.App().Suspend(func() {
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("\nCommand failed: %v\n", err)
+		}
+		fmt.Println("\nPress Enter to return to k9s...")
+		fmt.Scanln()
+	})
+
+	return nil
+}
+

--- a/internal/view/kagent_chat.go
+++ b/internal/view/kagent_chat.go
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/model"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/k9s/internal/view/cmd"
+	"github.com/derailed/tcell/v2"
+	"github.com/derailed/tview"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	chatTitleFmt = "[fg:bg:b] kagent Chat ([hilite:bg:b]%s[fg:bg:-])[fg:bg:-] "
+)
+
+// KAgentChat represents an embedded chat view for kagent agents.
+type KAgentChat struct {
+	*tview.Flex
+
+	app           *App
+	agentName     string
+	namespace     string
+	input         *tview.InputField
+	output        *tview.TextView
+	actions       *ui.KeyActions
+	history       []string
+	historyIdx    int
+}
+
+// NewKAgentChat creates a new kagent chat view.
+func NewKAgentChat(app *App, namespace, agentName string) *KAgentChat {
+	c := &KAgentChat{
+		Flex:       tview.NewFlex().SetDirection(tview.FlexRow),
+		app:        app,
+		agentName:  agentName,
+		namespace:  namespace,
+		output:     tview.NewTextView(),
+		input:      tview.NewInputField(),
+		actions:    ui.NewKeyActions(),
+		history:    make([]string, 0),
+		historyIdx: -1,
+	}
+
+	return c
+}
+
+func (*KAgentChat) SetCommand(*cmd.Interpreter)            {}
+func (*KAgentChat) SetFilter(string, bool)                 {}
+func (*KAgentChat) SetLabelSelector(labels.Selector, bool) {}
+
+// Init initializes the chat view.
+func (c *KAgentChat) Init(_ context.Context) error {
+	c.SetBorder(true)
+	c.SetBorderPadding(0, 0, 1, 1)
+	c.updateTitle()
+
+	// Configure output area
+	c.output.SetScrollable(true)
+	c.output.SetWrap(true)
+	c.output.SetDynamicColors(true)
+	c.output.SetChangedFunc(func() {
+		c.app.Draw()
+	})
+
+	// Configure input field
+	c.input.SetLabel("[green]> ")
+	c.input.SetFieldBackgroundColor(tcell.ColorDefault)
+	c.input.SetDoneFunc(c.handleInput)
+
+	// Layout: output takes most space, input at bottom
+	c.AddItem(c.output, 0, 1, false)
+	c.AddItem(c.input, 1, 0, true)
+
+	c.app.Styles.AddListener(c)
+	c.StylesChanged(c.app.Styles)
+
+	c.bindKeys()
+
+	// Add welcome message
+	c.appendOutput("[yellow]kagent Chat[white]\n")
+	c.appendOutput(fmt.Sprintf("Connected to agent: [green]%s[white] in namespace [cyan]%s[white]\n", c.agentName, c.namespace))
+	c.appendOutput("Type your message and press Enter to send.\n")
+	c.appendOutput("Press [yellow]Ctrl+C[white] or [yellow]Esc[white] to exit.\n")
+	c.appendOutput(strings.Repeat("-", 50) + "\n\n")
+
+	return nil
+}
+
+func (c *KAgentChat) bindKeys() {
+	c.actions.Bulk(ui.KeyMap{
+		tcell.KeyEscape: ui.NewKeyAction("Back", c.backCmd, false),
+		tcell.KeyCtrlC:  ui.NewKeyAction("Back", c.backCmd, false),
+		tcell.KeyUp:     ui.NewKeyAction("History Up", c.historyUpCmd, false),
+		tcell.KeyDown:   ui.NewKeyAction("History Down", c.historyDownCmd, false),
+	})
+}
+
+func (c *KAgentChat) handleInput(key tcell.Key) {
+	if key != tcell.KeyEnter {
+		return
+	}
+
+	text := strings.TrimSpace(c.input.GetText())
+	if text == "" {
+		return
+	}
+
+	// Add to history
+	c.history = append(c.history, text)
+	c.historyIdx = len(c.history)
+
+	// Clear input
+	c.input.SetText("")
+
+	// Show user message
+	c.appendOutput(fmt.Sprintf("[green]You:[white] %s\n\n", text))
+
+	// Send to agent
+	go c.sendMessage(text)
+}
+
+func (c *KAgentChat) sendMessage(message string) {
+	c.appendOutput("[yellow]Agent thinking...[white]\n")
+
+	// Check if kagent CLI exists
+	kagentPath, err := exec.LookPath("kagent")
+	if err != nil {
+		c.appendOutput("[red]Error:[white] kagent CLI not found. Install from: https://kagent.dev\n\n")
+		return
+	}
+
+	// Build command with JSON output
+	args := []string{
+		"invoke",
+		"--namespace", c.namespace,
+		"--agent", c.agentName,
+		"--task", message,
+		"--output-format", "json",
+	}
+
+	cmd := exec.Command(kagentPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		c.appendOutput(fmt.Sprintf("[red]Error:[white] %v\n", err))
+	}
+
+	// Parse JSON response and extract text
+	response := c.parseAgentResponse(string(output))
+	if response != "" {
+		c.appendOutput(fmt.Sprintf("[cyan]Agent:[white]\n%s\n\n", response))
+	}
+}
+
+// parseAgentResponse extracts text from kagent JSON response
+func (c *KAgentChat) parseAgentResponse(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	// Try to parse as JSON
+	var resp struct {
+		Artifacts []struct {
+			Parts []struct {
+				Kind string `json:"kind"`
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"artifacts"`
+	}
+
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		// Not JSON, return as-is
+		return raw
+	}
+
+	// Extract text from artifacts
+	var texts []string
+	for _, artifact := range resp.Artifacts {
+		for _, part := range artifact.Parts {
+			if part.Kind == "text" && part.Text != "" {
+				texts = append(texts, part.Text)
+			}
+		}
+	}
+
+	if len(texts) > 0 {
+		return strings.Join(texts, "\n")
+	}
+
+	return raw
+}
+
+func (c *KAgentChat) appendOutput(text string) {
+	c.app.QueueUpdateDraw(func() {
+		fmt.Fprintf(c.output, "%s", text)
+		c.output.ScrollToEnd()
+	})
+}
+
+func (c *KAgentChat) backCmd(*tcell.EventKey) *tcell.EventKey {
+	return c.app.PrevCmd(nil)
+}
+
+func (c *KAgentChat) historyUpCmd(*tcell.EventKey) *tcell.EventKey {
+	if len(c.history) == 0 {
+		return nil
+	}
+	if c.historyIdx > 0 {
+		c.historyIdx--
+	}
+	c.input.SetText(c.history[c.historyIdx])
+	return nil
+}
+
+func (c *KAgentChat) historyDownCmd(*tcell.EventKey) *tcell.EventKey {
+	if len(c.history) == 0 {
+		return nil
+	}
+	if c.historyIdx < len(c.history)-1 {
+		c.historyIdx++
+		c.input.SetText(c.history[c.historyIdx])
+	} else {
+		c.historyIdx = len(c.history)
+		c.input.SetText("")
+	}
+	return nil
+}
+
+func (c *KAgentChat) updateTitle() {
+	title := fmt.Sprintf(chatTitleFmt, c.agentName)
+	styles := c.app.Styles.Frame()
+	c.SetTitle(ui.SkinTitle(title, &styles))
+}
+
+// StylesChanged handles style changes.
+func (c *KAgentChat) StylesChanged(s *config.Styles) {
+	c.SetBackgroundColor(s.BgColor())
+	c.output.SetTextColor(s.FgColor())
+	c.output.SetBackgroundColor(s.BgColor())
+	c.input.SetFieldTextColor(s.FgColor())
+}
+
+// InCmdMode checks if in command mode.
+func (*KAgentChat) InCmdMode() bool { return false }
+
+// Name returns the view name.
+func (c *KAgentChat) Name() string { return "kagent-chat" }
+
+// Start starts the view.
+func (*KAgentChat) Start() {}
+
+// Stop stops the view.
+func (c *KAgentChat) Stop() {
+	c.app.Styles.RemoveListener(c)
+}
+
+// Hints returns menu hints.
+func (c *KAgentChat) Hints() model.MenuHints {
+	return c.actions.Hints()
+}
+
+// ExtraHints returns extra hints.
+func (*KAgentChat) ExtraHints() map[string]string {
+	return nil
+}
+
+// Actions returns key actions.
+func (c *KAgentChat) Actions() *ui.KeyActions {
+	return c.actions
+}

--- a/internal/view/kagent_modelconfig.go
+++ b/internal/view/kagent_modelconfig.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/tcell/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// KModelConfig represents a kagent ModelConfig viewer.
+type KModelConfig struct {
+	ResourceViewer
+}
+
+// NewKModelConfig returns a new ModelConfig viewer.
+func NewKModelConfig(gvr *client.GVR) ResourceViewer {
+	m := KModelConfig{
+		ResourceViewer: NewBrowser(gvr),
+	}
+	m.AddBindKeysFn(m.bindKeys)
+	m.GetTable().SetEnterFn(m.showModelConfigDetails)
+
+	return &m
+}
+
+func (m *KModelConfig) bindKeys(aa *ui.KeyActions) {
+	aa.Bulk(ui.KeyMap{
+		ui.KeyA:        ui.NewKeyAction("Show Agents", m.showAgentsCmd, true),
+		ui.KeyS:        ui.NewKeyAction("Show Secret", m.showSecretCmd, true),
+		tcell.KeyCtrlT: ui.NewKeyAction("Test Model", m.testModelCmd, true),
+	})
+}
+
+func (m *KModelConfig) showModelConfigDetails(app *App, _ ui.Tabular, gvr *client.GVR, path string) {
+	// Show YAML view by default
+	v := NewLiveView(app, yamlAction, model.NewYAML(gvr, path))
+	if err := app.inject(v, false); err != nil {
+		app.Flash().Err(err)
+	}
+}
+
+// showAgentsCmd shows all agents using this ModelConfig
+func (m *KModelConfig) showAgentsCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := m.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	ns, name := client.Namespaced(path)
+	m.App().Flash().Infof("Finding agents using ModelConfig %s...", name)
+
+	// Navigate to agents view - users can filter from there
+	agentPath := fmt.Sprintf("agents -n %s", ns)
+	m.App().gotoResource(agentPath, "", false, true)
+
+	return nil
+}
+
+// showSecretCmd shows the associated API key secret
+func (m *KModelConfig) showSecretCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := m.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	// Get the ModelConfig object
+	ctx := context.Background()
+	o, err := m.App().factory.Get(m.GVR(), path, true, nil)
+	if err != nil {
+		m.App().Flash().Errf("Failed to get ModelConfig: %v", err)
+		return nil
+	}
+
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return nil
+	}
+
+	// Extract secret reference from spec
+	spec, _, _ := unstructured.NestedMap(raw.Object, "spec")
+	secretName, ok := spec["apiKeySecret"].(string)
+	if !ok || secretName == "" {
+		m.App().Flash().Warn("ModelConfig has no API key secret configured")
+		return nil
+	}
+
+	// Navigate to the secret
+	secretPath := fmt.Sprintf("secrets %s/%s", raw.GetNamespace(), secretName)
+	m.App().gotoResource(secretPath, "", false, true)
+
+	_ = ctx
+	return nil
+}
+
+// testModelCmd provides info about testing the model
+func (m *KModelConfig) testModelCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := m.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	// Get the ModelConfig object
+	o, err := m.App().factory.Get(m.GVR(), path, true, nil)
+	if err != nil {
+		m.App().Flash().Errf("Failed to get ModelConfig: %v", err)
+		return nil
+	}
+
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return nil
+	}
+
+	// Extract model info
+	spec, _, _ := unstructured.NestedMap(raw.Object, "spec")
+	provider := ""
+	if p, ok := spec["provider"].(string); ok {
+		provider = p
+	}
+	model := ""
+	if m, ok := spec["model"].(string); ok {
+		model = m
+	}
+
+	// Build info message
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("ModelConfig: %s\n\n", raw.GetName()))
+	sb.WriteString(fmt.Sprintf("Provider: %s\n", provider))
+	sb.WriteString(fmt.Sprintf("Model: %s\n\n", model))
+
+	// Provider-specific info
+	switch provider {
+	case "OpenAI":
+		if openai, ok := spec["openAI"].(map[string]interface{}); ok {
+			if baseURL, ok := openai["baseUrl"].(string); ok && baseURL != "" {
+				sb.WriteString(fmt.Sprintf("Base URL: %s\n", baseURL))
+			}
+			if temp, ok := openai["temperature"].(string); ok && temp != "" {
+				sb.WriteString(fmt.Sprintf("Temperature: %s\n", temp))
+			}
+		}
+	case "Anthropic":
+		if anthropic, ok := spec["anthropic"].(map[string]interface{}); ok {
+			if baseURL, ok := anthropic["baseUrl"].(string); ok && baseURL != "" {
+				sb.WriteString(fmt.Sprintf("Base URL: %s\n", baseURL))
+			}
+			if maxTokens, ok := anthropic["maxTokens"].(int64); ok {
+				sb.WriteString(fmt.Sprintf("Max Tokens: %d\n", maxTokens))
+			}
+		}
+	case "AzureOpenAI":
+		if azure, ok := spec["azureOpenAI"].(map[string]interface{}); ok {
+			if endpoint, ok := azure["azureEndpoint"].(string); ok && endpoint != "" {
+				sb.WriteString(fmt.Sprintf("Endpoint: %s\n", endpoint))
+			}
+			if deployment, ok := azure["azureDeployment"].(string); ok && deployment != "" {
+				sb.WriteString(fmt.Sprintf("Deployment: %s\n", deployment))
+			}
+		}
+	case "Ollama":
+		if ollama, ok := spec["ollama"].(map[string]interface{}); ok {
+			if host, ok := ollama["host"].(string); ok && host != "" {
+				sb.WriteString(fmt.Sprintf("Host: %s\n", host))
+			}
+		}
+	}
+
+	sb.WriteString("\nTo test this model, create an agent using this ModelConfig")
+	sb.WriteString("\nand invoke it with 'kagent invoke <agent-name>'")
+
+	// Show in details view
+	v := NewDetails(m.App(), "ModelConfig Info", raw.GetName(), contentTXT, true)
+	v.Update(sb.String())
+	if err := m.App().inject(v, false); err != nil {
+		m.App().Flash().Err(err)
+	}
+
+	return nil
+}
+

--- a/internal/view/kagent_toolserver.go
+++ b/internal/view/kagent_toolserver.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/tcell/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// KToolServer represents a kagent ToolServer viewer.
+type KToolServer struct {
+	ResourceViewer
+}
+
+// NewKToolServer returns a new ToolServer viewer.
+func NewKToolServer(gvr *client.GVR) ResourceViewer {
+	t := KToolServer{
+		ResourceViewer: NewBrowser(gvr),
+	}
+	t.AddBindKeysFn(t.bindKeys)
+	t.GetTable().SetEnterFn(t.showToolServerDetails)
+
+	return &t
+}
+
+func (t *KToolServer) bindKeys(aa *ui.KeyActions) {
+	aa.Bulk(ui.KeyMap{
+		ui.KeyT:        ui.NewKeyAction("List Tools", t.listToolsCmd, true),
+		ui.KeyA:        ui.NewKeyAction("Show Agents", t.showAgentsCmd, true),
+		tcell.KeyCtrlT: ui.NewKeyAction("Test Connection", t.testConnectionCmd, true),
+	})
+}
+
+func (t *KToolServer) showToolServerDetails(app *App, _ ui.Tabular, gvr *client.GVR, path string) {
+	// Show YAML view by default
+	v := NewLiveView(app, yamlAction, model.NewYAML(gvr, path))
+	if err := app.inject(v, false); err != nil {
+		app.Flash().Err(err)
+	}
+}
+
+// listToolsCmd shows all discovered tools for this ToolServer
+func (t *KToolServer) listToolsCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := t.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	// Get the ToolServer object
+	ctx := context.Background()
+	o, err := t.App().factory.Get(t.GVR(), path, true, nil)
+	if err != nil {
+		t.App().Flash().Errf("Failed to get ToolServer: %v", err)
+		return nil
+	}
+
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return nil
+	}
+
+	// Extract discovered tools from status
+	status, _, _ := unstructured.NestedMap(raw.Object, "status")
+	discoveredTools, ok := status["discoveredTools"].([]interface{})
+	if !ok || len(discoveredTools) == 0 {
+		t.App().Flash().Warn("No tools discovered for this ToolServer")
+		return nil
+	}
+
+	// Build tools list
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Discovered Tools for ToolServer %s:\n\n", raw.GetName()))
+	sb.WriteString(fmt.Sprintf("Total: %d tools\n", len(discoveredTools)))
+	sb.WriteString(strings.Repeat("-", 60) + "\n\n")
+
+	for i, tool := range discoveredTools {
+		toolMap, ok := tool.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		name := ""
+		if n, ok := toolMap["name"].(string); ok {
+			name = n
+		}
+
+		description := ""
+		if d, ok := toolMap["description"].(string); ok {
+			description = d
+		}
+
+		sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, name))
+		if description != "" {
+			// Wrap description
+			wrapped := wrapText(description, 55)
+			for _, line := range strings.Split(wrapped, "\n") {
+				sb.WriteString(fmt.Sprintf("   %s\n", line))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	// Show in a details view
+	v := NewDetails(t.App(), "ToolServer Tools", raw.GetName(), contentTXT, true)
+	v.Update(sb.String())
+	if err := t.App().inject(v, false); err != nil {
+		t.App().Flash().Err(err)
+	}
+
+	_ = ctx
+	return nil
+}
+
+// showAgentsCmd shows all agents using this ToolServer
+func (t *KToolServer) showAgentsCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := t.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	ns, name := client.Namespaced(path)
+
+	// Navigate to agents view filtered by this toolserver
+	// This uses a label selector or we could scan agents
+	t.App().Flash().Infof("Finding agents using ToolServer %s...", name)
+
+	// For now, just show a hint - full implementation would query agents
+	agentPath := fmt.Sprintf("agents -n %s", ns)
+	t.App().gotoResource(agentPath, "", false, true)
+
+	return nil
+}
+
+// testConnectionCmd tests the connection to the ToolServer
+func (t *KToolServer) testConnectionCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := t.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	// Get the ToolServer object
+	o, err := t.App().factory.Get(t.GVR(), path, true, nil)
+	if err != nil {
+		t.App().Flash().Errf("Failed to get ToolServer: %v", err)
+		return nil
+	}
+
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return nil
+	}
+
+	// Extract config
+	spec, _, _ := unstructured.NestedMap(raw.Object, "spec")
+	config, _ := spec["config"].(map[string]interface{})
+
+	serverType := "unknown"
+	endpoint := ""
+
+	if sse, ok := config["sse"].(map[string]interface{}); ok {
+		serverType = "SSE"
+		if url, ok := sse["url"].(string); ok {
+			endpoint = url
+		}
+	} else if streamable, ok := config["streamableHttp"].(map[string]interface{}); ok {
+		serverType = "StreamableHTTP"
+		if url, ok := streamable["url"].(string); ok {
+			endpoint = url
+		}
+	} else if stdio, ok := config["stdio"].(map[string]interface{}); ok {
+		serverType = "Stdio"
+		if cmd, ok := stdio["command"].(string); ok {
+			endpoint = cmd
+		}
+	}
+
+	t.App().Flash().Infof("ToolServer %s (%s): %s", raw.GetName(), serverType, endpoint)
+
+	// For HTTP-based servers, we could do an actual health check here
+	if serverType == "SSE" || serverType == "StreamableHTTP" {
+		t.App().Flash().Infof("Testing connection to %s...", endpoint)
+		// In a real implementation, we'd make an HTTP request here
+		t.App().Flash().Infof("Connection test: Use 'kagent mcp inspector' for detailed testing")
+	}
+
+	return nil
+}
+
+// wrapText wraps text at the specified width
+func wrapText(text string, width int) string {
+	if len(text) <= width {
+		return text
+	}
+
+	var result strings.Builder
+	words := strings.Fields(text)
+	lineLen := 0
+
+	for i, word := range words {
+		if lineLen+len(word)+1 > width && lineLen > 0 {
+			result.WriteString("\n")
+			lineLen = 0
+		}
+		if i > 0 && lineLen > 0 {
+			result.WriteString(" ")
+			lineLen++
+		}
+		result.WriteString(word)
+		lineLen += len(word)
+	}
+
+	return result.String()
+}
+

--- a/internal/view/registrar.go
+++ b/internal/view/registrar.go
@@ -16,6 +16,7 @@ func loadCustomViewers() MetaViewers {
 	batchViewers(m)
 	crdViewers(m)
 	helmViewers(m)
+	kagentViewers(m)
 
 	return m
 }
@@ -143,5 +144,18 @@ func batchViewers(vv MetaViewers) {
 func crdViewers(vv MetaViewers) {
 	vv[client.CrdGVR] = MetaViewer{
 		viewerFn: NewCRD,
+	}
+}
+
+// kagentViewers registers kagent AI agent resource viewers.
+func kagentViewers(vv MetaViewers) {
+	vv[client.KAgentGVR] = MetaViewer{
+		viewerFn: NewKAgent,
+	}
+	vv[client.KModelConfigGVR] = MetaViewer{
+		viewerFn: NewKModelConfig,
+	}
+	vv[client.KToolServerGVR] = MetaViewer{
+		viewerFn: NewKToolServer,
 	}
 }

--- a/plugins/README-kagent.md
+++ b/plugins/README-kagent.md
@@ -1,0 +1,123 @@
+# k9s + kagent Integration
+
+This integration brings AI-powered Kubernetes management to k9s through kagent.
+
+## Features
+
+### Native Resource Views
+
+When kagent is installed in your cluster, k9s automatically discovers and displays:
+
+- **Agents** (`agents`, `ka`) - AI agents with custom views showing type, model, tools, and status
+- **ModelConfigs** (`modelconfigs`, `mc`) - LLM provider configurations with provider details
+- **ToolServers** (`toolservers`, `ts`) - MCP tool servers with discovered tools count
+
+### Custom Keybindings
+
+When viewing kagent Agents:
+
+| Key | Action | Description |
+|-----|--------|-------------|
+| `i` | Invoke | Run the agent with a message |
+| `c` | Chat | Open embedded chat interface |
+| `t` | Tools | List all tools available to the agent |
+| `m` | ModelConfig | Navigate to the agent's model configuration |
+| `l` | Logs | View logs for the agent's pods |
+| `Ctrl+i` | Quick Invoke | Quick invoke with prompt |
+
+When viewing ToolServers:
+
+| Key | Action | Description |
+|-----|--------|-------------|
+| `t` | List Tools | Show all discovered tools |
+| `a` | Show Agents | Find agents using this ToolServer |
+| `Ctrl+t` | Test | Test the connection |
+
+When viewing ModelConfigs:
+
+| Key | Action | Description |
+|-----|--------|-------------|
+| `a` | Show Agents | Find agents using this ModelConfig |
+| `s` | Show Secret | Navigate to the API key secret |
+| `Ctrl+t` | Test Model | Show model configuration details |
+
+### Plugins
+
+Install the kagent plugins by copying `kagent.yaml` to your k9s plugins directory:
+
+```bash
+cp plugins/kagent.yaml ~/.config/k9s/plugins.yaml
+# Or merge with existing plugins
+```
+
+Plugin shortcuts (work on any resource):
+
+| Key | Action | Description |
+|-----|--------|-------------|
+| `Shift+K` | Investigate | Ask kagent to investigate the resource |
+| `Shift+C` | Chat | Start interactive chat with context |
+| `Shift+A` | Ask | Custom question about the resource |
+| `Shift+L` | Analyze Logs | Get AI analysis of logs |
+| `Shift+E` | Explain | Explain the resource configuration |
+| `Shift+F` | Fix | Get suggestions to fix issues |
+
+### Aliases
+
+Add kagent aliases for quick navigation. Copy `kagent-aliases.yaml` to your aliases file:
+
+```bash
+# Merge with existing aliases
+cat plugins/kagent-aliases.yaml >> ~/.config/k9s/aliases.yaml
+```
+
+Then you can use:
+- `:ka` or `:agents` - View agents
+- `:mc` or `:models` - View model configs  
+- `:ts` or `:tools` - View tool servers
+- `:mcp` - View MCP servers (alias for toolservers)
+
+## Requirements
+
+1. **kagent installed in your cluster**
+   ```bash
+   helm install kagent kagent/kagent -n kagent-system --create-namespace
+   ```
+
+2. **kagent CLI** (for plugins and chat)
+   ```bash
+   curl -sSL https://kagent.dev/install.sh | bash
+   ```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `KAGENT_K8S_AGENT` | Default agent for k8s operations | `k8s-agent` |
+| `KAGENT_AGENT` | Default agent for chat | `k8s-agent` |
+
+## Troubleshooting
+
+### Agents not showing up
+
+Make sure kagent CRDs are installed:
+```bash
+kubectl get crd agents.kagent.dev
+```
+
+### Chat not working
+
+Ensure the kagent CLI is in your PATH:
+```bash
+which kagent
+```
+
+### Plugins not loading
+
+Check your k9s plugins directory:
+```bash
+ls ~/.config/k9s/plugins.yaml
+```
+
+## Contributing
+
+This integration is part of the k9s-kagent-integration project. Contributions welcome!

--- a/plugins/kagent-aliases.yaml
+++ b/plugins/kagent-aliases.yaml
@@ -1,0 +1,35 @@
+# kagent Aliases for K9s
+# Copy this file to ~/.config/k9s/aliases.yaml or merge with your existing aliases
+#
+# These aliases make it easy to navigate kagent resources quickly
+
+aliases:
+  # Agent shortcuts
+  ka: kagent.dev/v1alpha2/agents
+  kagent: kagent.dev/v1alpha2/agents
+  agents: kagent.dev/v1alpha2/agents
+  agent: kagent.dev/v1alpha2/agents
+  
+  # ModelConfig shortcuts  
+  kmc: kagent.dev/v1alpha2/modelconfigs
+  modelconfig: kagent.dev/v1alpha2/modelconfigs
+  modelconfigs: kagent.dev/v1alpha2/modelconfigs
+  mc: kagent.dev/v1alpha2/modelconfigs
+  models: kagent.dev/v1alpha2/modelconfigs
+  
+  # ToolServer shortcuts
+  kts: kagent.dev/v1alpha1/toolservers
+  toolserver: kagent.dev/v1alpha1/toolservers
+  toolservers: kagent.dev/v1alpha1/toolservers
+  ts: kagent.dev/v1alpha1/toolservers
+  tools: kagent.dev/v1alpha1/toolservers
+  mcp: kagent.dev/v1alpha1/toolservers
+  
+  # Memory shortcuts
+  kmem: kagent.dev/v1alpha1/memories
+  memories: kagent.dev/v1alpha1/memories
+  memory: kagent.dev/v1alpha1/memories
+  
+  # RemoteMCPServer shortcuts
+  krmcp: kagent.dev/v1alpha2/remotemcpservers
+  remotemcp: kagent.dev/v1alpha2/remotemcpservers

--- a/plugins/kagent.yaml
+++ b/plugins/kagent.yaml
@@ -1,0 +1,291 @@
+# kagent Plugins for K9s
+# Integrate AI agents into your Kubernetes workflow
+#
+# Prerequisites:
+# - kagent CLI installed: https://kagent.dev/docs/kagent/introduction/installation
+# - kagent deployed to your cluster with agents configured
+#
+# Usage:
+# - Navigate to any resource in k9s
+# - Use the shortcuts below to interact with kagent agents
+
+plugins:
+  # Invoke the K8s debugging agent to investigate a resource
+  kagent-investigate:
+    shortCut: Shift-K
+    description: Ask kagent to investigate
+    scopes:
+      - pods
+      - deployments
+      - services
+      - daemonsets
+      - statefulsets
+      - replicasets
+      - jobs
+      - cronjobs
+    command: bash
+    background: false
+    confirm: false
+    args:
+      - -c
+      - |
+        echo "🤖 Invoking kagent to investigate $RESOURCE_NAME/$NAME in namespace $NAMESPACE..."
+        echo ""
+        
+        # Check if kagent CLI is available
+        if ! command -v kagent &> /dev/null; then
+            echo "❌ kagent CLI not found. Install from: https://kagent.dev"
+            echo ""
+            echo "Press any key to exit..."
+            read -n 1
+            exit 1
+        fi
+        
+        # Try to invoke the k8s agent
+        AGENT_NAME="${KAGENT_K8S_AGENT:-k8s-agent}"
+        
+        kagent invoke --agent "$AGENT_NAME" \
+          --task "Investigate the $RESOURCE_NAME named '$NAME' in namespace '$NAMESPACE'. Check its status, events, logs if applicable, and identify any issues."
+        
+        echo ""
+        echo "Press 'q' to exit"
+        while : ; do
+          read -n 1 k <&1
+          if [[ $k = q ]] ; then
+            break
+          fi
+        done
+
+  # Interactive chat with a kagent agent
+  kagent-chat:
+    shortCut: Shift-C
+    description: Chat with kagent
+    scopes:
+      - all
+    command: bash
+    background: false
+    confirm: false
+    args:
+      - -c
+      - |
+        echo "🤖 Starting kagent chat session..."
+        echo "Context: Viewing $RESOURCE_NAME in namespace $NAMESPACE"
+        echo ""
+        
+        if ! command -v kagent &> /dev/null; then
+            echo "❌ kagent CLI not found. Install from: https://kagent.dev"
+            echo ""
+            echo "Press any key to exit..."
+            read -n 1
+            exit 1
+        fi
+        
+        # Default to k8s-agent if KAGENT_AGENT not set
+        AGENT_NAME="${KAGENT_AGENT:-k8s-agent}"
+        
+        kagent dashboard --agent "$AGENT_NAME"
+
+  # Custom question to kagent about current resource
+  kagent-ask:
+    shortCut: Shift-A
+    description: Ask kagent a custom question
+    scopes:
+      - all
+    command: bash
+    background: false
+    confirm: false
+    args:
+      - -c
+      - |
+        echo "🤖 kagent - Ask anything about $RESOURCE_NAME/$NAME"
+        echo ""
+        
+        if ! command -v kagent &> /dev/null; then
+            echo "❌ kagent CLI not found. Install from: https://kagent.dev"
+            echo ""
+            echo "Press any key to exit..."
+            read -n 1
+            exit 1
+        fi
+        
+        INSTRUCTIONS="# Enter your question below. Lines starting with '#' will be ignored."
+        DEFAULT_QUESTION="What is the current state of $NAME and are there any issues?"
+        
+        QUESTION_FILE=$(mktemp)
+        
+        echo "$INSTRUCTIONS" > "$QUESTION_FILE"
+        echo "" >> "$QUESTION_FILE"
+        echo "$DEFAULT_QUESTION" >> "$QUESTION_FILE"
+        
+        # Open in editor
+        ${EDITOR:-nano} "$QUESTION_FILE"
+        
+        # Read the question, ignoring comments
+        QUESTION=$(grep -v '^#' "$QUESTION_FILE" | tr '\n' ' ')
+        
+        if [ -z "$QUESTION" ]; then
+            echo "No question provided. Exiting."
+            rm "$QUESTION_FILE"
+            exit 0
+        fi
+        
+        AGENT_NAME="${KAGENT_K8S_AGENT:-k8s-agent}"
+        
+        echo "Asking: $QUESTION"
+        echo ""
+        
+        kagent invoke --agent "$AGENT_NAME" --task "$QUESTION"
+        
+        rm "$QUESTION_FILE"
+        
+        echo ""
+        echo "Press 'q' to exit"
+        while : ; do
+          read -n 1 k <&1
+          if [[ $k = q ]] ; then
+            break
+          fi
+        done
+
+  # Get logs analysis from kagent
+  kagent-analyze-logs:
+    shortCut: Shift-L
+    description: Analyze logs with kagent
+    scopes:
+      - pods
+      - deployments
+      - daemonsets
+      - statefulsets
+    command: bash
+    background: false
+    confirm: false
+    args:
+      - -c
+      - |
+        echo "🤖 Analyzing logs for $NAME with kagent..."
+        echo ""
+        
+        if ! command -v kagent &> /dev/null; then
+            echo "❌ kagent CLI not found. Install from: https://kagent.dev"
+            echo ""
+            echo "Press any key to exit..."
+            read -n 1
+            exit 1
+        fi
+        
+        # Capture recent logs
+        LOGS=$(kubectl logs --tail=100 -n "$NAMESPACE" "$NAME" 2>/dev/null || echo "Could not fetch logs directly")
+        
+        AGENT_NAME="${KAGENT_K8S_AGENT:-k8s-agent}"
+        
+        kagent invoke --agent "$AGENT_NAME" \
+          --task "Analyze the recent logs for $RESOURCE_NAME '$NAME' in namespace '$NAMESPACE'. Look for errors, warnings, and any patterns that might indicate issues. Here are the recent logs:
+        
+        $LOGS"
+        
+        echo ""
+        echo "Press 'q' to exit"
+        while : ; do
+          read -n 1 k <&1
+          if [[ $k = q ]] ; then
+            break
+          fi
+        done
+
+  # Explain a Kubernetes resource with kagent
+  kagent-explain:
+    shortCut: Shift-E
+    description: Explain resource with kagent
+    scopes:
+      - all
+    command: bash
+    background: false
+    confirm: false
+    args:
+      - -c
+      - |
+        echo "🤖 Getting kagent to explain $RESOURCE_NAME/$NAME..."
+        echo ""
+        
+        if ! command -v kagent &> /dev/null; then
+            echo "❌ kagent CLI not found. Install from: https://kagent.dev"
+            echo ""
+            echo "Press any key to exit..."
+            read -n 1
+            exit 1
+        fi
+        
+        # Get the resource YAML
+        YAML=$(kubectl get "$RESOURCE_NAME" "$NAME" -n "$NAMESPACE" -o yaml 2>/dev/null || echo "Could not fetch resource")
+        
+        AGENT_NAME="${KAGENT_K8S_AGENT:-k8s-agent}"
+        
+        kagent invoke --agent "$AGENT_NAME" \
+          --task "Explain this Kubernetes $RESOURCE_NAME resource in detail. Describe what it does, its current configuration, and any important settings:
+        
+        $YAML"
+        
+        echo ""
+        echo "Press 'q' to exit"
+        while : ; do
+          read -n 1 k <&1
+          if [[ $k = q ]] ; then
+            break
+          fi
+        done
+
+  # Suggest fixes for unhealthy resources
+  kagent-fix:
+    shortCut: Shift-F
+    description: Suggest fixes with kagent
+    scopes:
+      - pods
+      - deployments
+      - services
+      - daemonsets
+      - statefulsets
+    command: bash
+    background: false
+    confirm: false
+    args:
+      - -c
+      - |
+        echo "🤖 Getting kagent to suggest fixes for $RESOURCE_NAME/$NAME..."
+        echo ""
+        
+        if ! command -v kagent &> /dev/null; then
+            echo "❌ kagent CLI not found. Install from: https://kagent.dev"
+            echo ""
+            echo "Press any key to exit..."
+            read -n 1
+            exit 1
+        fi
+        
+        # Get resource details and events
+        RESOURCE=$(kubectl get "$RESOURCE_NAME" "$NAME" -n "$NAMESPACE" -o yaml 2>/dev/null)
+        EVENTS=$(kubectl get events -n "$NAMESPACE" --field-selector "involvedObject.name=$NAME" --sort-by='.lastTimestamp' 2>/dev/null | tail -20)
+        
+        AGENT_NAME="${KAGENT_K8S_AGENT:-k8s-agent}"
+        
+        kagent invoke --agent "$AGENT_NAME" \
+          --task "Analyze this $RESOURCE_NAME and suggest fixes for any issues:
+        
+        Resource YAML:
+        $RESOURCE
+        
+        Recent Events:
+        $EVENTS
+        
+        Please:
+        1. Identify any problems
+        2. Explain the root cause
+        3. Provide specific kubectl commands or YAML patches to fix the issues"
+        
+        echo ""
+        echo "Press 'q' to exit"
+        while : ; do
+          read -n 1 k <&1
+          if [[ $k = q ]] ; then
+            break
+          fi
+        done


### PR DESCRIPTION
Initial integration enabling k9s to display and interact with kagent resources (Agents, ModelConfigs, ToolServers) with a basic chat interface.
What's included:
- Custom views and renderers for kagent CRDs
- Plugin configuration and aliases
- Basic chat functionality with agents

Disclaimer: This is a vibecoded proof-of-concept. It works but definitely needs polish, testing, and refinement. Consider this a starting point to spark discussion and further development rather than a production-ready feature.


<img width="1142" height="869" alt="Screenshot 2026-02-04 at 2 10 13 AM" src="https://github.com/user-attachments/assets/dbc2d9ba-3b4e-4b70-a6e2-f11fe5b42a3d" />

