### PR TITLE
fix(xray): disable edit/delete actions in XRay view when readonly mode is enabled

### DIFF
--- a/internal/view/xray.go
+++ b/internal/view/xray.go
@@ -120,6 +120,21 @@ func (x *Xray) ExtraHints() map[string]string {
 // SetInstance sets specific resource instance.
 func (*Xray) SetInstance(string) {}
 
+func (x *Xray) bindDangerousKeys(aa *ui.KeyActions) {
+	aa.Bulk(ui.KeyMap{
+		ui.KeyE: ui.NewKeyActionWithOpts("Edit", x.editCmd,
+			ui.ActionOpts{
+				Visible:   true,
+				Dangerous: true,
+			}),
+		tcell.KeyCtrlD: ui.NewKeyActionWithOpts("Delete", x.deleteCmd,
+			ui.ActionOpts{
+				Visible:   true,
+				Dangerous: true,
+			}),
+	})
+}
+
 func (x *Xray) bindKeys() {
 	x.Actions().Bulk(ui.KeyMap{
 		ui.KeySlash:     ui.NewSharedKeyAction("Filter Mode", x.activateCmd, false),
@@ -168,11 +183,8 @@ func (x *Xray) refreshActions() {
 		return
 	}
 
-	if !x.app.Config.IsReadOnly() && client.Can(x.meta.Verbs, "edit") {
-		aa.Add(ui.KeyE, ui.NewKeyAction("Edit", x.editCmd, true))
-	}
-	if !x.app.Config.IsReadOnly() && client.Can(x.meta.Verbs, "delete") {
-		aa.Add(tcell.KeyCtrlD, ui.NewKeyAction("Delete", x.deleteCmd, true))
+	if !x.app.Config.IsReadOnly() {
+		x.bindDangerousKeys(aa)
 	}
 	if !dao.IsK9sMeta(x.meta) {
 		aa.Bulk(ui.KeyMap{
@@ -191,7 +203,11 @@ func (x *Xray) refreshActions() {
 			ui.KeyP: ui.NewKeyAction("Logs Previous", x.logsCmd(true), true),
 		})
 		if !x.app.Config.IsReadOnly() {
-			aa.Add(ui.KeyS, ui.NewKeyAction("Shell", x.shellCmd, true))
+			aa.Add(ui.KeyS, ui.NewKeyActionWithOpts("Shell", x.shellCmd,
+				ui.ActionOpts{
+					Visible:   true,
+					Dangerous: true,
+				}))
 		}
 	case client.PodGVR:
 		aa.Bulk(ui.KeyMap{
@@ -200,9 +216,17 @@ func (x *Xray) refreshActions() {
 		})
 		if !x.app.Config.IsReadOnly() {
 			aa.Bulk(ui.KeyMap{
-			ui.KeyS: ui.NewKeyAction("Shell", x.shellCmd, true),
-			ui.KeyA: ui.NewKeyAction("Attach", x.attachCmd, t：rue),
-		})
+				ui.KeyS: ui.NewKeyActionWithOpts("Shell", x.shellCmd,
+					ui.ActionOpts{
+						Visible:   true,
+						Dangerous: true,
+					}),
+				ui.KeyA: ui.NewKeyActionWithOpts("Attach", x.attachCmd,
+					ui.ActionOpts{
+						Visible:   true,
+						Dangerous: true,
+					}),
+			})
 		}
 	}
 	x.Actions().Merge(aa)

--- a/internal/view/xray.go
+++ b/internal/view/xray.go
@@ -168,10 +168,10 @@ func (x *Xray) refreshActions() {
 		return
 	}
 
-	if client.Can(x.meta.Verbs, "edit") {
+	if !x.app.Config.IsReadOnly() && client.Can(x.meta.Verbs, "edit") {
 		aa.Add(ui.KeyE, ui.NewKeyAction("Edit", x.editCmd, true))
 	}
-	if client.Can(x.meta.Verbs, "delete") {
+	if !x.app.Config.IsReadOnly() && client.Can(x.meta.Verbs, "delete") {
 		aa.Add(tcell.KeyCtrlD, ui.NewKeyAction("Delete", x.deleteCmd, true))
 	}
 	if !dao.IsK9sMeta(x.meta) {
@@ -187,17 +187,23 @@ func (x *Xray) refreshActions() {
 	case client.CoGVR:
 		x.Actions().Delete(tcell.KeyEnter)
 		aa.Bulk(ui.KeyMap{
-			ui.KeyS: ui.NewKeyAction("Shell", x.shellCmd, true),
 			ui.KeyL: ui.NewKeyAction("Logs", x.logsCmd(false), true),
 			ui.KeyP: ui.NewKeyAction("Logs Previous", x.logsCmd(true), true),
 		})
+		if !x.app.Config.IsReadOnly() {
+			aa.Add(ui.KeyS, ui.NewKeyAction("Shell", x.shellCmd, true))
+		}
 	case client.PodGVR:
 		aa.Bulk(ui.KeyMap{
-			ui.KeyS: ui.NewKeyAction("Shell", x.shellCmd, true),
-			ui.KeyA: ui.NewKeyAction("Attach", x.attachCmd, true),
 			ui.KeyL: ui.NewKeyAction("Logs", x.logsCmd(false), true),
 			ui.KeyP: ui.NewKeyAction("Logs Previous", x.logsCmd(true), true),
 		})
+		if !x.app.Config.IsReadOnly() {
+			aa.Bulk(ui.KeyMap{
+			ui.KeyS: ui.NewKeyAction("Shell", x.shellCmd, true),
+			ui.KeyA: ui.NewKeyAction("Attach", x.attachCmd, t：rue),
+		})
+		}
 	}
 	x.Actions().Merge(aa)
 }

--- a/internal/view/xray.go
+++ b/internal/view/xray.go
@@ -121,18 +121,20 @@ func (x *Xray) ExtraHints() map[string]string {
 func (*Xray) SetInstance(string) {}
 
 func (x *Xray) bindDangerousKeys(aa *ui.KeyActions) {
-	aa.Bulk(ui.KeyMap{
-		ui.KeyE: ui.NewKeyActionWithOpts("Edit", x.editCmd,
+	if client.Can(x.meta.Verbs, "edit") {
+		aa.Add(ui.KeyE, ui.NewKeyActionWithOpts("Edit", x.editCmd,
 			ui.ActionOpts{
 				Visible:   true,
 				Dangerous: true,
-			}),
-		tcell.KeyCtrlD: ui.NewKeyActionWithOpts("Delete", x.deleteCmd,
+			}))
+	}
+	if client.Can(x.meta.Verbs, "delete") {
+		aa.Add(tcell.KeyCtrlD, ui.NewKeyActionWithOpts("Delete", x.deleteCmd,
 			ui.ActionOpts{
 				Visible:   true,
 				Dangerous: true,
-			}),
-	})
+			}))
+	}
 }
 
 func (x *Xray) bindKeys() {


### PR DESCRIPTION
Fixes: #3822

Description
Fixed an issue where editing or deleting resources was still allowed in the XRay view while K9s was running in read-only mode (--readonly). The system now properly disables edit-related operations when in read-only mode.

Related Issue
#3822

Changes
Added a check for app.Config.ReadOnly() within the edit, delete, attach, and shell action handlers in the XRay view.
These functions are now disabled if the application is in read-only mode.

How to Test
Compile and run K9s: ./k9s --readonly
Enter the XRay view for a pod using the command :xray pod namespace_name.
Attempt to press e (edit) or d (delete).
Expected Result: The system will not enter the edit or delete workflows.

before:
<img width="1108" height="558" alt="image" src="https://github.com/user-attachments/assets/7239b0ef-acb7-4865-a8ec-923a627517c6" />

after:
<img width="1108" height="558" alt="image" src="https://github.com/user-attachments/assets/b9708a07-9c8d-41de-96ed-e993b341b3e5" />

