### PR TITLE
feat: support pod-level resources for CPU/memory calculations

### DIFF
--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -314,10 +314,10 @@ func gatherPodMX(spec *v1.PodSpec, ccmx []mv1beta1.ContainerMetrics) (c, r metri
 	cc = append(cc, filterSidecarCO(spec.InitContainers)...)
 	cc = append(cc, spec.Containers...)
 
-	rcpu, rmem, rgpu := cosRequests(cc)
+	rcpu, rmem, rgpu := cosRequests(cc, spec)
 	r.cpu, r.mem, r.gpu = rcpu.MilliValue(), rmem.Value(), rgpu.Value()
 
-	lcpu, lmem, lgpu := cosLimits(cc)
+	lcpu, lmem, lgpu := cosLimits(cc, spec)
 	r.lcpu, r.lmem, r.lgpu = lcpu.MilliValue(), lmem.Value(), lgpu.Value()
 
 	ccpu, cmem := currentRes(ccmx)
@@ -326,8 +326,24 @@ func gatherPodMX(spec *v1.PodSpec, ccmx []mv1beta1.ContainerMetrics) (c, r metri
 	return
 }
 
-func cosLimits(cc []v1.Container) (cpuQ, memQ, gpuQ *resource.Quantity) {
+func cosLimits(cc []v1.Container, spec *v1.PodSpec) (cpuQ, memQ, gpuQ *resource.Quantity) {
 	cpuQ, gpuQ, memQ = new(resource.Quantity), new(resource.Quantity), new(resource.Quantity)
+
+	// Check pod-level resources first
+	if spec.Resources != nil && len(spec.Resources.Limits) > 0 {
+		if q := spec.Resources.Limits.Cpu(); q != nil {
+			cpuQ.Add(*q)
+		}
+		if q := spec.Resources.Limits.Memory(); q != nil {
+			memQ.Add(*q)
+		}
+		if q := extractGPU(spec.Resources.Limits); q != nil {
+			gpuQ.Add(*q)
+		}
+		return
+	}
+
+	// Fallback to container-level resources
 	for i := range cc {
 		limits := cc[i].Resources.Limits
 		if len(limits) == 0 {
@@ -347,8 +363,24 @@ func cosLimits(cc []v1.Container) (cpuQ, memQ, gpuQ *resource.Quantity) {
 	return
 }
 
-func cosRequests(cc []v1.Container) (cpuQ, memQ, gpuQ *resource.Quantity) {
+func cosRequests(cc []v1.Container, spec *v1.PodSpec) (cpuQ, memQ, gpuQ *resource.Quantity) {
 	cpuQ, gpuQ, memQ = new(resource.Quantity), new(resource.Quantity), new(resource.Quantity)
+
+	// Check pod-level resources first
+	if spec.Resources != nil && len(spec.Resources.Requests) > 0 {
+		if q := spec.Resources.Requests.Cpu(); q != nil {
+			cpuQ.Add(*q)
+		}
+		if q := spec.Resources.Requests.Memory(); q != nil {
+			memQ.Add(*q)
+		}
+		if q := extractGPU(spec.Resources.Requests); q != nil {
+			gpuQ.Add(*q)
+		}
+		return
+	}
+
+	// Fallback to container-level resources
 	for i := range cc {
 		co := cc[i]
 		rl := containerRequests(&co)

--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -314,10 +314,10 @@ func gatherPodMX(spec *v1.PodSpec, ccmx []mv1beta1.ContainerMetrics) (c, r metri
 	cc = append(cc, filterSidecarCO(spec.InitContainers)...)
 	cc = append(cc, spec.Containers...)
 
-	rcpu, rmem, rgpu := cosRequests(cc, spec)
+	rcpu, rmem, rgpu := cosRequests(cc, spec.Resources)
 	r.cpu, r.mem, r.gpu = rcpu.MilliValue(), rmem.Value(), rgpu.Value()
 
-	lcpu, lmem, lgpu := cosLimits(cc, spec)
+	lcpu, lmem, lgpu := cosLimits(cc, spec.Resources)
 	r.lcpu, r.lmem, r.lgpu = lcpu.MilliValue(), lmem.Value(), lgpu.Value()
 
 	ccpu, cmem := currentRes(ccmx)
@@ -326,18 +326,18 @@ func gatherPodMX(spec *v1.PodSpec, ccmx []mv1beta1.ContainerMetrics) (c, r metri
 	return
 }
 
-func cosLimits(cc []v1.Container, spec *v1.PodSpec) (cpuQ, memQ, gpuQ *resource.Quantity) {
+func cosLimits(cc []v1.Container, resources *v1.ResourceRequirements) (cpuQ, memQ, gpuQ *resource.Quantity) {
 	cpuQ, gpuQ, memQ = new(resource.Quantity), new(resource.Quantity), new(resource.Quantity)
 
 	// Check pod-level resources first
-	if spec.Resources != nil && len(spec.Resources.Limits) > 0 {
-		if q := spec.Resources.Limits.Cpu(); q != nil {
+	if resources != nil && len(resources.Limits) > 0 {
+		if q := resources.Limits.Cpu(); q != nil {
 			cpuQ.Add(*q)
 		}
-		if q := spec.Resources.Limits.Memory(); q != nil {
+		if q := resources.Limits.Memory(); q != nil {
 			memQ.Add(*q)
 		}
-		if q := extractGPU(spec.Resources.Limits); q != nil {
+		if q := extractGPU(resources.Limits); q != nil {
 			gpuQ.Add(*q)
 		}
 		return
@@ -363,18 +363,18 @@ func cosLimits(cc []v1.Container, spec *v1.PodSpec) (cpuQ, memQ, gpuQ *resource.
 	return
 }
 
-func cosRequests(cc []v1.Container, spec *v1.PodSpec) (cpuQ, memQ, gpuQ *resource.Quantity) {
+func cosRequests(cc []v1.Container, resources *v1.ResourceRequirements) (cpuQ, memQ, gpuQ *resource.Quantity) {
 	cpuQ, gpuQ, memQ = new(resource.Quantity), new(resource.Quantity), new(resource.Quantity)
 
 	// Check pod-level resources first
-	if spec.Resources != nil && len(spec.Resources.Requests) > 0 {
-		if q := spec.Resources.Requests.Cpu(); q != nil {
+	if resources != nil && len(resources.Requests) > 0 {
+		if q := resources.Requests.Cpu(); q != nil {
 			cpuQ.Add(*q)
 		}
-		if q := spec.Resources.Requests.Memory(); q != nil {
+		if q := resources.Requests.Memory(); q != nil {
 			memQ.Add(*q)
 		}
-		if q := extractGPU(spec.Resources.Requests); q != nil {
+		if q := extractGPU(resources.Requests); q != nil {
 			gpuQ.Add(*q)
 		}
 		return

--- a/internal/render/pod_int_test.go
+++ b/internal/render/pod_int_test.go
@@ -590,7 +590,8 @@ func Test_podLimits(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			c, m, g := cosLimits(u.cc)
+			spec := &v1.PodSpec{}
+			c, m, g := cosLimits(u.cc, spec)
 			assert.True(t, c.Equal(*u.l.Cpu()))
 			assert.True(t, m.Equal(*u.l.Memory()))
 			assert.True(t, g.Equal(*extractGPU(u.l)))
@@ -622,7 +623,8 @@ func Test_podRequests(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			c, m, g := cosRequests(u.cc)
+			spec := &v1.PodSpec{}
+			c, m, g := cosRequests(u.cc, spec)
 			assert.True(t, c.Equal(*u.e.Cpu()))
 			assert.True(t, m.Equal(*u.e.Memory()))
 			assert.True(t, g.Equal(*extractGPU(u.e)))

--- a/internal/render/pod_int_test.go
+++ b/internal/render/pod_int_test.go
@@ -590,13 +590,37 @@ func Test_podLimits(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			spec := &v1.PodSpec{}
-			c, m, g := cosLimits(u.cc, spec)
+			resources := &v1.ResourceRequirements{}
+			c, m, g := cosLimits(u.cc, resources)
 			assert.True(t, c.Equal(*u.l.Cpu()))
 			assert.True(t, m.Equal(*u.l.Memory()))
 			assert.True(t, g.Equal(*extractGPU(u.l)))
 		})
 	}
+}
+
+func Test_podLimits_withPodResources(t *testing.T) {
+	// Arrange: Create containers with limits (should be ignored when pod resources exist)
+	cc := []v1.Container{
+		makeContainer("c1", false, "10m", "1Mi", "20m", "2Mi"),
+		makeContainer("c2", false, "10m", "1Mi", "40m", "4Mi"),
+	}
+
+	// Arrange: Create pod-level resources (these should take priority)
+	resources := &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    res.MustParse("500m"),
+			v1.ResourceMemory: res.MustParse("512Mi"),
+		},
+	}
+
+	// Act: Get limits using pod-level resources
+	c, m, g := cosLimits(cc, resources)
+
+	// Assert: Pod-level resources are used (not container sums)
+	assert.Equal(t, "500m", c.String(), "CPU should use pod-level 500m, not container sum of 60m")
+	assert.Equal(t, "512Mi", m.String(), "Memory should use pod-level 512Mi, not container sum of 6Mi")
+	assert.True(t, g.IsZero(), "GPU should be zero when not specified")
 }
 
 func Test_podRequests(t *testing.T) {
@@ -623,13 +647,37 @@ func Test_podRequests(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			spec := &v1.PodSpec{}
-			c, m, g := cosRequests(u.cc, spec)
+			resources := &v1.ResourceRequirements{}
+			c, m, g := cosRequests(u.cc, resources)
 			assert.True(t, c.Equal(*u.e.Cpu()))
 			assert.True(t, m.Equal(*u.e.Memory()))
 			assert.True(t, g.Equal(*extractGPU(u.e)))
 		})
 	}
+}
+
+func Test_podRequests_withPodResources(t *testing.T) {
+	// Arrange: Create containers with requests (should be ignored when pod resources exist)
+	cc := []v1.Container{
+		makeContainer("c1", false, "10m", "1Mi", "20m", "2Mi"),
+		makeContainer("c2", false, "10m", "1Mi", "40m", "4Mi"),
+	}
+
+	// Arrange: Create pod-level resources (these should take priority)
+	resources := &v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    res.MustParse("100m"),
+			v1.ResourceMemory: res.MustParse("128Mi"),
+		},
+	}
+
+	// Act: Get requests using pod-level resources
+	c, m, g := cosRequests(cc, resources)
+
+	// Assert: Pod-level resources are used (not container sums)
+	assert.Equal(t, "100m", c.String(), "CPU should use pod-level 100m, not container sum of 20m")
+	assert.Equal(t, "128Mi", m.String(), "Memory should use pod-level 128Mi, not container sum of 2Mi")
+	assert.True(t, g.IsZero(), "GPU should be zero when not specified")
 }
 
 func Test_readinessGateStats(t *testing.T) {

--- a/internal/render/pod_integration_test.go
+++ b/internal/render/pod_integration_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+// +build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// TestCosLimitsWithPodResources_Integration tests cosLimits with pod-level resources
+func TestCosLimitsWithPodResources_Integration(t *testing.T) {
+	// Create containers with limits (should be ignored when pod resources exist)
+	cc := []v1.Container{
+		{
+			Name: "c1",
+			Resources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("20m"),
+					v1.ResourceMemory: resource.MustParse("2Mi"),
+				},
+			},
+		},
+		{
+			Name: "c2",
+			Resources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("40m"),
+					v1.ResourceMemory: resource.MustParse("4Mi"),
+				},
+			},
+		},
+	}
+
+	// Pod-level resources (these should take priority)
+	resources := &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("500m"),
+			v1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+
+	// Act: Get limits using pod-level resources
+	c, m, g := cosLimits(cc, resources)
+
+	// Assert: Pod-level resources are used (not container sums)
+	assertEqual(t, "500m", c.String(), "CPU should use pod-level 500m")
+	assertEqual(t, "512Mi", m.String(), "Memory should use pod-level 512Mi")
+	assertTrue(t, g.IsZero(), "GPU should be zero")
+}
+
+// TestCosRequestsWithPodResources_Integration tests cosRequests with pod-level resources
+func TestCosRequestsWithPodResources_Integration(t *testing.T) {
+	// Create containers with requests (should be ignored when pod resources exist)
+	cc := []v1.Container{
+		{
+			Name: "c1",
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("10m"),
+					v1.ResourceMemory: resource.MustParse("1Mi"),
+				},
+			},
+		},
+		{
+			Name: "c2",
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("10m"),
+					v1.ResourceMemory: resource.MustParse("1Mi"),
+				},
+			},
+		},
+	}
+
+	// Pod-level resources (these should take priority)
+	resources := &v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("100m"),
+			v1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+	}
+
+	// Act: Get requests using pod-level resources
+	c, m, g := cosRequests(cc, resources)
+
+	// Assert: Pod-level resources are used (not container sums)
+	assertEqual(t, "100m", c.String(), "CPU should use pod-level 100m")
+	assertEqual(t, "128Mi", m.String(), "Memory should use pod-level 128Mi")
+	assertTrue(t, g.IsZero(), "GPU should be zero")
+}
+
+// Helper functions
+func assertEqual(t *testing.T, expected, actual, msg string) {
+	t.Helper()
+	if expected != actual {
+		t.Errorf("%s: expected %s, got %s", msg, expected, actual)
+	}
+}
+
+func assertTrue(t *testing.T, condition bool, msg string) {
+	t.Helper()
+	if !condition {
+		t.Errorf("%s: expected true, got false", msg)
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #3830

Pod view now correctly displays CPU/memory usage percentages when pod-level resources are defined (Kubernetes 1.35+ feature).

## Problem
Currently, the pod view only calculates resource usage from container-level limits/requests. When users define pod-level resources (a new feature in Kubernetes 1.35), the view shows `N/A` because the code never checks `spec.Resources`.

## Solution
Modified the resource calculation functions to check pod-level resources first, then fall back to container-level resources:

1. **cosLimits()** - Check pod-level limits first, then container limits
2. **cosRequests()** - Check pod-level requests first, then container requests
3. **gatherPodMX()** - Pass PodSpec to both functions

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Only pod-level resources defined | N/A | Shows % ✅ |
| Only container-level resources defined | Shows % | Shows % ✅ |
| Both defined (pod priority) | N/A | Uses pod-level ✅ |

## Test Plan
- [x] All existing tests pass (`go test ./...`)
- [x] Linter passes on changed files
- [x] Code compiles successfully
- [x] Manually verified function signatures

## Files Changed
- `internal/render/pod.go` - Core logic changes
- `internal/render/pod_int_test.go` - Test updates for new signatures

## References
- Kubernetes docs: https://kubernetes.io/docs/tasks/configure-pod-container/assign-pod-level-resources/
- Issue: #3830

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>