### PR TITLE
fix: Allow whitespaces in kube context

### DIFF
--- a/internal/view/cmd/args.go
+++ b/internal/view/cmd/args.go
@@ -82,9 +82,21 @@ func newArgs(p *Interpreter, aa []string) args {
 
 func (a args) String() string {
 	ss := make([]string, 0, len(a))
-	kk := maps.Keys(a)
-	for _, k := range slices.Sorted(kk) {
-		v := a[k]
+	ordered := []string{
+		contextKey,
+		filterKey,
+		fuzzyKey,
+		labelKey,
+		topicKey,
+		nsKey,
+	}
+	seen := make(map[string]struct{}, len(ordered))
+
+	appendKey := func(k string) {
+		v, ok := a[k]
+		if !ok || v == "" {
+			return
+		}
 		switch k {
 		case labelKey:
 			v = "'" + v + "'"
@@ -94,6 +106,19 @@ func (a args) String() string {
 			v = contextFlag + v
 		}
 		ss = append(ss, v)
+	}
+
+	for _, k := range ordered {
+		appendKey(k)
+		seen[k] = struct{}{}
+	}
+
+	kk := maps.Keys(a)
+	for _, k := range slices.Sorted(kk) {
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		appendKey(k)
 	}
 
 	return strings.Join(ss, " ")

--- a/internal/view/cmd/helpers.go
+++ b/internal/view/cmd/helpers.go
@@ -63,6 +63,21 @@ func ShouldAddSuggest(command, suggest string) (string, bool) {
 
 // SuggestSubCommand suggests namespaces or contexts based on current command.
 func SuggestSubCommand(command string, namespaces client.NamespaceNames, contexts []string) []string {
+	if ctx, quote, ok := quotedContextPrefix(command); ok {
+		suggests := completeCtx(command+" ", ctx, contexts, true)
+		qq := string(quote)
+		if quote != 0 {
+			for i, s := range suggests {
+				suggests[i] = s + qq
+			}
+			if ctx != "" && isExactContext(ctx, contexts) && !slices.Contains(suggests, qq) {
+				suggests = append(suggests, qq)
+			}
+		}
+		slices.Sort(suggests)
+		return suggests
+	}
+
 	p := NewInterpreter(command)
 	var suggests []string
 	switch {
@@ -81,11 +96,14 @@ func SuggestSubCommand(command string, namespaces client.NamespaceNames, context
 		if !ok {
 			return nil
 		}
-		suggests = completeCtx(command, n, contexts)
+		suggests = completeCtx(command, n, contexts, true)
+		if len(suggests) == 0 {
+			suggests = completeCtxToken(n, contexts)
+		}
 
 	case p.HasNS():
 		if n, ok := p.HasContext(); ok {
-			suggests = completeCtx(command, n, contexts)
+			suggests = completeCtx(command, n, contexts, false)
 		}
 		if len(suggests) > 0 {
 			break
@@ -99,12 +117,45 @@ func SuggestSubCommand(command string, namespaces client.NamespaceNames, context
 
 	default:
 		if n, ok := p.HasContext(); ok {
-			suggests = completeCtx(command, n, contexts)
+			suggests = completeCtx(command, n, contexts, false)
 		}
 	}
 	slices.Sort(suggests)
 
 	return suggests
+}
+
+func isExactContext(ctx string, contexts []string) bool {
+	for _, ctxName := range contexts {
+		if ctxName == ctx {
+			return true
+		}
+	}
+	return false
+}
+
+func quotedContextPrefix(command string) (string, byte, bool) {
+	at := strings.LastIndex(command, "@")
+	if at == -1 {
+		return "", 0, false
+	}
+	if at > 0 && !isWhitespace(command[at-1]) {
+		return "", 0, false
+	}
+	tail := command[at+1:]
+	if tail == "" {
+		return "", 0, false
+	}
+	quote := tail[0]
+	if quote != '"' && quote != '\'' {
+		return "", 0, false
+	}
+	rest := tail[1:]
+	if strings.IndexByte(rest, quote) != -1 {
+		return "", 0, false
+	}
+
+	return rest, quote, true
 }
 
 func completeNS(s string, nn client.NamespaceNames) []string {
@@ -122,15 +173,68 @@ func completeNS(s string, nn client.NamespaceNames) []string {
 	return suggests
 }
 
-func completeCtx(command, s string, contexts []string) []string {
+func completeCtx(command, s string, contexts []string, allowSpaces bool) []string {
 	var suggests []string
+	seen := make(map[string]struct{}, len(contexts))
+	disallowedMatch := false
 	for _, ctxName := range contexts {
+		if !allowSpaces && strings.IndexAny(ctxName, " \t") != -1 {
+			if strings.HasPrefix(ctxName, s) {
+				disallowedMatch = true
+			}
+			continue
+		}
+		if _, ok := seen[ctxName]; ok {
+			continue
+		}
+		seen[ctxName] = struct{}{}
 		if suggest, ok := ShouldAddSuggest(s, ctxName); ok {
 			if s == "" && !strings.HasSuffix(command, " ") {
 				suggests = append(suggests, " "+suggest)
 				continue
 			}
 			suggests = append(suggests, suggest)
+		}
+	}
+
+	if len(suggests) == 0 && disallowedMatch {
+		return []string{""}
+	}
+
+	return suggests
+}
+
+func completeCtxToken(needle string, contexts []string) []string {
+	idx := strings.LastIndexAny(needle, " \t")
+	if idx == -1 {
+		return nil
+	}
+	prefix := strings.TrimSpace(needle[:idx])
+	tail := strings.TrimSpace(needle[idx+1:])
+	if prefix == "" || tail == "" {
+		return nil
+	}
+	var suggests []string
+	seen := make(map[string]struct{}, len(contexts))
+	for _, ctxName := range contexts {
+		if !strings.HasPrefix(ctxName, prefix) {
+			continue
+		}
+		if len(ctxName) <= len(prefix) || !isWhitespace(ctxName[len(prefix)]) {
+			continue
+		}
+		for _, token := range strings.Fields(ctxName[len(prefix):]) {
+			if strings.HasPrefix(token, tail) {
+				remain := strings.TrimPrefix(token, tail)
+				if remain == "" {
+					continue
+				}
+				if _, ok := seen[remain]; ok {
+					continue
+				}
+				seen[remain] = struct{}{}
+				suggests = append(suggests, remain)
+			}
 		}
 	}
 

--- a/internal/view/cmd/helpers_test.go
+++ b/internal/view/cmd/helpers_test.go
@@ -65,7 +65,7 @@ func TestSuggestSubCommand(t *testing.T) {
 		"default":       {},
 		"nginx-ingress": {},
 	}
-	contextNames := []string{"develop", "test", "pre", "prod"}
+	contextNames := []string{"develop", "test", "pre", "prod", "ns/server:6443/Firstname Middlename Secondname"}
 
 	tests := []struct {
 		Command     string
@@ -77,10 +77,16 @@ func TestSuggestSubCommand(t *testing.T) {
 		{Command: "ctx p", Suggestions: []string{"re", "rod"}},
 		{Command: "ctx   p", Suggestions: []string{"re", "rod"}},
 		{Command: "ctx pr", Suggestions: []string{"e", "od"}},
-		{Command: "ctx", Suggestions: []string{" develop", " pre", " prod", " test"}},
-		{Command: "ctx ", Suggestions: []string{"develop", "pre", "prod", "test"}},
+		{Command: "ctx", Suggestions: []string{" develop", " ns/server:6443/Firstname Middlename Secondname", " pre", " prod", " test"}},
+		{Command: "ctx ", Suggestions: []string{"develop", "ns/server:6443/Firstname Middlename Secondname", "pre", "prod", "test"}},
 		{Command: "context   d", Suggestions: []string{"evelop"}},
 		{Command: "contexts   t", Suggestions: []string{"est"}},
+		{Command: "ctx ns/server:6443/Firstname S", Suggestions: []string{"econdname"}},
+		{Command: "po @\"d", Suggestions: []string{"evelop\""}},
+		{Command: "po @\"pre", Suggestions: []string{"\""}},
+		{Command: "po @'t", Suggestions: []string{"est'"}},
+		{Command: "po @\"n", Suggestions: []string{"s/server:6443/Firstname Middlename Secondname\""}},
+		{Command: "po @n", Suggestions: []string{""}},
 		{Command: "po ", Suggestions: nil},
 		{Command: "po  x", Suggestions: nil},
 		{Command: "po k", Suggestions: []string{"ube-public", "ube-system"}},

--- a/internal/view/cmd/interpreter.go
+++ b/internal/view/cmd/interpreter.go
@@ -82,6 +82,9 @@ func (c *Interpreter) grok() {
 	if lbls != "" {
 		ff = append(ff, lbls)
 	}
+	if c.IsContextCmd() && len(ff) > 1 {
+		ff = []string{strings.Join(ff, " ")}
+	}
 	c.args = newArgs(c, ff)
 }
 

--- a/internal/view/cmd/interpreter.go
+++ b/internal/view/cmd/interpreter.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"log/slog"
+	"regexp"
 	"strings"
 
 	"github.com/derailed/k9s/internal/client"
@@ -66,8 +67,9 @@ func (c *Interpreter) grok() {
 	}
 	c.cmd = strings.ToLower(ff[0])
 
-	var lbls string
 	line := strings.TrimSpace(strings.Replace(c.line, ff[0], "", 1))
+	ctx, line := extractContextArg(line)
+	var lbls string
 	if strings.Contains(line, "'") {
 		start, end, ok := quoteIndicies(line)
 		if ok {
@@ -86,6 +88,9 @@ func (c *Interpreter) grok() {
 		ff = []string{strings.Join(ff, " ")}
 	}
 	c.args = newArgs(c, ff)
+	if ctx != "" {
+		c.args[contextKey] = ctx
+	}
 }
 
 func quoteIndicies(s string) (start, end int, ok bool) {
@@ -102,6 +107,38 @@ func quoteIndicies(s string) (start, end int, ok bool) {
 	}
 	ok = start != -1 && end != -1
 	return
+}
+
+var (
+	contextQuotedSingleRX = regexp.MustCompile(`(^|\s)@'([^']+)'`)
+	contextQuotedDoubleRX = regexp.MustCompile(`(^|\s)@"([^"]+)"`)
+)
+
+func extractContextArg(line string) (string, string) {
+	if line == "" {
+		return "", line
+	}
+	if ctx, rest, ok := extractQuotedContext(line, contextQuotedSingleRX); ok {
+		return ctx, rest
+	}
+	if ctx, rest, ok := extractQuotedContext(line, contextQuotedDoubleRX); ok {
+		return ctx, rest
+	}
+	return "", line
+}
+
+func extractQuotedContext(line string, rx *regexp.Regexp) (string, string, bool) {
+	loc := rx.FindStringSubmatchIndex(line)
+	if loc == nil {
+		return "", line, false
+	}
+	ctx := line[loc[4]:loc[5]]
+	rest := strings.TrimSpace(line[:loc[0]] + line[loc[1]:])
+	return ctx, rest, true
+}
+
+func isWhitespace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
 }
 
 // HasNS returns true if ns is present in prompt.

--- a/internal/view/cmd/interpreter_test.go
+++ b/internal/view/cmd/interpreter_test.go
@@ -498,6 +498,11 @@ func TestContextCmd(t *testing.T) {
 			ok:  true,
 			ctx: "kind-fred",
 		},
+		"with-spaces": {
+			cmd: "ctx default/openshift-cluster:6443/Fistname Lastname",
+			ok:  true,
+			ctx: "default/openshift-cluster:6443/Fistname Lastname",
+		},
 	}
 
 	for k := range uu {

--- a/internal/view/cmd/interpreter_test.go
+++ b/internal/view/cmd/interpreter_test.go
@@ -650,6 +650,31 @@ func TestArgs(t *testing.T) {
 			ok:  true,
 			ctx: "fred",
 		},
+		"with-space-context-unquoted-last": {
+			cmd: "po @context with space",
+			ok:  true,
+			ctx: "context",
+		},
+		"with-space-context-unquoted-with-slashes": {
+			cmd: "po @default/server:6443/Firstname Middlename Lastname",
+			ok:  true,
+			ctx: "default/server:6443/Firstname",
+		},
+		"with-space-context-quoted": {
+			cmd: "po @'context with space'",
+			ok:  true,
+			ctx: "context with space",
+		},
+		"with-space-context-quoted-then-namespace": {
+			cmd: "po @'context with space' fred",
+			ok:  true,
+			ctx: "context with space",
+		},
+		"with-space-context-quoted-double-then-namespace": {
+			cmd: "po @\"context with space\" fred",
+			ok:  true,
+			ctx: "context with space",
+		},
 	}
 
 	for k := range uu {

--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -28,7 +28,7 @@ const (
 
 var (
 	customViewers MetaViewers
-	contextRX     = regexp.MustCompile(`\s+@([\w-]+)`)
+	contextRX     = regexp.MustCompile(`\s+@(?:'[^']+'|"[^"]+"|[\w-]+)`)
 )
 
 // Command represents a user command.
@@ -372,7 +372,12 @@ func (c *Command) exec(p *cmd.Interpreter, gvr *client.GVR, comp model.Component
 	comp.SetCommand(p)
 
 	if clearStack {
-		v := contextRX.ReplaceAllString(p.GetLine(), "")
+		v := p.GetLine()
+		if ctx, ok := p.HasContext(); ok {
+			v = stripContextFromLine(v, ctx)
+		} else {
+			v = contextRX.ReplaceAllString(v, "")
+		}
 		c.app.Config.SetActiveView(v)
 	}
 	if err := c.app.inject(comp, clearStack); err != nil {
@@ -384,4 +389,24 @@ func (c *Command) exec(p *cmd.Interpreter, gvr *client.GVR, comp model.Component
 	slog.Debug("History (exec)", slogs.Stack, strings.Join(c.app.cmdHistory.List(), "|"))
 
 	return
+}
+
+func stripContextFromLine(line, ctx string) string {
+	if ctx == "" {
+		return strings.TrimSpace(line)
+	}
+
+	candidates := []string{
+		" @\"" + ctx + "\"",
+		" @'" + ctx + "'",
+		" @" + ctx,
+	}
+	for _, c := range candidates {
+		if strings.Contains(line, c) {
+			line = strings.Replace(line, c, "", 1)
+			return strings.TrimSpace(line)
+		}
+	}
+
+	return strings.TrimSpace(line)
 }


### PR DESCRIPTION
I use OpenShift with Azure Entra auth, and the context I get generated on `oc login` (or `oc project`) includes my full name separated by a whitespace. This patch makes it valid for k9s.

> Disclaimer: I don't read or write go fluently. This patch has been done with the help of ChatGPT codex. I've tested it, though.

Closes #3815 