### PR TITLE
internal/render: prevent index out of range panic in initContainerStats

### DIFF
--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -10,6 +10,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/model1"
+	"github.com/derailed/k9s/internal/slogs"
 	"github.com/derailed/tcell/v2"
 	"github.com/derailed/tview"
 	v1 "k8s.io/api/core/v1"
@@ -20,11 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	mv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
-
-	"github.com/derailed/k9s/internal/client"
-	"github.com/derailed/k9s/internal/config"
-	"github.com/derailed/k9s/internal/model1"
-	"github.com/derailed/k9s/internal/slogs"
 )
 
 const (

--- a/internal/render/pod_int_test.go
+++ b/internal/render/pod_int_test.go
@@ -8,14 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/derailed/k9s/internal/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	res "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	mv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
-
-	"github.com/derailed/k9s/internal/client"
 )
 
 func Test_checkInitContainerStatus(t *testing.T) {
@@ -821,8 +820,8 @@ func Test_initContainerStats(t *testing.T) {
 	always := v1.ContainerRestartPolicyAlways
 
 	uu := map[string]struct {
-		cc                              []v1.Container
-		cos                             []v1.ContainerStatus
+		cc                       []v1.Container
+		cos                      []v1.ContainerStatus
 		eReady, eTotal, eRestart int
 	}{
 		"sidecar-ready": {
@@ -853,7 +852,7 @@ func Test_initContainerStats(t *testing.T) {
 			eReady: 1, eTotal: 1,
 		},
 		"more-statuses-than-containers": {
-			cc:  []v1.Container{},
+			cc: []v1.Container{},
 			cos: []v1.ContainerStatus{
 				{Name: "gone", Ready: true},
 			},


### PR DESCRIPTION
During pod initialization, `InitContainerStatuses` can have more entries than `InitContainers` (or they may temporarily be out of sync). `initContainerStats` iterates over the status slice and directly indexes into the container slice at the same position, causing:

```
panic: runtime error: index out of range [1] with length 1
goroutine 440 [running]:
github.com/derailed/k9s/internal/render.(*Pod).initContainerStats(...)
    github.com/derailed/k9s/internal/render/pod.go:430
```

Added a bounds check to break early when the status index exceeds the container list length.

Fixes #3866