### PR TITLE
internal/model1: handle empty capacity string in sort

### DIFF
--- a/internal/model1/helpers.go
+++ b/internal/model1/helpers.go
@@ -150,7 +150,13 @@ func runesToNum(rr []rune) int64 {
 }
 
 func capacityToNumber(capacity string) int64 {
-	quantity := resource.MustParse(capacity)
+	if capacity == "" {
+		return 0
+	}
+	quantity, err := resource.ParseQuantity(capacity)
+	if err != nil {
+		return 0
+	}
 	return quantity.Value()
 }
 


### PR DESCRIPTION
Sorting PVCs by capacity crashes when there are Pending PVCs in the list:

```
Boom!! cannot parse '': quantities must match the regular expression ...
```

Pending PVCs have no bound volume, so `capacity` stays empty. `capacityToNumber` passes this empty string to `resource.MustParse`, which panics.

Switched to `resource.ParseQuantity` and return 0 on parse error, so empty/invalid capacity values sort to the bottom instead of crashing.

Fixes #3863