### PR TITLE
internal/view: respect read-only mode in xray view

### DIFF
--- a/internal/view/xray.go
+++ b/internal/view/xray.go
@@ -168,11 +168,13 @@ func (x *Xray) refreshActions() {
 		return
 	}
 
-	if client.Can(x.meta.Verbs, "edit") {
-		aa.Add(ui.KeyE, ui.NewKeyAction("Edit", x.editCmd, true))
-	}
-	if client.Can(x.meta.Verbs, "delete") {
-		aa.Add(tcell.KeyCtrlD, ui.NewKeyAction("Delete", x.deleteCmd, true))
+	if !x.app.Config.IsReadOnly() {
+		if client.Can(x.meta.Verbs, "edit") {
+			aa.Add(ui.KeyE, ui.NewKeyAction("Edit", x.editCmd, true))
+		}
+		if client.Can(x.meta.Verbs, "delete") {
+			aa.Add(tcell.KeyCtrlD, ui.NewKeyAction("Delete", x.deleteCmd, true))
+		}
 	}
 	if !dao.IsK9sMeta(x.meta) {
 		aa.Bulk(ui.KeyMap{


### PR DESCRIPTION
The xray view registers edit (`e`) and delete (`ctrl-d`) key bindings without checking the read-only config flag. This lets users modify or remove resources from the xray view even when k9s is started with `--readonly`.

Other views (browser, live_view, pod, node, etc.) all guard these bindings behind `IsReadOnly()`. This change adds the same check to xray for consistency.

Fixes #3822