### PR TITLE
fix: allow case-insensitive resource kind

### DIFF
--- a/internal/config/alias.go
+++ b/internal/config/alias.go
@@ -160,14 +160,31 @@ func (a *Aliases) LoadFile(path string) error {
 	}
 
 	a.mx.Lock()
+	defer a.mx.Unlock()
+
+	// Track existing keys before unmarshalling.
+	existing := make(map[string]bool, len(a.Alias))
+	for k := range a.Alias {
+		existing[k] = true
+	}
+
 	if err := yaml.Unmarshal(bb, a); err != nil {
 		return err
 	}
 
 	for k, v := range a.Alias {
-		a.Alias[k] = client.NewGVR(v.String())
+		gvr := client.NewGVR(v.String())
+		if existing[k] {
+			a.Alias[k] = gvr
+			continue
+		}
+		// Normalize new keys from file to lowercase.
+		lower := strings.ToLower(k)
+		if lower != k {
+			delete(a.Alias, k)
+		}
+		a.Alias[lower] = gvr
 	}
-	defer a.mx.Unlock()
 
 	return nil
 }

--- a/internal/config/alias_test.go
+++ b/internal/config/alias_test.go
@@ -57,12 +57,17 @@ func TestAliasGetCaseInsensitive(t *testing.T) {
 		alias string
 		ok    bool
 	}{
-		"lowercase":  {alias: "pod", ok: true},
-		"uppercase":  {alias: "POD", ok: true},
-		"mixed-case": {alias: "Pod", ok: true},
-		"short":      {alias: "PO", ok: true},
-		"miss":       {alias: "zorg", ok: false},
+		"lowercase":        {alias: "pod", ok: true},
+		"uppercase":        {alias: "POD", ok: true},
+		"mixed-case":       {alias: "Pod", ok: true},
+		"short":            {alias: "PO", ok: true},
+		"miss":             {alias: "zorg", ok: false},
+		"defined-upper":    {alias: "deploy", ok: true},
+		"lookup-upper-def": {alias: "DEPLOY", ok: true},
 	}
+
+	// Define with uppercase to verify Define() normalizes keys.
+	a.Define(client.NewGVR("apps/v1/deployments"), "DEPLOY")
 
 	for k := range uu {
 		u := uu[k]


### PR DESCRIPTION
  names in command bar

  Normalizes alias keys to lowercase in both Get() and
  Define(),
  so users can type 'Deployment', 'POD', etc. instead of only
  lowercase.

  Fixes #985