### PR TITLE
feat: allow decrypting env vars in pod's describe view

### DIFF
--- a/internal/dao/env_resolver.go
+++ b/internal/dao/env_resolver.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/derailed/k9s/internal/client"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Regexes match kubectl describe output format for env var references.
+// See: https://github.com/kubernetes/kubectl/blob/master/pkg/describe/describe.go
+var (
+	secretKeyRefRE    = regexp.MustCompile(`<set to the key '([^']+)' in secret '([^']+)'>(\s*Optional: (?:true|false))?`)
+	configMapKeyRefRE = regexp.MustCompile(`<set to the key '([^']+)' of config map '([^']+)'>(\s*Optional: (?:true|false))?`)
+)
+
+type fetchResult struct {
+	name        string
+	isSecret    bool
+	isConfigMap bool
+	data        map[string]string
+	err         string
+}
+
+// sanitizeValue escapes newlines so multi-line values (e.g. PEM certs)
+// don't break the one-line-per-env-var describe format.
+func sanitizeValue(s string) string {
+	return strings.ReplaceAll(s, "\n", `\n`)
+}
+
+// ResolveEnvVars resolves secret/configmap env var references in a describe
+// output string. Errors are inlined per-reference so partial results are
+// always returned.
+func ResolveEnvVars(f Factory, desc, path string) string {
+	ns, _ := client.Namespaced(path)
+
+	// Collect unique secret and configmap names.
+	secretNames := make(map[string]struct{})
+	for _, mm := range secretKeyRefRE.FindAllStringSubmatch(desc, -1) {
+		if len(mm) >= 3 {
+			secretNames[mm[2]] = struct{}{}
+		}
+	}
+	cmNames := make(map[string]struct{})
+	for _, mm := range configMapKeyRefRE.FindAllStringSubmatch(desc, -1) {
+		if len(mm) >= 3 {
+			cmNames[mm[2]] = struct{}{}
+		}
+	}
+
+	if len(secretNames) == 0 && len(cmNames) == 0 {
+		return desc
+	}
+
+	// Fetch all secrets and configmaps concurrently.
+	var wg sync.WaitGroup
+	out := make(chan fetchResult)
+
+	for name := range secretNames {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			out <- fetchSecret(f, ns, name)
+		}(name)
+	}
+	for name := range cmNames {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			out <- fetchConfigMap(f, ns, name)
+		}(name)
+	}
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+
+	secretCache := make(map[string]fetchResult, len(secretNames))
+	cmCache := make(map[string]fetchResult, len(cmNames))
+	for res := range out {
+		if res.isSecret {
+			secretCache[res.name] = res
+		}
+		if res.isConfigMap {
+			cmCache[res.name] = res
+		}
+	}
+
+	// Replace secret refs using pre-fetched data.
+	desc = secretKeyRefRE.ReplaceAllStringFunc(desc, func(match string) string {
+		mm := secretKeyRefRE.FindStringSubmatch(match)
+		if len(mm) < 3 {
+			return match
+		}
+		key, name := mm[1], mm[2]
+		res := secretCache[name]
+		if res.err != "" {
+			return res.err
+		}
+		if val, ok := res.data[key]; ok {
+			return sanitizeValue(val)
+		}
+		return fmt.Sprintf("<error: key '%s' not found in secret '%s'>", key, name)
+	})
+
+	// Replace configmap refs using pre-fetched data.
+	desc = configMapKeyRefRE.ReplaceAllStringFunc(desc, func(match string) string {
+		mm := configMapKeyRefRE.FindStringSubmatch(match)
+		if len(mm) < 3 {
+			return match
+		}
+		key, name := mm[1], mm[2]
+		res := cmCache[name]
+		if res.err != "" {
+			return res.err
+		}
+		if val, ok := res.data[key]; ok {
+			return sanitizeValue(val)
+		}
+		return fmt.Sprintf("<error: key '%s' not found in configmap '%s'>", key, name)
+	})
+
+	return desc
+}
+
+func fetchSecret(f Factory, ns, name string) fetchResult {
+	fqn := FQN(ns, name)
+	res := fetchResult{name: name, isSecret: true}
+
+	o, err := f.Get(client.SecGVR, fqn, true, labels.Everything())
+	if err != nil {
+		res.err = fmt.Sprintf("<error: could not fetch secret '%s': %s>", name, err)
+		return res
+	}
+	data, err := ExtractSecrets(o)
+	if err != nil {
+		res.err = fmt.Sprintf("<error: could not decode secret '%s': %s>", name, err)
+		return res
+	}
+	res.data = data
+
+	return res
+}
+
+func fetchConfigMap(f Factory, ns, name string) fetchResult {
+	fqn := FQN(ns, name)
+	res := fetchResult{name: name, isConfigMap: true}
+
+	o, err := f.Get(client.CmGVR, fqn, true, labels.Everything())
+	if err != nil {
+		res.err = fmt.Sprintf("<error: could not fetch configmap '%s': %s>", name, err)
+		return res
+	}
+	u, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		res.err = fmt.Sprintf("<error: could not decode configmap '%s': unexpected type %T>", name, o)
+		return res
+	}
+	var cm v1.ConfigMap
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &cm); err != nil {
+		res.err = fmt.Sprintf("<error: could not decode configmap '%s': %s>", name, err)
+		return res
+	}
+	res.data = cm.Data
+
+	return res
+}

--- a/internal/dao/env_resolver_test.go
+++ b/internal/dao/env_resolver_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao_test
+
+import (
+	"testing"
+
+	"github.com/derailed/k9s/internal/dao"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveEnvVars(t *testing.T) {
+	f := makeFactory()
+
+	uu := map[string]struct {
+		input string
+		want  string
+	}{
+		"secret_ref": {
+			input: "    DB_PASSWORD:  <set to the key 'token-secret' in secret 'bootstrap-token-abcdef'>  Optional: false",
+			want:  "    DB_PASSWORD:  0123456789abcdef",
+		},
+		"secret_ref_optional_true": {
+			input: "    DB_PASSWORD:  <set to the key 'token-secret' in secret 'bootstrap-token-abcdef'>  Optional: true",
+			want:  "    DB_PASSWORD:  0123456789abcdef",
+		},
+		"configmap_ref": {
+			input: "    DB_HOST:  <set to the key 'db-host' of config map 'app-config'>  Optional: true",
+			want:  "    DB_HOST:  postgres.default.svc",
+		},
+		"multiple_refs": {
+			input: "    DB_PASSWORD:  <set to the key 'token-secret' in secret 'bootstrap-token-abcdef'>  Optional: false\n" +
+				"    DB_HOST:  <set to the key 'db-host' of config map 'app-config'>  Optional: true\n" +
+				"    DB_PORT:  <set to the key 'db-port' of config map 'app-config'>  Optional: false",
+			want: "    DB_PASSWORD:  0123456789abcdef\n" +
+				"    DB_HOST:  postgres.default.svc\n" +
+				"    DB_PORT:  5432",
+		},
+		"missing_secret": {
+			input: "    FOO:  <set to the key 'bar' in secret 'no-such-secret'>  Optional: false",
+			want:  "    FOO:  <error: could not fetch secret 'no-such-secret': resource kube-system/no-such-secret not found>",
+		},
+		"missing_configmap": {
+			input: "    FOO:  <set to the key 'bar' of config map 'no-such-cm'>  Optional: true",
+			want:  "    FOO:  <error: could not fetch configmap 'no-such-cm': resource kube-system/no-such-cm not found>",
+		},
+		"missing_key_in_secret": {
+			input: "    FOO:  <set to the key 'no-key' in secret 'bootstrap-token-abcdef'>  Optional: true",
+			want:  "    FOO:  <error: key 'no-key' not found in secret 'bootstrap-token-abcdef'>",
+		},
+		"missing_key_in_configmap": {
+			input: "    FOO:  <set to the key 'no-key' of config map 'app-config'>  Optional: false",
+			want:  "    FOO:  <error: key 'no-key' not found in configmap 'app-config'>",
+		},
+		"multiline_value": {
+			input: "    PEM_CERT:  <set to the key 'pem-cert' in secret 'pem-secret'>  Optional: false",
+			want:  `    PEM_CERT:  -----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhki\n-----END PUBLIC KEY-----\n`,
+		},
+		"no_refs": {
+			input: "    STATIC_VAR:  hello-world",
+			want:  "    STATIC_VAR:  hello-world",
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			got := dao.ResolveEnvVars(f, u.input, "kube-system/my-pod")
+			assert.Equal(t, u.want, got)
+		})
+	}
+}

--- a/internal/dao/testdata/configmap.json
+++ b/internal/dao/testdata/configmap.json
@@ -1,0 +1,12 @@
+{
+  "apiVersion": "v1",
+  "kind": "ConfigMap",
+  "metadata": {
+    "name": "app-config",
+    "namespace": "kube-system"
+  },
+  "data": {
+    "db-host": "postgres.default.svc",
+    "db-port": "5432"
+  }
+}

--- a/internal/dao/testdata/secret_pem.json
+++ b/internal/dao/testdata/secret_pem.json
@@ -1,0 +1,12 @@
+{
+    "apiVersion": "v1",
+    "data": {
+        "pem-cert": "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo="
+    },
+    "kind": "Secret",
+    "metadata": {
+        "name": "pem-secret",
+        "namespace": "kube-system"
+    },
+    "type": "Opaque"
+}

--- a/internal/dao/utils_test.go
+++ b/internal/dao/utils_test.go
@@ -27,9 +27,8 @@ func makeFactory() dao.Factory {
 	return &testFactory{
 		inventory: map[string]map[*client.GVR][]runtime.Object{
 			"kube-system": {
-				client.SecGVR: {
-					load("secret"),
-				},
+				client.SecGVR: {load("secret"), load("secret_pem")},
+				client.CmGVR:  {load("configmap")},
 			},
 		},
 	}
@@ -50,7 +49,7 @@ func (f *testFactory) Get(gvr *client.GVR, fqn string, _ bool, _ labels.Selector
 		}
 	}
 
-	return nil, nil
+	return nil, fmt.Errorf("resource %s not found", fqn)
 }
 func (f *testFactory) List(gvr *client.GVR, ns string, _ bool, _ labels.Selector) ([]runtime.Object, error) {
 	return f.inventory[ns][gvr], nil

--- a/internal/model/describe.go
+++ b/internal/model/describe.go
@@ -181,11 +181,21 @@ func (d *Describe) describe(ctx context.Context, gvr *client.GVR, path string) (
 	if !ok {
 		return "", fmt.Errorf("no describer for %q", meta.DAO.GVR())
 	}
-	if desc, ok := meta.DAO.(*dao.Secret); ok {
-		desc.SetDecodeData(d.decode)
+	if sec, ok := meta.DAO.(*dao.Secret); ok {
+		sec.SetDecodeData(d.decode)
 	}
 
-	return desc.Describe(path)
+	s, err := desc.Describe(path)
+	if err != nil {
+		return "", err
+	}
+	if d.decode {
+		if factory, ok := ctx.Value(internal.KeyFactory).(dao.Factory); ok {
+			s = dao.ResolveEnvVars(factory, s, path)
+		}
+	}
+
+	return s, nil
 }
 
 // AddListener adds a new model listener.

--- a/internal/view/live_view.go
+++ b/internal/view/live_view.go
@@ -42,6 +42,7 @@ type LiveView struct {
 	fullScreen                bool
 	managedField              bool
 	autoRefresh               bool
+	decode                    bool
 }
 
 // NewLiveView returns a live viewer.
@@ -175,7 +176,16 @@ func (v *LiveView) toggleEncodedDecodedCmd(evt *tcell.EventKey) *tcell.EventKey 
 	}
 
 	m.Toggle()
+	v.decode = !v.decode
+	if v.cancel != nil {
+		v.cancel()
+	}
 	v.Start()
+	if v.decode {
+		v.app.Flash().Info("Decoding is enabled")
+	} else {
+		v.app.Flash().Info("Decoding is disabled")
+	}
 	return nil
 }
 


### PR DESCRIPTION
When describing secrets, pressing X will decrypt the secret.

However, when describing a pod, pressing X does not decrypt/show the env vars -- it's currently a no-op. This PR implements pressing X to decrypt/show a pod's env vars.