### PR TITLE
fix(view): panic on invalid write count in log viewer (#3802)

### DIFF
--- a/internal/view/logger.go
+++ b/internal/view/logger.go
@@ -163,3 +163,11 @@ func (l *Logger) saveCmd(*tcell.EventKey) *tcell.EventKey {
 
 	return nil
 }
+
+func (l *Logger) Write(p []byte) (n int, err error) {
+	n, err = l.TextView.Write(p)
+	if n > len(p) {
+		return len(p), err
+	}
+	return n, err
+}


### PR DESCRIPTION
Description
Fixes a panic bytes.Buffer.WriteTo: invalid Write count that occurs when jumping to the head of logs (pressing 1).

Issue Links
Fixes #3802

Root Cause
The tview dependency's TextView.Write method implementation violates the io.Writer contract. It can return a byte count (n) larger than the length of the input slice (len(p)) when it flushes internal buffers alongside the new data. This invalid return value causes bytes.Buffer.WriteTo (and potentially other standard library functions) to panic.

Solution
Implemented a Write method on the Logger struct in internal/view/logger.go. This method shadows the underlying TextView.Write implementation. It calls the original method but defensively clamps the returned byte count to len(p) before returning. This ensures k9s remains stable even when tview misbehaves, without requiring a fork or upstream fix of the library immediately.