### PR TITLE
feat: make search history case sensitive

### DIFF
--- a/internal/model/history.go
+++ b/internal/model/history.go
@@ -16,9 +16,10 @@ const MaxHistory = 20
 
 // History represents a command history.
 type History struct {
-	commands   []string
-	limit      int
-	currentIdx int
+	commands      []string
+	limit         int
+	currentIdx    int
+	caseSensitive bool
 }
 
 // NewHistory returns a new instance.
@@ -26,6 +27,15 @@ func NewHistory(limit int) *History {
 	return &History{
 		limit:      limit,
 		currentIdx: -1,
+	}
+}
+
+// NewCaseSensitiveHistory returns a new instance that preserves entry casing.
+func NewCaseSensitiveHistory(limit int) *History {
+	return &History{
+		limit:         limit,
+		currentIdx:    -1,
+		caseSensitive: true,
 	}
 }
 
@@ -116,14 +126,20 @@ func (h *History) Push(c string) {
 	if c == "" || len(h.commands) >= h.limit {
 		return
 	}
-	if t, ok := h.Top(); ok && t == c {
+
+	nc := c
+	if !h.caseSensitive {
+		nc = strings.ToLower(c)
+	}
+
+	if t, ok := h.Top(); ok && t == nc {
 		return
 	}
 
 	if h.currentIdx < len(h.commands)-1 {
 		h.commands = h.commands[:h.currentIdx+1]
 	}
-	h.commands = append(h.commands, strings.ToLower(c))
+	h.commands = append(h.commands, nc)
 	h.currentIdx = len(h.commands) - 1
 }
 

--- a/internal/model/history_test.go
+++ b/internal/model/history_test.go
@@ -135,6 +135,23 @@ func TestHistoryBack(t *testing.T) {
 	}
 }
 
+func TestCaseSensitiveHistoryPush(t *testing.T) {
+	h := model.NewCaseSensitiveHistory(5)
+	h.Push("App=MyLabel")
+	h.Push("app=mylabel")
+	h.Push("Env=Prod")
+
+	assert.Equal(t, []string{"App=MyLabel", "app=mylabel", "Env=Prod"}, h.List())
+}
+
+func TestCaseSensitiveHistoryDupCheck(t *testing.T) {
+	h := model.NewCaseSensitiveHistory(5)
+	h.Push("App=MyLabel")
+	h.Push("App=MyLabel")
+
+	assert.Equal(t, []string{"App=MyLabel"}, h.List())
+}
+
 func TestHistoryForward(t *testing.T) {
 	uu := map[string]struct {
 		push []string

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -63,7 +63,7 @@ func NewApp(cfg *config.Config) *App {
 	a := App{
 		App:           ui.NewApp(cfg, cfg.K9s.ActiveContextName()),
 		cmdHistory:    model.NewHistory(model.MaxHistory),
-		filterHistory: model.NewHistory(model.MaxHistory),
+		filterHistory: model.NewCaseSensitiveHistory(model.MaxHistory),
 		Content:       NewPageStack(),
 	}
 	a.ReloadStyles()

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -134,7 +134,6 @@ func (b *Browser) suggestFilter() model.SuggestionFunc {
 			return b.App().filterHistory.List()
 		}
 
-		s = strings.ToLower(s)
 		for _, h := range b.App().filterHistory.List() {
 			if s == h {
 				continue


### PR DESCRIPTION
Since https://github.com/derailed/k9s/pull/2888 was closed due to inactivity, I thought I might try again.
(Fixes https://github.com/derailed/k9s/issues/3849 and this stale issue: https://github.com/derailed/k9s/issues/2855)

Why: I mostly use one label filter all day long and it uses different casing so the completion is currently unusable for me which is annoying.

I'm happy to adjust if the approach is not nice :)