### PR TITLE
feat: add support for plugin input fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,6 +829,80 @@ A plugin is defined as follows:
 * Args specifies the various arguments that should apply to the command above
 * OverwriteOutput boolean option allows plugin developers to provide custom messages on plugin stdout execution. See example in [#2644](https://github.com/derailed/k9s/pull/2644)
 * Dangerous boolean option enables disabling the plugin when read-only mode is set. See [#2604](https://github.com/derailed/k9s/issues/2604)
+* Inputs defines a list of input fields to prompt the user for before executing the plugin (see below)
+
+#### Plugin Inputs
+
+Plugins can define input fields that prompt users for values before execution. This is useful when you need dynamic values like replica counts, environment variables, or profile selections.
+
+Each input has the following properties:
+
+* `name` (required) -- the input identifier used to reference the value in args as `$INPUT_<NAME>` (uppercase)
+* `description` -- the label shown to the user in the input dialog
+* `type` (required) -- the input type: `string`, `int`, `bool`, or `dropdown`
+* `required` -- when true, the user must provide a value before the plugin can execute
+* `options` -- for `dropdown` type only, defines the list of available choices
+
+Input values are available in plugin args using the format `$INPUT_<NAME>` where `<NAME>` is the uppercase version of the input name.
+
+**Input Types:**
+
+| Type | Description | UI Element |
+|------|-------------|------------|
+| `string` | Free-form text input | Text field |
+| `int` | Numeric input (integers only) | Text field with numeric validation |
+| `bool` | Boolean toggle | Checkbox |
+| `dropdown` | Selection from predefined options | Dropdown menu |
+
+**Example:**
+
+```yaml
+plugins:
+  demo-inputs:
+    shortCut: Ctrl-Y
+    description: Demo all input types
+    scopes:
+      - po
+    command: bash
+    background: false
+    args:
+      - -c
+      - >-
+        echo "=== Plugin input demo ===" &&
+        echo "" &&
+        echo "Pod: $NAME" &&
+        echo "Namespace: $NAMESPACE" &&
+        echo "Context: $CONTEXT" &&
+        echo "" &&
+        echo "=== Your inputs ===" &&
+        echo "Message: $INPUT_MESSAGE" &&
+        echo "Count: $INPUT_COUNT" &&
+        echo "Enabled: $INPUT_ENABLED" &&
+        echo "Environment: $INPUT_ENVIRONMENT" &&
+        echo "" &&
+        read -p "Press Enter to return to k9s..."
+    inputs:
+      - name: message
+        description: Enter a message
+        type: string
+        required: true
+      - name: count
+        description: Enter a number
+        type: int
+        required: true
+      - name: enabled
+        description: Enable feature
+        type: bool
+        required: false
+      - name: environment
+        description: Select environment
+        type: dropdown
+        required: true
+        options:
+          - development
+          - staging
+          - production
+```
 
 K9s does provide additional environment variables for you to customize your plugins arguments. Currently, the available environment variables are as follows:
 

--- a/README.md
+++ b/README.md
@@ -875,10 +875,10 @@ plugins:
         echo "Context: $CONTEXT" &&
         echo "" &&
         echo "=== Your inputs ===" &&
-        echo "Message: $INPUT_MESSAGE" &&
-        echo "Count: $INPUT_COUNT" &&
-        echo "Enabled: $INPUT_ENABLED" &&
-        echo "Environment: $INPUT_ENVIRONMENT" &&
+        if [ -n "$INPUT_MESSAGE" ]; then echo "Message: $INPUT_MESSAGE (set)"; else echo "Message: (not set)"; fi &&
+        if [ -n "$INPUT_COUNT" ]; then echo "Count: $INPUT_COUNT (set)"; else echo "Count: (not set)"; fi &&
+        if [ -n "$INPUT_ENABLED" ]; then echo "Enabled: $INPUT_ENABLED (set)"; else echo "Enabled: (not set)"; fi &&
+        if [ -n "$INPUT_ENVIRONMENT" ]; then echo "Environment: $INPUT_ENVIRONMENT (set)"; else echo "Environment: (not set)"; fi &&
         echo "" &&
         read -p "Press Enter to return to k9s..."
     inputs:

--- a/README.md
+++ b/README.md
@@ -838,7 +838,7 @@ Plugins can define input fields that prompt users for values before execution. T
 Each input has the following properties:
 
 * `name` (required) -- the input identifier used to reference the value in args as `$INPUT_<NAME>` (uppercase)
-* `description` -- the label shown to the user in the input dialog
+* `label` -- the label shown to the user in the input dialog
 * `type` (required) -- the input type: `string`, `number`, `bool`, or `dropdown`
 * `required` -- when true, the user must provide a value before the plugin can execute
 * `options` -- for `dropdown` type only, defines the list of available choices
@@ -883,19 +883,19 @@ plugins:
         read -p "Press Enter to return to k9s..."
     inputs:
       - name: message
-        description: Enter a message
+        label: Enter a message
         type: string
         required: true
       - name: count
-        description: Enter a number
+        label: Enter a number
         type: number
         required: true
       - name: enabled
-        description: Enable feature
+        label: Enable feature
         type: bool
         required: false
       - name: environment
-        description: Select environment
+        label: Select environment
         type: dropdown
         required: true
         options:

--- a/README.md
+++ b/README.md
@@ -839,7 +839,7 @@ Each input has the following properties:
 
 * `name` (required) -- the input identifier used to reference the value in args as `$INPUT_<NAME>` (uppercase)
 * `description` -- the label shown to the user in the input dialog
-* `type` (required) -- the input type: `string`, `int`, `bool`, or `dropdown`
+* `type` (required) -- the input type: `string`, `number`, `bool`, or `dropdown`
 * `required` -- when true, the user must provide a value before the plugin can execute
 * `options` -- for `dropdown` type only, defines the list of available choices
 
@@ -850,7 +850,7 @@ Input values are available in plugin args using the format `$INPUT_<NAME>` where
 | Type | Description | UI Element |
 |------|-------------|------------|
 | `string` | Free-form text input | Text field |
-| `int` | Numeric input (integers only) | Text field with numeric validation |
+| `number` | Numeric input (integers and floats) | Text field with numeric validation |
 | `bool` | Boolean toggle | Checkbox |
 | `dropdown` | Selection from predefined options | Dropdown menu |
 
@@ -888,7 +888,7 @@ plugins:
         required: true
       - name: count
         description: Enter a number
-        type: int
+        type: number
         required: true
       - name: enabled
         description: Enable feature

--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ A plugin is defined as follows:
 
 #### Plugin Inputs
 
-Plugins can define input fields that prompt users for values before execution. This is useful when you need dynamic values like replica counts, environment variables, or profile selections.
+Plugins can define input fields that prompt users for values before execution. This is useful when you need dynamic values like replica counts, environment variables, or profile selections. A maximum of 5 inputs per plugin is allowed.
 
 Each input has the following properties:
 

--- a/internal/config/json/schemas/plugin-multi.json
+++ b/internal/config/json/schemas/plugin-multi.json
@@ -19,6 +19,23 @@
       "args": {
         "type": "array",
         "items": { "type": ["string", "number"] }
+      },
+      "inputs": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "description": { "type": "string" },
+            "type": { "type": "string", "enum": ["string", "int", "bool", "dropdown"] },
+            "required": { "type": "boolean" },
+            "options": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "required": ["name", "type"]
+        }
       }
     },
     "required": ["shortCut", "description", "scopes", "command"]

--- a/internal/config/json/schemas/plugin-multi.json
+++ b/internal/config/json/schemas/plugin-multi.json
@@ -22,6 +22,7 @@
       },
       "inputs": {
         "type": "array",
+        "maxItems": 5,
         "items": {
           "type": "object",
           "properties": {

--- a/internal/config/json/schemas/plugin-multi.json
+++ b/internal/config/json/schemas/plugin-multi.json
@@ -27,7 +27,7 @@
           "properties": {
             "name": { "type": "string" },
             "description": { "type": "string" },
-            "type": { "type": "string", "enum": ["string", "int", "bool", "dropdown"] },
+            "type": { "type": "string", "enum": ["string", "number", "bool", "dropdown"] },
             "required": { "type": "boolean" },
             "options": {
               "type": "array",

--- a/internal/config/json/schemas/plugin-multi.json
+++ b/internal/config/json/schemas/plugin-multi.json
@@ -26,7 +26,7 @@
           "type": "object",
           "properties": {
             "name": { "type": "string" },
-            "description": { "type": "string" },
+            "label": { "type": "string" },
             "type": { "type": "string", "enum": ["string", "number", "bool", "dropdown"] },
             "required": { "type": "boolean" },
             "options": {

--- a/internal/config/json/schemas/plugin.json
+++ b/internal/config/json/schemas/plugin.json
@@ -19,6 +19,23 @@
       "args": {
         "type": "array",
         "items": { "type": ["string", "number"] }
+      },
+      "inputs": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "description": { "type": "string" },
+            "type": { "type": "string", "enum": ["string", "int", "bool", "dropdown"] },
+            "required": { "type": "boolean" },
+            "options": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "required": ["name", "type"]
+        }
       }
   },
   "required": ["shortCut", "description", "scopes", "command"]

--- a/internal/config/json/schemas/plugin.json
+++ b/internal/config/json/schemas/plugin.json
@@ -22,6 +22,7 @@
       },
       "inputs": {
         "type": "array",
+        "maxItems": 5,
         "items": {
           "type": "object",
           "properties": {

--- a/internal/config/json/schemas/plugin.json
+++ b/internal/config/json/schemas/plugin.json
@@ -27,7 +27,7 @@
           "properties": {
             "name": { "type": "string" },
             "description": { "type": "string" },
-            "type": { "type": "string", "enum": ["string", "int", "bool", "dropdown"] },
+            "type": { "type": "string", "enum": ["string", "number", "bool", "dropdown"] },
             "required": { "type": "boolean" },
             "options": {
               "type": "array",

--- a/internal/config/json/schemas/plugin.json
+++ b/internal/config/json/schemas/plugin.json
@@ -26,7 +26,7 @@
           "type": "object",
           "properties": {
             "name": { "type": "string" },
-            "description": { "type": "string" },
+            "label": { "type": "string" },
             "type": { "type": "string", "enum": ["string", "number", "bool", "dropdown"] },
             "required": { "type": "boolean" },
             "options": {

--- a/internal/config/json/schemas/plugins.json
+++ b/internal/config/json/schemas/plugins.json
@@ -23,6 +23,23 @@
           "args": {
             "type": "array",
             "items": { "type": ["string", "number"] }
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "description": { "type": "string" },
+                "type": { "type": "string", "enum": ["string", "int", "bool", "dropdown"] },
+                "required": { "type": "boolean" },
+                "options": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              },
+              "required": ["name", "type"]
+            }
           }
         },
         "required": ["shortCut", "description", "scopes", "command"]

--- a/internal/config/json/schemas/plugins.json
+++ b/internal/config/json/schemas/plugins.json
@@ -31,7 +31,7 @@
               "properties": {
                 "name": { "type": "string" },
                 "description": { "type": "string" },
-                "type": { "type": "string", "enum": ["string", "int", "bool", "dropdown"] },
+                "type": { "type": "string", "enum": ["string", "number", "bool", "dropdown"] },
                 "required": { "type": "boolean" },
                 "options": {
                   "type": "array",

--- a/internal/config/json/schemas/plugins.json
+++ b/internal/config/json/schemas/plugins.json
@@ -30,7 +30,7 @@
               "type": "object",
               "properties": {
                 "name": { "type": "string" },
-                "description": { "type": "string" },
+                "label": { "type": "string" },
                 "type": { "type": "string", "enum": ["string", "number", "bool", "dropdown"] },
                 "required": { "type": "boolean" },
                 "options": {

--- a/internal/config/json/schemas/plugins.json
+++ b/internal/config/json/schemas/plugins.json
@@ -26,6 +26,7 @@
           },
           "inputs": {
             "type": "array",
+            "maxItems": 5,
             "items": {
               "type": "object",
               "properties": {

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -32,13 +32,9 @@ type Plugins struct {
 type PluginInputType string
 
 const (
-	// InputTypeString represents a text input field.
-	InputTypeString PluginInputType = "string"
-	// InputTypeInt represents a numeric input field.
-	InputTypeInt PluginInputType = "int"
-	// InputTypeBool represents a boolean checkbox input.
-	InputTypeBool PluginInputType = "bool"
-	// InputTypeDropdown represents a dropdown selection input.
+	InputTypeString   PluginInputType = "string"
+	InputTypeInt      PluginInputType = "int"
+	InputTypeBool     PluginInputType = "bool"
 	InputTypeDropdown PluginInputType = "dropdown"
 )
 
@@ -48,7 +44,7 @@ type PluginInput struct {
 	Description string          `yaml:"description"`
 	Type        PluginInputType `yaml:"type"`
 	Required    bool            `yaml:"required"`
-	Options     []string        `yaml:"options"` // For dropdown type
+	Options     []string        `yaml:"options"`
 }
 
 // Plugin describes a K9s plugin.

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -28,19 +28,43 @@ type Plugins struct {
 	Plugins plugins `yaml:"plugins"`
 }
 
+// PluginInputType represents the type of input field.
+type PluginInputType string
+
+const (
+	// InputTypeString represents a text input field.
+	InputTypeString PluginInputType = "string"
+	// InputTypeInt represents a numeric input field.
+	InputTypeInt PluginInputType = "int"
+	// InputTypeBool represents a boolean checkbox input.
+	InputTypeBool PluginInputType = "bool"
+	// InputTypeDropdown represents a dropdown selection input.
+	InputTypeDropdown PluginInputType = "dropdown"
+)
+
+// PluginInput describes an input field for a plugin.
+type PluginInput struct {
+	Name        string          `yaml:"name"`
+	Description string          `yaml:"description"`
+	Type        PluginInputType `yaml:"type"`
+	Required    bool            `yaml:"required"`
+	Options     []string        `yaml:"options"` // For dropdown type
+}
+
 // Plugin describes a K9s plugin.
 type Plugin struct {
-	Scopes          []string `yaml:"scopes"`
-	Args            []string `yaml:"args"`
-	ShortCut        string   `yaml:"shortCut"`
-	Override        bool     `yaml:"override"`
-	Pipes           []string `yaml:"pipes"`
-	Description     string   `yaml:"description"`
-	Command         string   `yaml:"command"`
-	Confirm         bool     `yaml:"confirm"`
-	Background      bool     `yaml:"background"`
-	Dangerous       bool     `yaml:"dangerous"`
-	OverwriteOutput bool     `yaml:"overwriteOutput"`
+	Scopes          []string      `yaml:"scopes"`
+	Args            []string      `yaml:"args"`
+	ShortCut        string        `yaml:"shortCut"`
+	Override        bool          `yaml:"override"`
+	Pipes           []string      `yaml:"pipes"`
+	Description     string        `yaml:"description"`
+	Command         string        `yaml:"command"`
+	Confirm         bool          `yaml:"confirm"`
+	Background      bool          `yaml:"background"`
+	Dangerous       bool          `yaml:"dangerous"`
+	OverwriteOutput bool          `yaml:"overwriteOutput"`
+	Inputs          []PluginInput `yaml:"inputs"`
 }
 
 func (p Plugin) String() string {

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -68,7 +68,7 @@ func (p Plugin) String() string {
 }
 
 // Validate checks the plugin configuration for errors.
-func (p Plugin) Validate() error {
+func (p *Plugin) Validate() error {
 	seen := make(map[string]struct{}, len(p.Inputs))
 	for _, input := range p.Inputs {
 		if _, ok := seen[input.Name]; ok {
@@ -152,10 +152,11 @@ func (p *Plugins) load(path string) error {
 			return fmt.Errorf("plugin unmarshal failed for %s: %w", path, err)
 		}
 		for k := range oo.Plugins {
-			if err := oo.Plugins[k].Validate(); err != nil {
+			plug := oo.Plugins[k]
+			if err := plug.Validate(); err != nil {
 				return fmt.Errorf("plugin %q validation failed for %s: %w", k, path, err)
 			}
-			p.Plugins[k] = oo.Plugins[k]
+			p.Plugins[k] = plug
 		}
 	case json.PluginMultiSchema:
 		var oo plugins
@@ -163,10 +164,11 @@ func (p *Plugins) load(path string) error {
 			return fmt.Errorf("plugin unmarshal failed for %s: %w", path, err)
 		}
 		for k := range oo {
-			if err := oo[k].Validate(); err != nil {
+			plug := oo[k]
+			if err := plug.Validate(); err != nil {
 				return fmt.Errorf("plugin %q validation failed for %s: %w", k, path, err)
 			}
-			p.Plugins[k] = oo[k]
+			p.Plugins[k] = plug
 		}
 	}
 

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -36,6 +36,8 @@ const (
 	InputTypeNumber   PluginInputType = "number"
 	InputTypeBool     PluginInputType = "bool"
 	InputTypeDropdown PluginInputType = "dropdown"
+
+	MaxPluginInputs = 5
 )
 
 // PluginInput describes an input field for a plugin.
@@ -69,6 +71,10 @@ func (p Plugin) String() string {
 
 // Validate checks the plugin configuration for errors.
 func (p *Plugin) Validate() error {
+	if len(p.Inputs) > MaxPluginInputs {
+		return fmt.Errorf("too many inputs: %d (max %d)", len(p.Inputs), MaxPluginInputs)
+	}
+
 	seen := make(map[string]struct{}, len(p.Inputs))
 	for _, input := range p.Inputs {
 		if _, ok := seen[input.Name]; ok {

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -36,8 +36,6 @@ const (
 	InputTypeNumber   PluginInputType = "number"
 	InputTypeBool     PluginInputType = "bool"
 	InputTypeDropdown PluginInputType = "dropdown"
-
-	MaxPluginInputs = 5
 )
 
 // PluginInput describes an input field for a plugin.
@@ -71,10 +69,6 @@ func (p Plugin) String() string {
 
 // Validate checks the plugin configuration for errors.
 func (p *Plugin) Validate() error {
-	if len(p.Inputs) > MaxPluginInputs {
-		return fmt.Errorf("too many inputs: %d (max %d)", len(p.Inputs), MaxPluginInputs)
-	}
-
 	seen := make(map[string]struct{}, len(p.Inputs))
 	for _, input := range p.Inputs {
 		if _, ok := seen[input.Name]; ok {
@@ -82,7 +76,6 @@ func (p *Plugin) Validate() error {
 		}
 		seen[input.Name] = struct{}{}
 	}
-
 	return nil
 }
 

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -40,11 +40,11 @@ const (
 
 // PluginInput describes an input field for a plugin.
 type PluginInput struct {
-	Name        string          `yaml:"name"`
-	Description string          `yaml:"description"`
-	Type        PluginInputType `yaml:"type"`
-	Required    bool            `yaml:"required"`
-	Options     []string        `yaml:"options"`
+	Name     string          `yaml:"name"`
+	Label    string          `yaml:"label"`
+	Type     PluginInputType `yaml:"type"`
+	Required bool            `yaml:"required"`
+	Options  []string        `yaml:"options"`
 }
 
 // Plugin describes a K9s plugin.

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -33,7 +33,7 @@ type PluginInputType string
 
 const (
 	InputTypeString   PluginInputType = "string"
-	InputTypeInt      PluginInputType = "int"
+	InputTypeNumber   PluginInputType = "number"
 	InputTypeBool     PluginInputType = "bool"
 	InputTypeDropdown PluginInputType = "dropdown"
 )

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -67,6 +67,19 @@ func (p Plugin) String() string {
 	return fmt.Sprintf("[%s] %s(%s)", p.ShortCut, p.Command, strings.Join(p.Args, " "))
 }
 
+// Validate checks the plugin configuration for errors.
+func (p Plugin) Validate() error {
+	seen := make(map[string]struct{}, len(p.Inputs))
+	for _, input := range p.Inputs {
+		if _, ok := seen[input.Name]; ok {
+			return fmt.Errorf("duplicate input name %q", input.Name)
+		}
+		seen[input.Name] = struct{}{}
+	}
+
+	return nil
+}
+
 // NewPlugins returns a new plugin.
 func NewPlugins() Plugins {
 	return Plugins{
@@ -129,6 +142,9 @@ func (p *Plugins) load(path string) error {
 		if err := yaml.Unmarshal(bb, &o); err != nil {
 			return fmt.Errorf("plugin unmarshal failed for %s: %w", path, err)
 		}
+		if err := o.Validate(); err != nil {
+			return fmt.Errorf("plugin validation failed for %s: %w", path, err)
+		}
 		p.Plugins[strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))] = o
 	case json.PluginsSchema:
 		var oo Plugins
@@ -136,6 +152,9 @@ func (p *Plugins) load(path string) error {
 			return fmt.Errorf("plugin unmarshal failed for %s: %w", path, err)
 		}
 		for k := range oo.Plugins {
+			if err := oo.Plugins[k].Validate(); err != nil {
+				return fmt.Errorf("plugin %q validation failed for %s: %w", k, path, err)
+			}
 			p.Plugins[k] = oo.Plugins[k]
 		}
 	case json.PluginMultiSchema:
@@ -144,6 +163,9 @@ func (p *Plugins) load(path string) error {
 			return fmt.Errorf("plugin unmarshal failed for %s: %w", path, err)
 		}
 		for k := range oo {
+			if err := oo[k].Validate(); err != nil {
+				return fmt.Errorf("plugin %q validation failed for %s: %w", k, path, err)
+			}
 			p.Plugins[k] = oo[k]
 		}
 	}

--- a/internal/ui/dialog/plugin_inputs.go
+++ b/internal/ui/dialog/plugin_inputs.go
@@ -51,14 +51,14 @@ func ShowPluginInputs(styles *config.Dialog, pages *ui.Pages, title string, inpu
 		switch input.Type {
 		case config.InputTypeString:
 			values[input.Name] = ""
-			inputName := input.Name // capture for closure
+			inputName := input.Name
 			f.AddInputField(label, "", 40, nil, func(text string) {
 				values[inputName] = text
 			})
 
 		case config.InputTypeInt:
 			values[input.Name] = ""
-			inputName := input.Name // capture for closure
+			inputName := input.Name
 			f.AddInputField(label, "", 20, func(text string, _ rune) bool {
 				// Allow empty, negative sign at start, or digits
 				if text == "" || text == "-" {
@@ -72,16 +72,17 @@ func ShowPluginInputs(styles *config.Dialog, pages *ui.Pages, title string, inpu
 
 		case config.InputTypeBool:
 			values[input.Name] = "false"
-			inputName := input.Name // capture for closure
+			inputName := input.Name
 			f.AddCheckbox(label, false, func(_ string, checked bool) {
 				values[inputName] = fmt.Sprintf("%t", checked)
 			})
 
 		case config.InputTypeDropdown:
 			if len(input.Options) > 0 {
-				values[input.Name] = input.Options[0]
-				inputName := input.Name  // capture for closure
-				options := input.Options // capture for closure
+				values[input.Name] = ""
+				inputName := input.Name
+				// Prepend empty option so dropdown starts unselected
+				options := append([]string{""}, input.Options...)
 				f.AddDropDown(label, options, 0, func(_ string, optionIndex int) {
 					if optionIndex >= 0 && optionIndex < len(options) {
 						values[inputName] = options[optionIndex]

--- a/internal/ui/dialog/plugin_inputs.go
+++ b/internal/ui/dialog/plugin_inputs.go
@@ -59,7 +59,7 @@ func ShowPluginInputs(styles *config.Dialog, pages *ui.Pages, title string, inpu
 		case config.InputTypeInt:
 			values[input.Name] = ""
 			inputName := input.Name // capture for closure
-			f.AddInputField(label, "", 20, func(text string, lastChar rune) bool {
+			f.AddInputField(label, "", 20, func(text string, _ rune) bool {
 				// Allow empty, negative sign at start, or digits
 				if text == "" || text == "-" {
 					return true

--- a/internal/ui/dialog/plugin_inputs.go
+++ b/internal/ui/dialog/plugin_inputs.go
@@ -24,7 +24,15 @@ type PluginInputsOkFunc func(values PluginInputValues)
 type PluginInputsFlashFunc func(msg string)
 
 // ShowPluginInputs pops a dialog to collect plugin input values.
-func ShowPluginInputs(styles *config.Dialog, pages *ui.Pages, title string, inputs []config.PluginInput, flash PluginInputsFlashFunc, ok PluginInputsOkFunc, cancel cancelFunc) {
+func ShowPluginInputs(
+	styles *config.Dialog,
+	pages *ui.Pages,
+	title string,
+	inputs []config.PluginInput,
+	flash PluginInputsFlashFunc,
+	ok PluginInputsOkFunc,
+	cancel cancelFunc,
+) {
 	if len(inputs) == 0 {
 		ok(make(PluginInputValues))
 		return

--- a/internal/ui/dialog/plugin_inputs.go
+++ b/internal/ui/dialog/plugin_inputs.go
@@ -20,8 +20,11 @@ type PluginInputValues map[string]string
 // PluginInputsOkFunc is called when the user confirms the plugin inputs.
 type PluginInputsOkFunc func(values PluginInputValues)
 
+// PluginInputsFlashFunc is called to display flash messages.
+type PluginInputsFlashFunc func(msg string)
+
 // ShowPluginInputs pops a dialog to collect plugin input values.
-func ShowPluginInputs(styles *config.Dialog, pages *ui.Pages, title string, inputs []config.PluginInput, ok PluginInputsOkFunc, cancel cancelFunc) {
+func ShowPluginInputs(styles *config.Dialog, pages *ui.Pages, title string, inputs []config.PluginInput, flash PluginInputsFlashFunc, ok PluginInputsOkFunc, cancel cancelFunc) {
 	if len(inputs) == 0 {
 		ok(make(PluginInputValues))
 		return
@@ -88,7 +91,7 @@ func ShowPluginInputs(styles *config.Dialog, pages *ui.Pages, title string, inpu
 						values[inputName] = options[optionIndex]
 					}
 				})
-				// Style the dropdown
+
 				if dropDown := f.GetFormItemByLabel(label); dropDown != nil {
 					if dd, ok := dropDown.(*tview.DropDown); ok {
 						dd.SetListStyles(
@@ -106,7 +109,6 @@ func ShowPluginInputs(styles *config.Dialog, pages *ui.Pages, title string, inpu
 		dismissPluginInputs(pages)
 		cancel()
 	})
-
 	// Add OK button with validation
 	f.AddButton("OK", func() {
 		// Validate required fields
@@ -120,7 +122,9 @@ func ShowPluginInputs(styles *config.Dialog, pages *ui.Pages, title string, inpu
 			}
 		}
 		if len(missing) > 0 {
-			// TODO: Show error message for missing required fields
+			if flash != nil {
+				flash("Required fields are missing")
+			}
 			return
 		}
 

--- a/internal/ui/dialog/plugin_inputs.go
+++ b/internal/ui/dialog/plugin_inputs.go
@@ -124,7 +124,8 @@ func ShowPluginInputs(
 		for _, input := range inputs {
 			if input.Required {
 				val := values[input.Name]
-				if val == "" || (input.Type == config.InputTypeBool && val == "false") {
+				// Bools always have a value (true/false), so skip validation for them
+				if input.Type != config.InputTypeBool && val == "" {
 					missing = append(missing, input.Name)
 				}
 			}
@@ -134,6 +135,13 @@ func ShowPluginInputs(
 				flash("Required fields are missing")
 			}
 			return
+		}
+
+		// Remove optional fields with zero values
+		for _, input := range inputs {
+			if !input.Required && input.Type != config.InputTypeBool && values[input.Name] == "" {
+				delete(values, input.Name)
+			}
 		}
 
 		ok(values)

--- a/internal/ui/dialog/plugin_inputs.go
+++ b/internal/ui/dialog/plugin_inputs.go
@@ -67,15 +67,15 @@ func ShowPluginInputs(
 				values[inputName] = text
 			})
 
-		case config.InputTypeInt:
+		case config.InputTypeNumber:
 			values[input.Name] = ""
 			inputName := input.Name
 			f.AddInputField(label, "", 20, func(text string, _ rune) bool {
-				// Allow empty, negative sign at start, or digits
-				if text == "" || text == "-" {
+				// Allow empty, negative sign, dot for decimals, or valid numbers
+				if text == "" || text == "-" || text == "." || text == "-." {
 					return true
 				}
-				_, err := strconv.Atoi(text)
+				_, err := strconv.ParseFloat(text, 64)
 				return err == nil
 			}, func(text string) {
 				values[inputName] = text

--- a/internal/ui/dialog/plugin_inputs.go
+++ b/internal/ui/dialog/plugin_inputs.go
@@ -51,8 +51,8 @@ func ShowPluginInputs(
 	// Add input fields based on type
 	for _, input := range inputs {
 		label := input.Name
-		if input.Description != "" {
-			label = input.Description
+		if input.Label != "" {
+			label = input.Label
 		}
 		if input.Required {
 			label += " *"

--- a/internal/view/actions.go
+++ b/internal/view/actions.go
@@ -187,6 +187,9 @@ func pluginAction(r Runner, p *config.Plugin) ui.ActionHandler {
 		if len(p.Inputs) > 0 {
 			d := r.App().Styles.Dialog()
 			dialog.ShowPluginInputs(&d, r.App().Content.Pages, "Plugin Inputs", p.Inputs,
+				func(msg string) {
+					r.App().Flash().Warn(msg)
+				},
 				func(inputValues dialog.PluginInputValues) {
 					executePlugin(r, p, inputValues)
 				},

--- a/internal/view/actions.go
+++ b/internal/view/actions.go
@@ -183,59 +183,80 @@ func pluginAction(r Runner, p *config.Plugin) ui.ActionHandler {
 			return nil
 		}
 
-		args := make([]string, len(p.Args))
-		for i, a := range p.Args {
-			arg, err := r.EnvFn()().Substitute(a)
-			if err != nil {
-				slog.Error("Plugin Args match failed", slogs.Error, err)
-				return nil
-			}
-			args[i] = arg
+		// Collect inputs if defined, then execute plugin
+		if len(p.Inputs) > 0 {
+			d := r.App().Styles.Dialog()
+			dialog.ShowPluginInputs(&d, r.App().Content.Pages, "Plugin Inputs", p.Inputs,
+				func(inputValues dialog.PluginInputValues) {
+					executePlugin(r, p, inputValues)
+				},
+				func() {},
+			)
+			return nil
 		}
 
-		cb := func() {
-			opts := shellOpts{
-				binary:     p.Command,
-				background: p.Background,
-				pipes:      p.Pipes,
-				args:       args,
-			}
-			suspend, errChan, statusChan := run(r.App(), &opts)
-			if !suspend {
-				r.App().Flash().Infof("Plugin command failed: %q", p.Description)
+		executePlugin(r, p, nil)
+		return nil
+	}
+}
+
+func executePlugin(r Runner, p *config.Plugin, inputValues dialog.PluginInputValues) {
+	// Get base environment and add input values with INPUT_ prefix
+	env := r.EnvFn()()
+	for name, value := range inputValues {
+		env["INPUT_"+strings.ToUpper(name)] = value
+	}
+
+	args := make([]string, len(p.Args))
+	for i, a := range p.Args {
+		arg, err := env.Substitute(a)
+		if err != nil {
+			slog.Error("Plugin Args match failed", slogs.Error, err)
+			return
+		}
+		args[i] = arg
+	}
+
+	cb := func() {
+		opts := shellOpts{
+			binary:     p.Command,
+			background: p.Background,
+			pipes:      p.Pipes,
+			args:       args,
+		}
+		suspend, errChan, statusChan := run(r.App(), &opts)
+		if !suspend {
+			r.App().Flash().Infof("Plugin command failed: %q", p.Description)
+			return
+		}
+		var errs error
+		for e := range errChan {
+			errs = errors.Join(errs, e)
+		}
+		if errs != nil {
+			if !strings.Contains(errs.Error(), "signal: interrupt") {
+				slog.Error("Plugin command failed", slogs.Error, errs)
+				r.App().cowCmd(errs.Error())
 				return
 			}
-			var errs error
-			for e := range errChan {
-				errs = errors.Join(errs, e)
-			}
-			if errs != nil {
-				if !strings.Contains(errs.Error(), "signal: interrupt") {
-					slog.Error("Plugin command failed", slogs.Error, errs)
-					r.App().cowCmd(errs.Error())
+		}
+		go func() {
+			for st := range statusChan {
+				if !p.OverwriteOutput {
+					r.App().Flash().Infof("Plugin command launched successfully: %q", st)
+				} else if strings.Contains(st, outputPrefix) {
+					infoMsg := strings.TrimPrefix(st, outputPrefix)
+					r.App().Flash().Info(strings.TrimSpace(infoMsg))
 					return
 				}
 			}
-			go func() {
-				for st := range statusChan {
-					if !p.OverwriteOutput {
-						r.App().Flash().Infof("Plugin command launched successfully: %q", st)
-					} else if strings.Contains(st, outputPrefix) {
-						infoMsg := strings.TrimPrefix(st, outputPrefix)
-						r.App().Flash().Info(strings.TrimSpace(infoMsg))
-						return
-					}
-				}
-			}()
-		}
-		if p.Confirm {
-			msg := fmt.Sprintf("Run?\n%s %s", p.Command, strings.Join(args, " "))
-			d := r.App().Styles.Dialog()
-			dialog.ShowConfirm(&d, r.App().Content.Pages, "Confirm "+p.Description, msg, cb, func() {})
-			return nil
-		}
-		cb()
-
-		return nil
+		}()
 	}
+	if p.Confirm {
+		msg := fmt.Sprintf("Run?\n%s %s", p.Command, strings.Join(args, " "))
+		d := r.App().Styles.Dialog()
+		dialog.ShowConfirm(&d, r.App().Content.Pages, "Confirm "+p.Description, msg, cb, func() {})
+		return
+	}
+	cb()
 }


### PR DESCRIPTION
Closes #3812 #3820

**The Problem**
Currently, plugins execute immediately with predefined arguments. But sometimes you need dynamic values that vary each time. Like scaling a PVC to a specific size, choosing a log verbosity level, or specifying a custom timeout.

**The Solution**
This PR adds an inputs field to plugin definitions. When a plugin has inputs defined, K9s shows a dialog prompting for values before executing the command.

Example - PVC Resize Plugin:

```yaml
plugins:
  resize-pvc:
    shortCut: Ctrl-R
    description: Resize PVC
    scopes:
      - persistentvolumeclaims
    command: kubectl
    confirm: true
    dangerous: true
    args:
      - patch
      - pvc
      - $NAME
      - -n
      - $NAMESPACE
      - -p
      - '{"spec":{"resources":{"requests":{"storage":"$INPUT_SIZE"}}}}'
    inputs:
      - name: size
        label: New size (e.g. 10Gi)
        type: string
        required: true
```
When you trigger this plugin, K9s pops up a dialog asking for the new size. The value you enter becomes available as `$INPUT_SIZE` in the args.


**Input Types**
Type | What it does
-- | --
string | Free text input
number| Number input
bool | Checkbox (true/false)
dropdown | Pick from a list of options

**Dropdown example:**
```yaml
inputs:
  - name: environment
    label: Target environment
    type: dropdown
    required: true
    options:
      - staging
      - production
```