### PR TITLE
Add config to disable pod Kill command

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,8 @@ You can now override the context portForward default address configuration by se
     maxConnRetry: 5
     # Indicates whether modification commands like delete/kill/edit are disabled. Default is false
     readOnly: false
+    # Disables the pod kill command (Ctrl+K) in pod view. Default is false
+    disablePodKillCmd: false
     # This setting allows users to specify the default view, but it is not set by default.
     defaultView: ""
     # Toggles whether k9s should exit when CTRL-C is pressed. When set to true, you will need to exit k9s via the :quit command. Default is false.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,11 @@ func (c *Config) IsReadOnly() bool {
 	return c.K9s.IsReadOnly()
 }
 
+// IsPodKillDisabled returns true if the pod kill command (Ctrl+K) is disabled.
+func (c *Config) IsPodKillDisabled() bool {
+	return c.K9s.DisablePodKillCmd
+}
+
 // ActiveClusterName returns the corresponding cluster name.
 func (c *Config) ActiveClusterName(contextName string) (string, error) {
 	ct, err := c.settings.GetContext(contextName)

--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -27,6 +27,7 @@
         "noExitOnCtrlC": { "type": "boolean" },
         "skipLatestRevCheck": { "type": "boolean" },
         "disablePodCounting": { "type": "boolean" },
+        "disablePodKillCmd": { "type": "boolean" },
         "defaultView": { "type": "string" },
         "portForwardAddress": { "type": "string" },
         "ui": {

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -46,6 +46,7 @@ type K9s struct {
 	UI                  UI         `json:"ui" yaml:"ui"`
 	SkipLatestRevCheck  bool       `json:"skipLatestRevCheck" yaml:"skipLatestRevCheck"`
 	DisablePodCounting  bool       `json:"disablePodCounting" yaml:"disablePodCounting"`
+	DisablePodKillCmd   bool       `json:"disablePodKillCmd" yaml:"disablePodKillCmd"`
 	ShellPod            *ShellPod  `json:"shellPod" yaml:"shellPod"`
 	ImageScans          ImageScans `json:"imageScans" yaml:"imageScans"`
 	Logger              Logger     `json:"logger" yaml:"logger"`
@@ -147,6 +148,7 @@ func (k *K9s) Merge(k1 *K9s) {
 	k.UI = k1.UI
 	k.SkipLatestRevCheck = k1.SkipLatestRevCheck
 	k.DisablePodCounting = k1.DisablePodCounting
+	k.DisablePodKillCmd = k1.DisablePodKillCmd
 	k.ShellPod = k1.ShellPod
 	k.Logger = k1.Logger
 	k.ImageScans = k1.ImageScans

--- a/internal/config/testdata/configs/default.yaml
+++ b/internal/config/testdata/configs/default.yaml
@@ -21,6 +21,7 @@ k9s:
     useFullGVRTitle: false
   skipLatestRevCheck: false
   disablePodCounting: false
+  disablePodKillCmd: false
   shellPod:
     image: busybox:1.37.0
     namespace: default

--- a/internal/config/testdata/configs/expected.yaml
+++ b/internal/config/testdata/configs/expected.yaml
@@ -22,6 +22,7 @@ k9s:
     useFullGVRTitle: true
   skipLatestRevCheck: false
   disablePodCounting: false
+  disablePodKillCmd: false
   shellPod:
     image: busybox:1.37.0
     namespace: default

--- a/internal/config/testdata/configs/k9s.yaml
+++ b/internal/config/testdata/configs/k9s.yaml
@@ -21,6 +21,7 @@ k9s:
     useFullGVRTitle: false
   skipLatestRevCheck: false
   disablePodCounting: false
+  disablePodKillCmd: false
   shellPod:
     image: busybox:1.37.0
     namespace: default

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -84,15 +84,8 @@ func (p *Pod) portForwardIndicator(data *model1.TableData) {
 	})
 }
 
-func (p *Pod) bindDangerousKeys(aa *ui.KeyActions) {
-	aa.Bulk(ui.KeyMap{
-		tcell.KeyCtrlK: ui.NewKeyActionWithOpts(
-			"Kill",
-			p.killCmd,
-			ui.ActionOpts{
-				Visible:   true,
-				Dangerous: true,
-			}),
+func (p *Pod) bindDangerousKeys(aa *ui.KeyActions, disableKill bool) {
+	km := ui.KeyMap{
 		ui.KeyS: ui.NewKeyActionWithOpts(
 			"Shell",
 			p.shellCmd,
@@ -121,12 +114,22 @@ func (p *Pod) bindDangerousKeys(aa *ui.KeyActions) {
 				Visible:   true,
 				Dangerous: true,
 			}),
-	})
+	}
+	if !disableKill {
+		km[tcell.KeyCtrlK] = ui.NewKeyActionWithOpts(
+			"Kill",
+			p.killCmd,
+			ui.ActionOpts{
+				Visible:   true,
+				Dangerous: true,
+			})
+	}
+	aa.Bulk(km)
 }
 
 func (p *Pod) bindKeys(aa *ui.KeyActions) {
 	if !p.App().Config.IsReadOnly() {
-		p.bindDangerousKeys(aa)
+		p.bindDangerousKeys(aa, p.App().Config.IsPodKillDisabled())
 	}
 
 	aa.Bulk(ui.KeyMap{


### PR DESCRIPTION
https://github.com/derailed/k9s/issues/319#issuecomment-3867183425

Adds a config to allow disabling of the 'CTRL+K' pod kill shortcut.
I understand that one-off configs aren’t ideal & have seen discussion about customizing keybinds for all pod commands - happy to work on that that if it unblocks this feature.

Flag off:
<img width="676" height="104" alt="image" src="https://github.com/user-attachments/assets/8d37b318-1c53-44d4-87c0-8d06cc8e3b28" />

Flag on:
<img width="624" height="101" alt="image" src="https://github.com/user-attachments/assets/a1bd876a-d35c-47cd-b5a3-1226a017fa8a" />


Somewhat relevant to 
https://github.com/derailed/k9s/issues/782
https://github.com/derailed/k9s/issues/1391
https://github.com/derailed/k9s/issues/1318