### PR TITLE
feat: Add default value support for plugin inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,7 @@ Each input has the following properties:
 * `label` -- the label shown to the user in the input dialog
 * `type` (required) -- the input type: `string`, `number`, `bool`, or `dropdown`
 * `required` -- when true, the user must provide a value before the plugin can execute
+* `default` -- a default value pre-filled in the input field (must be a valid option for `dropdown`, `"true"`/`"false"` for `bool`, or a valid number for `number`)
 * `options` -- for `dropdown` type only, defines the list of available choices
 
 Input values are available in plugin args using the format `$INPUT_<NAME>` where `<NAME>` is the uppercase version of the input name.
@@ -886,18 +887,22 @@ plugins:
         label: Enter a message
         type: string
         required: true
+        default: hello world
       - name: count
         label: Enter a number
         type: number
         required: true
+        default: 3
       - name: enabled
         label: Enable feature
         type: bool
         required: false
+        default: true
       - name: environment
         label: Select environment
         type: dropdown
         required: true
+        default: staging
         options:
           - development
           - staging

--- a/internal/config/json/schemas/plugin-multi.json
+++ b/internal/config/json/schemas/plugin-multi.json
@@ -36,7 +36,12 @@
               "items": { "type": "string" }
             }
           },
-          "required": ["name", "type"]
+          "required": ["name", "type"],
+          "if": { "required": ["default"] },
+          "then": {
+            "properties": { "required": { "const": true } },
+            "required": ["required"]
+          }
         }
       }
     },

--- a/internal/config/json/schemas/plugin-multi.json
+++ b/internal/config/json/schemas/plugin-multi.json
@@ -30,6 +30,7 @@
             "label": { "type": "string" },
             "type": { "type": "string", "enum": ["string", "number", "bool", "dropdown"] },
             "required": { "type": "boolean" },
+            "default": { "type": ["string", "number", "boolean"] },
             "options": {
               "type": "array",
               "items": { "type": "string" }

--- a/internal/config/json/schemas/plugin.json
+++ b/internal/config/json/schemas/plugin.json
@@ -36,7 +36,12 @@
               "items": { "type": "string" }
             }
           },
-          "required": ["name", "type"]
+          "required": ["name", "type"],
+          "if": { "required": ["default"] },
+          "then": {
+            "properties": { "required": { "const": true } },
+            "required": ["required"]
+          }
         }
       }
   },

--- a/internal/config/json/schemas/plugin.json
+++ b/internal/config/json/schemas/plugin.json
@@ -30,6 +30,7 @@
             "label": { "type": "string" },
             "type": { "type": "string", "enum": ["string", "number", "bool", "dropdown"] },
             "required": { "type": "boolean" },
+            "default": { "type": ["string", "number", "boolean"] },
             "options": {
               "type": "array",
               "items": { "type": "string" }

--- a/internal/config/json/schemas/plugins.json
+++ b/internal/config/json/schemas/plugins.json
@@ -40,7 +40,12 @@
                   "items": { "type": "string" }
                 }
               },
-              "required": ["name", "type"]
+              "required": ["name", "type"],
+              "if": { "required": ["default"] },
+              "then": {
+                "properties": { "required": { "const": true } },
+                "required": ["required"]
+              }
             }
           }
         },

--- a/internal/config/json/schemas/plugins.json
+++ b/internal/config/json/schemas/plugins.json
@@ -34,6 +34,7 @@
                 "label": { "type": "string" },
                 "type": { "type": "string", "enum": ["string", "number", "bool", "dropdown"] },
                 "required": { "type": "boolean" },
+                "default": { "type": ["string", "number", "boolean"] },
                 "options": {
                   "type": "array",
                   "items": { "type": "string" }

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -79,22 +79,20 @@ func (p *Plugin) Validate() error {
 		}
 		seen[input.Name] = struct{}{}
 
-		// Validate default value for dropdown must be one of the options
-		if input.Default != "" && input.Type == InputTypeDropdown {
+		if input.Default == "" {
+			continue
+		}
+
+		switch input.Type {
+		case InputTypeDropdown:
 			if !slices.Contains(input.Options, input.Default) {
 				return fmt.Errorf("default value %q for input %q is not a valid option", input.Default, input.Name)
 			}
-		}
-
-		// Validate default value for bool must be "true" or "false"
-		if input.Default != "" && input.Type == InputTypeBool {
+		case InputTypeBool:
 			if input.Default != "true" && input.Default != "false" {
 				return fmt.Errorf("default value %q for bool input %q must be \"true\" or \"false\"", input.Default, input.Name)
 			}
-		}
-
-		// Validate default value for number must be a valid number
-		if input.Default != "" && input.Type == InputTypeNumber {
+		case InputTypeNumber:
 			if _, err := strconv.ParseFloat(input.Default, 64); err != nil {
 				return fmt.Errorf("default value %q for number input %q is not a valid number", input.Default, input.Name)
 			}

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -11,6 +11,8 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/adrg/xdg"
@@ -44,6 +46,7 @@ type PluginInput struct {
 	Label    string          `yaml:"label"`
 	Type     PluginInputType `yaml:"type"`
 	Required bool            `yaml:"required"`
+	Default  string          `yaml:"default"`
 	Options  []string        `yaml:"options"`
 }
 
@@ -75,7 +78,29 @@ func (p *Plugin) Validate() error {
 			return fmt.Errorf("duplicate input name %q", input.Name)
 		}
 		seen[input.Name] = struct{}{}
+
+		// Validate default value for dropdown must be one of the options
+		if input.Default != "" && input.Type == InputTypeDropdown {
+			if !slices.Contains(input.Options, input.Default) {
+				return fmt.Errorf("default value %q for input %q is not a valid option", input.Default, input.Name)
+			}
+		}
+
+		// Validate default value for bool must be "true" or "false"
+		if input.Default != "" && input.Type == InputTypeBool {
+			if input.Default != "true" && input.Default != "false" {
+				return fmt.Errorf("default value %q for bool input %q must be \"true\" or \"false\"", input.Default, input.Name)
+			}
+		}
+
+		// Validate default value for number must be a valid number
+		if input.Default != "" && input.Type == InputTypeNumber {
+			if _, err := strconv.ParseFloat(input.Default, 64); err != nil {
+				return fmt.Errorf("default value %q for number input %q is not a valid number", input.Default, input.Name)
+			}
+		}
 	}
+
 	return nil
 }
 

--- a/internal/ui/dialog/plugin_inputs.go
+++ b/internal/ui/dialog/plugin_inputs.go
@@ -5,7 +5,9 @@ package dialog
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/ui"
@@ -64,6 +66,9 @@ func ShowPluginInputs(
 			values[input.Name] = input.Default
 			inputName := input.Name
 			f.AddInputField(label, input.Default, 40, nil, func(text string) {
+				if strings.Contains(text, " ") {
+					text = fmt.Sprintf("%q", text)
+				}
 				values[inputName] = text
 			})
 
@@ -83,7 +88,7 @@ func ShowPluginInputs(
 
 		case config.InputTypeBool:
 			defaultChecked := input.Default == "true"
-			values[input.Name] = fmt.Sprintf("%t", defaultChecked)
+			values[input.Name] = input.Default
 			inputName := input.Name
 			f.AddCheckbox(label, defaultChecked, func(_ string, checked bool) {
 				values[inputName] = fmt.Sprintf("%t", checked)
@@ -94,15 +99,7 @@ func ShowPluginInputs(
 				inputName := input.Name
 				// Prepend empty option so dropdown starts unselected
 				options := append([]string{""}, input.Options...)
-				defaultIndex := 0
-				if input.Default != "" {
-					for i, opt := range options {
-						if opt == input.Default {
-							defaultIndex = i
-							break
-						}
-					}
-				}
+				defaultIndex := max(0, slices.Index(options, input.Default))
 				values[input.Name] = options[defaultIndex]
 				f.AddDropDown(label, options, defaultIndex, func(_ string, optionIndex int) {
 					if optionIndex >= 0 && optionIndex < len(options) {

--- a/internal/ui/dialog/plugin_inputs.go
+++ b/internal/ui/dialog/plugin_inputs.go
@@ -61,16 +61,16 @@ func ShowPluginInputs(
 
 		switch input.Type {
 		case config.InputTypeString:
-			values[input.Name] = ""
+			values[input.Name] = input.Default
 			inputName := input.Name
-			f.AddInputField(label, "", 40, nil, func(text string) {
+			f.AddInputField(label, input.Default, 40, nil, func(text string) {
 				values[inputName] = text
 			})
 
 		case config.InputTypeNumber:
-			values[input.Name] = ""
+			values[input.Name] = input.Default
 			inputName := input.Name
-			f.AddInputField(label, "", 20, func(text string, _ rune) bool {
+			f.AddInputField(label, input.Default, 20, func(text string, _ rune) bool {
 				// Allow empty, negative sign, dot for decimals, or valid numbers
 				if text == "" || text == "-" || text == "." || text == "-." {
 					return true
@@ -82,19 +82,29 @@ func ShowPluginInputs(
 			})
 
 		case config.InputTypeBool:
-			values[input.Name] = "false"
+			defaultChecked := input.Default == "true"
+			values[input.Name] = fmt.Sprintf("%t", defaultChecked)
 			inputName := input.Name
-			f.AddCheckbox(label, false, func(_ string, checked bool) {
+			f.AddCheckbox(label, defaultChecked, func(_ string, checked bool) {
 				values[inputName] = fmt.Sprintf("%t", checked)
 			})
 
 		case config.InputTypeDropdown:
 			if len(input.Options) > 0 {
-				values[input.Name] = ""
 				inputName := input.Name
 				// Prepend empty option so dropdown starts unselected
 				options := append([]string{""}, input.Options...)
-				f.AddDropDown(label, options, 0, func(_ string, optionIndex int) {
+				defaultIndex := 0
+				if input.Default != "" {
+					for i, opt := range options {
+						if opt == input.Default {
+							defaultIndex = i
+							break
+						}
+					}
+				}
+				values[input.Name] = options[defaultIndex]
+				f.AddDropDown(label, options, defaultIndex, func(_ string, optionIndex int) {
 					if optionIndex >= 0 && optionIndex < len(options) {
 						values[inputName] = options[optionIndex]
 					}


### PR DESCRIPTION
Closes: #3852

Adds an optional default field to plugin inputs
See #3854 for an plugin example

```yaml
inputs:
  - name: image
    label: Container image
    type: string
    default: busybox
  - name: replicas
    label: Replica count
    type: number
    default: 3
  - name: verbose
    label: Verbose mode
    type: bool
    default: true
  - name: env
    label: Environment
    type: dropdown
    default: staging
    options:
      - development
      - staging
      - production
```