### PR TITLE
feat: decode secrets during edit mode

### DIFF
--- a/internal/dao/secret.go
+++ b/internal/dao/secret.go
@@ -9,12 +9,15 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/derailed/k9s/internal/slogs"
+	yamlv3 "gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
+	sigsyaml "sigs.k8s.io/yaml"
 )
 
 // Secret represents a secret K8s resource.
@@ -79,6 +82,97 @@ func (s *Secret) decodeYAML(path string, showManaged bool) (string, error) {
 	return buff.String(), nil
 }
 
+// secretKeyOrder surfaces the secret type (for context) followed by the editable
+// fields first. sigs.k8s.io/yaml sorts alphabetically (via JSON), which would
+// push stringData off-screen and make editing non-obvious.
+var secretKeyOrder = []string{"type", "stringData", "data"}
+
+// EditYAML returns the secret YAML decoded for editing. Text values are moved
+// to stringData and the output is reordered so editable fields appear first.
+func (s *Secret) EditYAML(path string) (string, error) {
+	o, err := s.Get(context.Background(), path)
+	if err != nil {
+		return "", err
+	}
+	if o == nil {
+		return "", fmt.Errorf("secret not found: %s", path)
+	}
+
+	u, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return "", fmt.Errorf("expecting unstructured but got %T", o)
+	}
+
+	secret, err := toSecret(o)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert to secret: %w", err)
+	}
+
+	// TypeMeta is not populated by DefaultUnstructuredConverter.
+	secret.APIVersion = u.GetAPIVersion()
+	secret.Kind = u.GetKind()
+
+	// Separate text-safe values (stringData) from binary values (data).
+	// sigs.k8s.io/yaml marshals []byte via JSON, which base64-encodes them.
+	stringData := make(map[string]string, len(secret.Data))
+	binaryData := make(map[string][]byte, len(secret.Data))
+	for k, val := range secret.Data {
+		if utf8.Valid(val) {
+			stringData[k] = string(val)
+		} else {
+			binaryData[k] = val
+		}
+	}
+	secret.Data = binaryData
+	secret.StringData = stringData
+
+	out, err := sigsyaml.Marshal(secret)
+	if err != nil {
+		return "", err
+	}
+
+	return reorderSecretYAML(string(out))
+}
+
+// reorderSecretYAML reorders top-level keys so type (for context) and the
+// editable fields (stringData, data) appear first, visible without scrolling.
+func reorderSecretYAML(src string) (string, error) {
+	var doc yamlv3.Node
+	if err := yamlv3.Unmarshal([]byte(src), &doc); err != nil {
+		return src, err
+	}
+	if len(doc.Content) == 0 || doc.Content[0].Kind != yamlv3.MappingNode {
+		return src, nil
+	}
+	root := doc.Content[0]
+
+	pairs := make(map[string][2]*yamlv3.Node, len(root.Content)/2)
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		pairs[root.Content[i].Value] = [2]*yamlv3.Node{root.Content[i], root.Content[i+1]}
+	}
+
+	newContent := make([]*yamlv3.Node, 0, len(root.Content))
+	seen := make(map[string]bool, len(secretKeyOrder))
+	for _, k := range secretKeyOrder {
+		if p, ok := pairs[k]; ok {
+			newContent = append(newContent, p[0], p[1])
+			seen[k] = true
+		}
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if k := root.Content[i].Value; !seen[k] {
+			newContent = append(newContent, root.Content[i], root.Content[i+1])
+		}
+	}
+	root.Content = newContent
+
+	out, err := yamlv3.Marshal(root)
+	if err != nil {
+		return src, err
+	}
+	return string(out), nil
+}
+
 // SetDecodeData toggles decode mode.
 func (s *Secret) SetDecodeData(b bool) {
 	s.decodeData = b
@@ -124,12 +218,7 @@ func (s *Secret) Decode(encodedDescription, path string) (string, error) {
 // the corresponding secret data values.
 // If the conversion fails, it returns an error.
 func ExtractSecrets(o runtime.Object) (map[string]string, error) {
-	u, ok := o.(*unstructured.Unstructured)
-	if !ok {
-		return nil, fmt.Errorf("expecting *unstructured.Unstructured but got %T", o)
-	}
-	var secret v1.Secret
-	err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &secret)
+	secret, err := toSecret(o)
 	if err != nil {
 		return nil, err
 	}
@@ -139,4 +228,18 @@ func ExtractSecrets(o runtime.Object) (map[string]string, error) {
 	}
 
 	return secretData, nil
+}
+
+func toSecret(o runtime.Object) (*v1.Secret, error) {
+	u, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("expecting *unstructured.Unstructured but got %T", o)
+	}
+	var secret v1.Secret
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &secret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &secret, nil
 }

--- a/internal/dao/secret_test.go
+++ b/internal/dao/secret_test.go
@@ -4,6 +4,7 @@
 package dao_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/derailed/k9s/internal/client"
@@ -42,4 +43,138 @@ token-secret:  24 bytes`
 	decodedDescription, err := s.Decode(encodedString, "kube-system/bootstrap-token-abcdef")
 	require.NoError(t, err)
 	assert.Equal(t, expected, decodedDescription)
+}
+
+func TestEditYAML_AllTextData(t *testing.T) {
+	var s dao.Secret
+	s.Init(makeFactory(), client.SecGVR)
+
+	yaml, err := s.EditYAML("kube-system/bootstrap-token-abcdef")
+	require.NoError(t, err)
+
+	// Text data should be in stringData
+	assert.Contains(t, yaml, "stringData:")
+	assert.Contains(t, yaml, "token-secret: 0123456789abcdef")
+	// No data field since all values are text
+	assert.NotContains(t, yaml, "\ndata:")
+}
+
+func TestEditYAML_MixedData(t *testing.T) {
+	var s dao.Secret
+	s.Init(makeFactory(), client.SecGVR)
+
+	yaml, err := s.EditYAML("default/mixed-secret")
+	require.NoError(t, err)
+
+	// Text fields go to stringData
+	assert.Contains(t, yaml, "stringData:")
+	assert.Contains(t, yaml, "username: admin")
+	assert.Contains(t, yaml, "password: s3cr3t")
+
+	// Binary field stays base64-encoded in data
+	assert.Contains(t, yaml, "data:")
+	assert.Contains(t, yaml, "key: gA4CAwQ=")
+}
+
+func TestEditYAML_AllBinaryData(t *testing.T) {
+	var s dao.Secret
+	s.Init(makeFactory(), client.SecGVR)
+
+	yaml, err := s.EditYAML("default/binary-secret")
+	require.NoError(t, err)
+
+	// Binary data stays in data field
+	assert.Contains(t, yaml, "data:")
+	assert.Contains(t, yaml, "binary-key: gA4CAwQ=")
+	// No stringData since nothing is text
+	assert.NotContains(t, yaml, "stringData:")
+}
+
+func TestEditYAML_EmptyData(t *testing.T) {
+	var s dao.Secret
+	s.Init(makeFactory(), client.SecGVR)
+
+	yaml, err := s.EditYAML("default/empty-secret")
+	require.NoError(t, err)
+
+	// No stringData or data sections with values
+	assert.NotContains(t, yaml, "stringData:")
+	assert.Contains(t, yaml, "kind: Secret")
+}
+
+func TestExtractSecrets(t *testing.T) {
+	o := load("secret_mixed")
+
+	data, err := dao.ExtractSecrets(o)
+	require.NoError(t, err)
+
+	assert.Len(t, data, 3)
+	assert.Equal(t, "admin", data["username"])
+	assert.Equal(t, "s3cr3t", data["password"])
+	// Binary data is still returned as raw string (not base64)
+	assert.Contains(t, data, "key")
+}
+
+func TestEditYAML_SpecialCharacters(t *testing.T) {
+	var s dao.Secret
+	s.Init(makeFactory(), client.SecGVR)
+
+	yaml, err := s.EditYAML("default/special-secret")
+	require.NoError(t, err)
+
+	// All valid UTF-8 should be in stringData
+	assert.Contains(t, yaml, "stringData:")
+	assert.Contains(t, yaml, "multiline:")
+	assert.Contains(t, yaml, "line1")
+	assert.Contains(t, yaml, "unicode:")
+	// sigs.k8s.io/yaml emits emoji as literal UTF-8
+	assert.Contains(t, yaml, `\U0001F60A`)
+	assert.Contains(t, yaml, "whitespace:")
+	// No data field since all are valid UTF-8
+	assert.NotContains(t, yaml, "\ndata:")
+}
+
+func TestEditYAML_NonExistentSecret(t *testing.T) {
+	var s dao.Secret
+	s.Init(makeFactory(), client.SecGVR)
+
+	_, err := s.EditYAML("default/does-not-exist")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestEditYAML_FieldOrder_TypeStringDataData(t *testing.T) {
+	var s dao.Secret
+	s.Init(makeFactory(), client.SecGVR)
+
+	// Use mixed fixture: has both binary (data) and text (stringData) fields
+	yaml, err := s.EditYAML("default/mixed-secret")
+	require.NoError(t, err)
+
+	stringDataIdx := strings.Index(yaml, "stringData:")
+	dataIdx := strings.Index(yaml, "data:")
+	typeIdx := strings.Index(yaml, "type:")
+
+	require.True(t, stringDataIdx >= 0, "stringData not found in output")
+	require.True(t, dataIdx >= 0, "data not found in output")
+	require.True(t, typeIdx >= 0, "type not found in output")
+
+	// type first, then stringData, then data
+	assert.Less(t, typeIdx, stringDataIdx, "type should appear before stringData")
+	assert.Less(t, stringDataIdx, dataIdx, "stringData should appear before data")
+}
+
+func TestEditYAML_FieldOrder_TypeStringDataFirst(t *testing.T) {
+	var s dao.Secret
+	s.Init(makeFactory(), client.SecGVR)
+
+	// All-text fixture: no binary data, only stringData
+	yaml, err := s.EditYAML("kube-system/bootstrap-token-abcdef")
+	require.NoError(t, err)
+
+	// type is at the very top, stringData follows
+	require.True(t, strings.HasPrefix(yaml, "type:"), "type should be the first key")
+	stringDataIdx := strings.Index(yaml, "stringData:")
+	typeIdx := strings.Index(yaml, "type:")
+	assert.Less(t, typeIdx, stringDataIdx, "type should appear before stringData")
 }

--- a/internal/dao/testdata/secret_binary.json
+++ b/internal/dao/testdata/secret_binary.json
@@ -1,0 +1,15 @@
+{
+    "apiVersion": "v1",
+    "data": {
+        "binary-key": "gA4CAwQ="
+    },
+    "kind": "Secret",
+    "metadata": {
+        "creationTimestamp": "2024-01-15T18:19:00Z",
+        "name": "binary-secret",
+        "namespace": "default",
+        "resourceVersion": "301",
+        "uid": "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+    },
+    "type": "Opaque"
+}

--- a/internal/dao/testdata/secret_empty.json
+++ b/internal/dao/testdata/secret_empty.json
@@ -1,0 +1,13 @@
+{
+    "apiVersion": "v1",
+    "data": {},
+    "kind": "Secret",
+    "metadata": {
+        "creationTimestamp": "2024-01-15T18:19:00Z",
+        "name": "empty-secret",
+        "namespace": "default",
+        "resourceVersion": "302",
+        "uid": "c3d4e5f6-a7b8-9012-cdef-123456789012"
+    },
+    "type": "Opaque"
+}

--- a/internal/dao/testdata/secret_mixed.json
+++ b/internal/dao/testdata/secret_mixed.json
@@ -1,0 +1,17 @@
+{
+    "apiVersion": "v1",
+    "data": {
+        "username": "YWRtaW4=",
+        "password": "czNjcjN0",
+        "key": "gA4CAwQ="
+    },
+    "kind": "Secret",
+    "metadata": {
+        "creationTimestamp": "2024-01-15T18:19:00Z",
+        "name": "mixed-secret",
+        "namespace": "default",
+        "resourceVersion": "300",
+        "uid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    },
+    "type": "Opaque"
+}

--- a/internal/dao/testdata/secret_special.json
+++ b/internal/dao/testdata/secret_special.json
@@ -1,0 +1,17 @@
+{
+    "apiVersion": "v1",
+    "data": {
+        "multiline": "bGluZTEKbGluZTIKbGluZTM=",
+        "unicode": "SGVsbG8g8J+Yig==",
+        "whitespace": "ICAgIHRhYnMJYW5kCXNwYWNlcyAgIA=="
+    },
+    "kind": "Secret",
+    "metadata": {
+        "creationTimestamp": "2024-01-15T18:19:00Z",
+        "name": "special-secret",
+        "namespace": "default",
+        "resourceVersion": "303",
+        "uid": "d4e5f6a7-b8c9-0123-def0-234567890123"
+    },
+    "type": "Opaque"
+}

--- a/internal/dao/utils_test.go
+++ b/internal/dao/utils_test.go
@@ -31,6 +31,14 @@ func makeFactory() dao.Factory {
 					load("secret"),
 				},
 			},
+			"default": {
+				client.SecGVR: {
+					load("secret_mixed"),
+					load("secret_binary"),
+					load("secret_empty"),
+					load("secret_special"),
+				},
+			},
 		},
 	}
 }

--- a/internal/view/details.go
+++ b/internal/view/details.go
@@ -31,6 +31,7 @@ type Details struct {
 
 	text                      *tview.TextView
 	actions                   *ui.KeyActions
+	editFn                    func() error
 	app                       *App
 	title, subject            string
 	cmdBuff                   *model.FishBuff
@@ -147,6 +148,12 @@ func (d *Details) bindKeys() {
 		ui.KeySlash:     ui.NewSharedKeyAction("Filter Mode", d.activateCmd, false),
 		tcell.KeyDelete: ui.NewSharedKeyAction("Erase", d.eraseCmd, false),
 	})
+	if !d.app.Config.IsReadOnly() && d.editFn != nil {
+		d.actions.Add(ui.KeyE, ui.NewKeyActionWithOpts("Edit", d.editCmd, ui.ActionOpts{
+			Visible:   true,
+			Dangerous: true,
+		}))
+	}
 
 	if !d.searchable {
 		d.actions.Delete(ui.KeyN, ui.KeyShiftN)
@@ -172,6 +179,13 @@ func (d *Details) StylesChanged(s *config.Styles) {
 // Update updates the view content.
 func (d *Details) Update(buff string) *Details {
 	d.model.SetText(buff)
+
+	return d
+}
+
+// SetEditFn configures an optional edit action for the details view.
+func (d *Details) SetEditFn(fn func() error) *Details {
+	d.editFn = fn
 
 	return d
 }
@@ -208,6 +222,17 @@ func (d *Details) Hints() model.MenuHints {
 
 // ExtraHints returns additional hints.
 func (*Details) ExtraHints() map[string]string {
+	return nil
+}
+
+func (d *Details) editCmd(*tcell.EventKey) *tcell.EventKey {
+	if d.editFn == nil {
+		return nil
+	}
+	if err := d.editFn(); err != nil {
+		d.app.Flash().Err(err)
+	}
+
 	return nil
 }
 

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -186,7 +186,15 @@ func (v *LiveView) editCmd(evt *tcell.EventKey) *tcell.EventKey {
 	}
 	v.Stop()
 	defer v.Start()
-	if err := editRes(v.app, v.model.GVR(), path); err != nil {
+
+	gvr := v.model.GVR()
+	var err error
+	if gvr.IsDecodable() {
+		err = editSecretRes(v.app, gvr, path)
+	} else {
+		err = editRes(v.app, gvr, path)
+	}
+	if err != nil {
 		v.app.Flash().Err(err)
 	}
 

--- a/internal/view/live_view_test.go
+++ b/internal/view/live_view_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/config/mock"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/tcell/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,4 +27,44 @@ apiVersion: v1
 	v.text.SetText(colorizeYAML(config.Yaml{}, s))
 
 	assert.Equal(t, s, sanitizeEsc(v.text.GetText(true)))
+}
+
+func TestDetailsEditAction(t *testing.T) {
+	var called int
+
+	d := NewDetails(NewApp(mock.NewMockConfig(t)), "Secret Decoder", "default/secret", contentYAML, true).
+		SetEditFn(func() error {
+			called++
+			return nil
+		})
+	require.NoError(t, d.Init(context.Background()))
+
+	a, ok := d.Actions().Get(ui.KeyE)
+	require.True(t, ok)
+	assert.Equal(t, "Edit", a.Description)
+	assert.True(t, a.Opts.Dangerous)
+	assert.Nil(t, d.keyboard(tcell.NewEventKey(tcell.KeyRune, 'e', tcell.ModNone)))
+	assert.Equal(t, 1, called)
+}
+
+func TestDetailsEditActionCanRefreshContent(t *testing.T) {
+	d := NewDetails(NewApp(mock.NewMockConfig(t)), "Secret Decoder", "default/secret", contentYAML, true).
+		Update("old: value\n")
+	d.SetEditFn(func() error {
+		d.Update("new: value\n")
+		return nil
+	})
+	require.NoError(t, d.Init(context.Background()))
+
+	assert.Contains(t, sanitizeEsc(d.text.GetText(true)), "old: value")
+	assert.Nil(t, d.keyboard(tcell.NewEventKey(tcell.KeyRune, 'e', tcell.ModNone)))
+	assert.Contains(t, sanitizeEsc(d.text.GetText(true)), "new: value")
+}
+
+func TestDetailsWithoutEditAction(t *testing.T) {
+	d := NewDetails(NewApp(mock.NewMockConfig(t)), "Details", "subject", contentYAML, true)
+	require.NoError(t, d.Init(context.Background()))
+
+	_, ok := d.Actions().Get(ui.KeyE)
+	assert.False(t, ok)
 }

--- a/internal/view/secret.go
+++ b/internal/view/secret.go
@@ -4,6 +4,9 @@
 package view
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/config/data"
 	"github.com/derailed/k9s/internal/dao"
@@ -28,10 +31,32 @@ func NewSecret(gvr *client.GVR) ResourceViewer {
 }
 
 func (s *Secret) bindKeys(aa *ui.KeyActions) {
+	if !s.App().Config.IsReadOnly() {
+		aa.Add(ui.KeyE, ui.NewKeyActionWithOpts("Edit", s.editCmd, ui.ActionOpts{
+			Visible:   true,
+			Dangerous: true,
+		}))
+	}
+
 	aa.Bulk(ui.KeyMap{
 		ui.KeyX: ui.NewKeyAction("Decode", s.decodeCmd, true),
 		ui.KeyU: ui.NewKeyAction("UsedBy", s.refCmd, true),
 	})
+}
+
+func (s *Secret) editCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := s.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+
+	s.Stop()
+	defer s.Start()
+	if err := editSecretRes(s.App(), s.GVR(), path); err != nil {
+		s.App().Flash().Err(err)
+	}
+
+	return nil
 }
 
 func (s *Secret) refCmd(evt *tcell.EventKey) *tcell.EventKey {
@@ -44,28 +69,102 @@ func (s *Secret) decodeCmd(evt *tcell.EventKey) *tcell.EventKey {
 		return evt
 	}
 
-	o, err := s.App().factory.Get(s.GVR(), path, true, labels.Everything())
-	if err != nil {
-		s.App().Flash().Err(err)
-		return nil
-	}
-
-	mm, err := dao.ExtractSecrets(o)
-	if err != nil {
-		s.App().Flash().Err(err)
-		return nil
-	}
-
-	raw, err := data.WriteYAML(mm)
+	raw, err := decodedSecretYAML(s.App(), s.GVR(), path)
 	if err != nil {
 		s.App().Flash().Errf("Error decoding secret %s", err)
 		return nil
 	}
 
-	details := NewDetails(s.App(), "Secret Decoder", path, contentYAML, true).Update(string(raw))
+	details := NewDetails(s.App(), "Secret Decoder", path, contentYAML, true)
+	details.SetEditFn(func() error {
+		if err := editSecretRes(s.App(), s.GVR(), path); err != nil {
+			return err
+		}
+
+		raw, err := decodedSecretYAML(s.App(), s.GVR(), path)
+		if err != nil {
+			return err
+		}
+		details.Update(raw)
+
+		return nil
+	}).
+		Update(raw)
 	if err := s.App().inject(details, false); err != nil {
 		s.App().Flash().Err(err)
 	}
 
 	return nil
+}
+
+func decodedSecretYAML(app *App, gvr *client.GVR, path string) (string, error) {
+	o, err := app.factory.Get(gvr, path, true, labels.Everything())
+	if err != nil {
+		return "", err
+	}
+
+	mm, err := dao.ExtractSecrets(o)
+	if err != nil {
+		return "", err
+	}
+
+	raw, err := data.WriteYAML(mm)
+	if err != nil {
+		return "", err
+	}
+
+	return string(raw), nil
+}
+
+func editSecretRes(app *App, gvr *client.GVR, path string) error {
+	if path == "" {
+		return fmt.Errorf("nothing selected %q", path)
+	}
+	ns, n := client.Namespaced(path)
+	if n == "" {
+		return fmt.Errorf("missing resource name in path %q", path)
+	}
+	if ok, err := app.Conn().CanI(ns, gvr, n, client.PatchAccess); !ok || err != nil {
+		return fmt.Errorf("current user can't edit resource %s", gvr)
+	}
+
+	res, err := dao.AccessorFor(app.factory, gvr)
+	if err != nil {
+		return fmt.Errorf("failed to get accessor: %w", err)
+	}
+	sec, ok := res.(*dao.Secret)
+	if !ok {
+		return fmt.Errorf("expecting Secret DAO but got %T", res)
+	}
+
+	yaml, err := sec.EditYAML(path)
+	if err != nil {
+		return fmt.Errorf("failed to get secret YAML: %w", err)
+	}
+
+	tmpFile, err := os.CreateTemp("", "k9s-secret-*.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(yaml); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	if !edit(app, &shellOpts{clear: true, args: []string{tmpFile.Name()}}) {
+		return fmt.Errorf("failed to launch editor")
+	}
+
+	args := make([]string, 0, 5)
+	args = append(args, "replace", "-f", tmpFile.Name())
+	if ns != client.BlankNamespace {
+		args = append(args, "-n", ns)
+	}
+
+	return runK(app, &shellOpts{clear: false, args: args})
 }

--- a/internal/view/secret_test.go
+++ b/internal/view/secret_test.go
@@ -17,5 +17,5 @@ func TestSecretNew(t *testing.T) {
 
 	require.NoError(t, s.Init(makeCtx(t)))
 	assert.Equal(t, "Secrets", s.Name())
-	assert.Len(t, s.Hints(), 10)
+	assert.Len(t, s.Hints(), 11)
 }


### PR DESCRIPTION
Adds the ability to edit secrets in their decoded state. Leveraging `stringData` in the Secret spec. For secret fields that contain binary data those are just left as encoded in the `data` field.

addresses #1017