### PR TITLE
feat: add an "owner" treeview (with help of xray view) for displaying ressources using OwnerReferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ K9s uses aliases to navigate most K8s resources.
 | To kill a resource (no confirmation dialog, equivalent to kubectl delete --now) | `ctrl-k`                      |                                                                        |
 | Launch pulses view                                                              | `:`pulses or pu⏎              |                                                                        |
 | Launch XRay view                                                                | `:`xray RESOURCE [NAMESPACE]⏎  | RESOURCE can be one of po, svc, dp, rs, sts, ds, NAMESPACE is optional |
+| Launch Owners view                                                              | `:`owners RESOURCE [NAMESPACE]⏎ | Displays the OwnerReferences tree for a given resource type. Aliases: `own`, `ot`. Ex: `:owners deploy` |
 | Launch Popeye view                                                              | `:`popeye or pop⏎              | See [popeye](#popeye)                                                  |
 | Mark resource                                                                   | `space`                        |                                                                        |
 | Mark range of resources                                                         | `ctrl-space`                   |                                                                        |

--- a/internal/client/gvrs.go
+++ b/internal/client/gvrs.go
@@ -50,23 +50,23 @@ var (
 	PmxGVR = NewGVR("metrics.k8s.io/v1beta1/pods")
 
 	// K9s...
-	CpuGVR    = NewGVR("cpu")
-	MemGVR    = NewGVR("memory")
-	WkGVR     = NewGVR("workloads")
-	CoGVR     = NewGVR("containers")
-	CtGVR     = NewGVR("contexts")
-	RefGVR    = NewGVR("references")
-	PuGVR     = NewGVR("pulses")
-	ScnGVR    = NewGVR("scans")
-	DirGVR    = NewGVR("dirs")
-	PfGVR     = NewGVR("portforwards")
-	SdGVR     = NewGVR("screendumps")
-	BeGVR     = NewGVR("benchmarks")
-	AliGVR    = NewGVR("aliases")
-	XGVR      = NewGVR("xrays")
-	OwnersGVR = NewGVR("owners")
-	HlpGVR    = NewGVR("help")
-	QGVR      = NewGVR("quit")
+	CpuGVR = NewGVR("cpu")
+	MemGVR = NewGVR("memory")
+	WkGVR  = NewGVR("workloads")
+	CoGVR  = NewGVR("containers")
+	CtGVR  = NewGVR("contexts")
+	RefGVR = NewGVR("references")
+	PuGVR  = NewGVR("pulses")
+	ScnGVR = NewGVR("scans")
+	DirGVR = NewGVR("dirs")
+	PfGVR  = NewGVR("portforwards")
+	SdGVR  = NewGVR("screendumps")
+	BeGVR  = NewGVR("benchmarks")
+	AliGVR = NewGVR("aliases")
+	XGVR   = NewGVR("xrays")
+	OwnGVR = NewGVR("owners")
+	HlpGVR = NewGVR("help")
+	QGVR   = NewGVR("quit")
 
 	// Helm...
 	HmGVR  = NewGVR("helm")
@@ -98,7 +98,7 @@ var reservedGVRs = sets.New(
 	BeGVR,
 	AliGVR,
 	XGVR,
-	OwnersGVR,
+	OwnGVR,
 	HlpGVR,
 	QGVR,
 	HmGVR,

--- a/internal/client/gvrs.go
+++ b/internal/client/gvrs.go
@@ -50,22 +50,23 @@ var (
 	PmxGVR = NewGVR("metrics.k8s.io/v1beta1/pods")
 
 	// K9s...
-	CpuGVR = NewGVR("cpu")
-	MemGVR = NewGVR("memory")
-	WkGVR  = NewGVR("workloads")
-	CoGVR  = NewGVR("containers")
-	CtGVR  = NewGVR("contexts")
-	RefGVR = NewGVR("references")
-	PuGVR  = NewGVR("pulses")
-	ScnGVR = NewGVR("scans")
-	DirGVR = NewGVR("dirs")
-	PfGVR  = NewGVR("portforwards")
-	SdGVR  = NewGVR("screendumps")
-	BeGVR  = NewGVR("benchmarks")
-	AliGVR = NewGVR("aliases")
-	XGVR   = NewGVR("xrays")
-	HlpGVR = NewGVR("help")
-	QGVR   = NewGVR("quit")
+	CpuGVR    = NewGVR("cpu")
+	MemGVR    = NewGVR("memory")
+	WkGVR     = NewGVR("workloads")
+	CoGVR     = NewGVR("containers")
+	CtGVR     = NewGVR("contexts")
+	RefGVR    = NewGVR("references")
+	PuGVR     = NewGVR("pulses")
+	ScnGVR    = NewGVR("scans")
+	DirGVR    = NewGVR("dirs")
+	PfGVR     = NewGVR("portforwards")
+	SdGVR     = NewGVR("screendumps")
+	BeGVR     = NewGVR("benchmarks")
+	AliGVR    = NewGVR("aliases")
+	XGVR      = NewGVR("xrays")
+	OwnersGVR = NewGVR("owners")
+	HlpGVR    = NewGVR("help")
+	QGVR      = NewGVR("quit")
 
 	// Helm...
 	HmGVR  = NewGVR("helm")
@@ -97,6 +98,7 @@ var reservedGVRs = sets.New(
 	BeGVR,
 	AliGVR,
 	XGVR,
+	OwnersGVR,
 	HlpGVR,
 	QGVR,
 	HmGVR,

--- a/internal/config/alias.go
+++ b/internal/config/alias.go
@@ -195,7 +195,7 @@ func (a *Aliases) loadDefaultAliases() {
 	a.declare(client.SdGVR, "screendump", "sd")
 	a.declare(client.PuGVR, "pulse", "pu", "hz")
 	a.declare(client.XGVR, "xray", "x")
-	a.declare(client.OwnersGVR, "owners", "own", "ot")
+	a.declare(client.OwnGVR, "owners", "own", "ot")
 	a.declare(client.WkGVR, "workload", "wk")
 }
 

--- a/internal/config/alias.go
+++ b/internal/config/alias.go
@@ -195,6 +195,7 @@ func (a *Aliases) loadDefaultAliases() {
 	a.declare(client.SdGVR, "screendump", "sd")
 	a.declare(client.PuGVR, "pulse", "pu", "hz")
 	a.declare(client.XGVR, "xray", "x")
+	a.declare(client.OwnersGVR, "owners", "own", "ot")
 	a.declare(client.WkGVR, "workload", "wk")
 }
 

--- a/internal/config/alias_test.go
+++ b/internal/config/alias_test.go
@@ -113,7 +113,7 @@ func TestAliasesLoad(t *testing.T) {
 	a := config.NewAliases()
 	require.NoError(t, a.Load(path.Join(config.AppConfigDir, "plain.yaml")))
 
-	assert.Len(t, a.Alias, 55)
+	assert.Len(t, a.Alias, 58)
 }
 
 func TestAliasesSave(t *testing.T) {

--- a/internal/dao/registry.go
+++ b/internal/dao/registry.go
@@ -211,7 +211,7 @@ func loadK9s(m ResourceMetas) {
 		SingularName: "xray",
 		Categories:   []string{k9sCat},
 	}
-	m[client.OwnersGVR] = &metav1.APIResource{
+	m[client.OwnGVR] = &metav1.APIResource{
 		Name:         "owners",
 		Kind:         "Owners",
 		SingularName: "owner",

--- a/internal/dao/registry.go
+++ b/internal/dao/registry.go
@@ -211,6 +211,13 @@ func loadK9s(m ResourceMetas) {
 		SingularName: "xray",
 		Categories:   []string{k9sCat},
 	}
+	m[client.OwnersGVR] = &metav1.APIResource{
+		Name:         "owners",
+		Kind:         "Owners",
+		SingularName: "owner",
+		ShortNames:   []string{"own", "ot"},
+		Categories:   []string{k9sCat},
+	}
 	m[client.RefGVR] = &metav1.APIResource{
 		Name:         "references",
 		Kind:         "References",

--- a/internal/model/owner_tree.go
+++ b/internal/model/owner_tree.go
@@ -381,7 +381,10 @@ func setOwnerNodeStatus(node *xray.TreeNode, u *unstructured.Unstructured) {
 				node.Extras[xray.InfoKey] = reason
 			}
 			return
+		} else {
+			node.Extras[xray.StatusKey] = xray.CompletedStatus
 		}
+			
 		if reason != "" {
 			node.Extras[xray.InfoKey] = reason
 		}

--- a/internal/model/owner_tree.go
+++ b/internal/model/owner_tree.go
@@ -93,7 +93,7 @@ func (t *OwnerTree) SetFilter(q string) {
 }
 
 // ToYAML returns the YAML representation of the given resource.
-func (t *OwnerTree) ToYAML(ctx context.Context, gvr *client.GVR, path string) (string, error) {
+func (*OwnerTree) ToYAML(ctx context.Context, gvr *client.GVR, path string) (string, error) {
 	factory, ok := ctx.Value(internal.KeyFactory).(dao.Factory)
 	if !ok {
 		return "", fmt.Errorf("expected Factory in context but got %T", ctx.Value(internal.KeyFactory))
@@ -105,7 +105,7 @@ func (t *OwnerTree) ToYAML(ctx context.Context, gvr *client.GVR, path string) (s
 }
 
 // Describe returns a textual description of the given resource.
-func (t *OwnerTree) Describe(ctx context.Context, gvr *client.GVR, path string) (string, error) {
+func (*OwnerTree) Describe(ctx context.Context, gvr *client.GVR, path string) (string, error) {
 	factory, ok := ctx.Value(internal.KeyFactory).(dao.Factory)
 	if !ok {
 		return "", fmt.Errorf("expected Factory in context but got %T", ctx.Value(internal.KeyFactory))
@@ -165,17 +165,12 @@ func (t *OwnerTree) reconcile(ctx context.Context) error {
 
 	// Step 1 & 2: build the reverse ownerRef index.
 	indexStart := time.Now()
-	ownerIndex, err := buildOwnerIndex(factory, ns)
-	slog.Debug("OwnerTree: buildOwnerIndex", "duration", time.Since(indexStart), "entries", len(ownerIndex))
-	if err != nil {
-		// Non-fatal — we still try to build the tree with what we have.
-		slog.Warn("OwnerTree: partial index build error", slogs.Error, err)
-	}
-
+	ownerIndex := buildOwnerIndex(factory, ns)
+	slog.Debug("OwnerTree: buildOwnerIndex", slogs.Duration, time.Since(indexStart), slogs.Entries, len(ownerIndex))
 	// Step 3: list root resources from the informer cache (no direct API call).
 	listStart := time.Now()
 	rootObjs, err := factory.List(t.gvr, ns, false, labels.Everything())
-	slog.Debug("OwnerTree: factory.List root GVR", slogs.GVR, t.gvr, "duration", time.Since(listStart), "count", len(rootObjs))
+	slog.Debug("OwnerTree: factory.List root GVR", slogs.GVR, t.gvr, slogs.Duration, time.Since(listStart), slogs.Count, len(rootObjs))
 	if err != nil {
 		return fmt.Errorf("listing root GVR %s: %w", t.gvr, err)
 	}
@@ -189,7 +184,7 @@ func (t *OwnerTree) reconcile(ctx context.Context) error {
 			continue
 		}
 		nodeFQN := resourceFQN(u)
-		slog.Info("OwnerTree: root resource", "fqn", nodeFQN, "uid", u.GetUID(), "childrenInIndex", len(ownerIndex[u.GetUID()]))
+		slog.Info("OwnerTree: root resource", slogs.FQN, nodeFQN, slogs.UID, u.GetUID(), slogs.ChildrenInIndex, len(ownerIndex[u.GetUID()]))
 		node := xray.NewTreeNode(t.gvr, nodeFQN)
 		setOwnerNodeStatus(node, u)
 		buildOwnerChildren(node, u.GetUID(), ownerIndex)
@@ -224,7 +219,7 @@ func (t *OwnerTree) reconcile(ctx context.Context) error {
 // informer lister cache (in-memory, no network calls). Resources whose
 // informer is not yet synced are silently skipped — they will appear on
 // the next reconcile cycle once the watch stream has caught up.
-func buildOwnerIndex(factory dao.Factory, ns string) (map[types.UID][]*unstructured.Unstructured, error) {
+func buildOwnerIndex(factory dao.Factory, ns string) map[types.UID][]*unstructured.Unstructured {
 	totalStart := time.Now()
 
 	// Collect all namespaced, listable GVRs first.
@@ -287,8 +282,8 @@ func buildOwnerIndex(factory dao.Factory, ns string) (map[types.UID][]*unstructu
 		"objects", totalObjs,
 		"entries", len(index),
 	)
-	slog.Debug("OwnerTree: buildOwnerIndex total", "duration", time.Since(totalStart))
-	return index, nil
+	slog.Debug("OwnerTree: buildOwnerIndex total", slogs.Duration, time.Since(totalStart))
+	return index
 }
 
 // buildOwnerChildren recursively adds children to a tree node using the

--- a/internal/model/owner_tree.go
+++ b/internal/model/owner_tree.go
@@ -187,7 +187,7 @@ func (t *OwnerTree) reconcile(ctx context.Context) error {
 		slog.Info("OwnerTree: root resource", slogs.FQN, nodeFQN, slogs.UID, u.GetUID(), slogs.ChildrenInIndex, len(ownerIndex[u.GetUID()]))
 		node := xray.NewTreeNode(t.gvr, nodeFQN)
 		setOwnerNodeStatus(node, u)
-		buildOwnerChildren(node, u.GetUID(), ownerIndex)
+		buildOwnerChildren(node, u.GetUID(), ownerIndex, map[types.UID]struct{}{u.GetUID(): {}})
 		root.Add(node)
 	}
 	slog.Debug("OwnerTree: tree build", "duration", time.Since(buildStart))
@@ -199,7 +199,17 @@ func (t *OwnerTree) reconcile(ctx context.Context) error {
 	resultRoot := root
 	if t.query != "" {
 		filterStart := time.Now()
-		if filtered := root.Filter(t.query, ownerRxMatch); filtered != nil {
+		rx, err := regexp.Compile(`(?i)` + t.query)
+		if err != nil {
+			slog.Warn("OwnerTree: invalid filter regex", "query", t.query, "error", err)
+		} else if filtered := root.Filter(t.query, func(_, path string) bool {
+			for _, tok := range strings.Split(path, "::") {
+				if rx.MatchString(tok) {
+					return true
+				}
+			}
+			return false
+		}); filtered != nil {
 			resultRoot = filtered
 		}
 		slog.Debug("OwnerTree: filter", "query", t.query, "duration", time.Since(filterStart))
@@ -287,14 +297,21 @@ func buildOwnerIndex(factory dao.Factory, ns string) map[types.UID][]*unstructur
 }
 
 // buildOwnerChildren recursively adds children to a tree node using the
-// ownerIndex reverse map.
-func buildOwnerChildren(parent *xray.TreeNode, uid types.UID, ownerIndex map[types.UID][]*unstructured.Unstructured) {
+// ownerIndex reverse map. visited tracks UIDs already on the current path
+// to prevent infinite recursion on circular OwnerReferences.
+func buildOwnerChildren(parent *xray.TreeNode, uid types.UID, ownerIndex map[types.UID][]*unstructured.Unstructured, visited map[types.UID]struct{}) {
 	for _, child := range ownerIndex[uid] {
+		if _, seen := visited[child.GetUID()]; seen {
+			slog.Warn("OwnerTree: cycle detected, skipping", slogs.UID, child.GetUID())
+			continue
+		}
 		childGVR := gvrFromUnstructured(child)
 		childNode := xray.NewTreeNode(childGVR, resourceFQN(child))
 		childNode.Extras[xray.KindKey] = child.GetKind()
 		setOwnerNodeStatus(childNode, child)
-		buildOwnerChildren(childNode, child.GetUID(), ownerIndex)
+		visited[child.GetUID()] = struct{}{}
+		buildOwnerChildren(childNode, child.GetUID(), ownerIndex, visited)
+		delete(visited, child.GetUID())
 		parent.Add(childNode)
 	}
 }
@@ -381,15 +398,4 @@ func (t *OwnerTree) fireTreeLoadFailed(err error) {
 	for _, l := range t.listeners {
 		l.TreeLoadFailed(err)
 	}
-}
-
-func ownerRxMatch(q, path string) bool {
-	rx := regexp.MustCompile(`(?i)` + q)
-	tokens := strings.Split(path, "::")
-	for _, t := range tokens {
-		if rx.MatchString(t) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/model/owner_tree.go
+++ b/internal/model/owner_tree.go
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package model
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/derailed/k9s/internal"
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/dao"
+	"github.com/derailed/k9s/internal/slogs"
+	"github.com/derailed/k9s/internal/xray"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Ensure OwnerTree satisfies the TreeModel interface.
+var _ TreeModel = (*OwnerTree)(nil)
+
+// OwnerTree represents a tree model that builds its hierarchy from
+// OwnerReferences, traversing all resource types in the namespace.
+type OwnerTree struct {
+	gvr         *client.GVR
+	namespace   string
+	root        *xray.TreeNode
+	listeners   []TreeListener
+	inUpdate    int32
+	refreshRate time.Duration
+	query       string
+}
+
+// NewOwnerTree returns a new OwnerTree model for the given root GVR.
+func NewOwnerTree(gvr *client.GVR) *OwnerTree {
+	return &OwnerTree{
+		gvr:         gvr,
+		refreshRate: 2 * time.Second,
+	}
+}
+
+// SetRefreshRate sets model refresh duration.
+func (t *OwnerTree) SetRefreshRate(d time.Duration) {
+	t.refreshRate = d
+}
+
+// SetNamespace sets up model namespace.
+func (t *OwnerTree) SetNamespace(ns string) {
+	t.namespace = ns
+	if t.root == nil {
+		return
+	}
+	t.root.Clear()
+}
+
+// GetNamespace returns the model namespace.
+func (t *OwnerTree) GetNamespace() string {
+	return t.namespace
+}
+
+// AddListener adds a listener.
+func (t *OwnerTree) AddListener(l TreeListener) {
+	t.listeners = append(t.listeners, l)
+}
+
+// Watch initiates model updates.
+func (t *OwnerTree) Watch(ctx context.Context) {
+	t.refresh(ctx)
+	go t.updater(ctx)
+}
+
+// Peek returns model data.
+func (t *OwnerTree) Peek() *xray.TreeNode {
+	return t.root
+}
+
+// ClearFilter clears out active filter.
+func (t *OwnerTree) ClearFilter() {
+	t.query = ""
+}
+
+// SetFilter sets the current filter.
+func (t *OwnerTree) SetFilter(q string) {
+	t.query = q
+}
+
+// ToYAML returns the YAML representation of the given resource.
+func (t *OwnerTree) ToYAML(ctx context.Context, gvr *client.GVR, path string) (string, error) {
+	factory, ok := ctx.Value(internal.KeyFactory).(dao.Factory)
+	if !ok {
+		return "", fmt.Errorf("expected Factory in context but got %T", ctx.Value(internal.KeyFactory))
+	}
+	g := new(dao.Generic)
+	g.Init(factory, gvr)
+
+	return g.ToYAML(path, false)
+}
+
+// Describe returns a textual description of the given resource.
+func (t *OwnerTree) Describe(ctx context.Context, gvr *client.GVR, path string) (string, error) {
+	factory, ok := ctx.Value(internal.KeyFactory).(dao.Factory)
+	if !ok {
+		return "", fmt.Errorf("expected Factory in context but got %T", ctx.Value(internal.KeyFactory))
+	}
+	g := new(dao.Generic)
+	g.Init(factory, gvr)
+
+	return g.Describe(path)
+}
+
+// ----------------------------------------------------------------------------
+// Internals
+
+func (t *OwnerTree) updater(ctx context.Context) {
+	defer slog.Debug("OwnerTree model canceled", slogs.GVR, t.gvr)
+
+	for {
+		select {
+		case <-ctx.Done():
+			t.root = nil
+			return
+		case <-time.After(t.refreshRate):
+			t.refresh(ctx)
+		}
+	}
+}
+
+func (t *OwnerTree) refresh(ctx context.Context) {
+	if !atomic.CompareAndSwapInt32(&t.inUpdate, 0, 1) {
+		slog.Debug("OwnerTree dropping update...")
+		return
+	}
+	defer atomic.StoreInt32(&t.inUpdate, 0)
+
+	if err := t.reconcile(ctx); err != nil {
+		slog.Error("OwnerTree reconcile failed", slogs.Error, err)
+		t.fireTreeLoadFailed(err)
+	}
+}
+
+// reconcile builds the owner-reference tree for the model's root GVR.
+//
+// Algorithm:
+//  1. List all resources in the namespace across every known GVR.
+//  2. Build an ownerUID→children reverse index.
+//  3. List root resources (of the model's GVR).
+//  4. Recursively attach owned resources as children in the tree.
+func (t *OwnerTree) reconcile(ctx context.Context) error {
+	reconcileStart := time.Now()
+
+	factory, ok := ctx.Value(internal.KeyFactory).(dao.Factory)
+	if !ok {
+		return fmt.Errorf("expected Factory in context but got %T", ctx.Value(internal.KeyFactory))
+	}
+
+	ns := client.CleanseNamespace(t.namespace)
+
+	// Step 1 & 2: build the reverse ownerRef index.
+	indexStart := time.Now()
+	ownerIndex, err := buildOwnerIndex(factory, ns)
+	slog.Debug("OwnerTree: buildOwnerIndex", "duration", time.Since(indexStart), "entries", len(ownerIndex))
+	if err != nil {
+		// Non-fatal — we still try to build the tree with what we have.
+		slog.Warn("OwnerTree: partial index build error", slogs.Error, err)
+	}
+
+	// Step 3: list root resources from the informer cache (no direct API call).
+	listStart := time.Now()
+	rootObjs, err := factory.List(t.gvr, ns, false, labels.Everything())
+	slog.Debug("OwnerTree: factory.List root GVR", slogs.GVR, t.gvr, "duration", time.Since(listStart), "count", len(rootObjs))
+	if err != nil {
+		return fmt.Errorf("listing root GVR %s: %w", t.gvr, err)
+	}
+
+	// Step 4: build the tree.
+	buildStart := time.Now()
+	root := xray.NewTreeNode(t.gvr, t.gvr.R())
+	for _, o := range rootObjs {
+		u, ok := o.(*unstructured.Unstructured)
+		if !ok {
+			continue
+		}
+		nodeFQN := resourceFQN(u)
+		slog.Info("OwnerTree: root resource", "fqn", nodeFQN, "uid", u.GetUID(), "childrenInIndex", len(ownerIndex[u.GetUID()]))
+		node := xray.NewTreeNode(t.gvr, nodeFQN)
+		setOwnerNodeStatus(node, u)
+		buildOwnerChildren(node, u.GetUID(), ownerIndex)
+		root.Add(node)
+	}
+	slog.Debug("OwnerTree: tree build", "duration", time.Since(buildStart))
+
+	sortStart := time.Now()
+	root.Sort()
+	slog.Debug("OwnerTree: sort", "duration", time.Since(sortStart))
+
+	resultRoot := root
+	if t.query != "" {
+		filterStart := time.Now()
+		if filtered := root.Filter(t.query, ownerRxMatch); filtered != nil {
+			resultRoot = filtered
+		}
+		slog.Debug("OwnerTree: filter", "query", t.query, "duration", time.Since(filterStart))
+	}
+
+	if t.root == nil || t.root.Diff(resultRoot) {
+		t.root = resultRoot
+		t.fireTreeChanged(t.root)
+	}
+
+	slog.Debug("OwnerTree: reconcile total", slogs.GVR, t.gvr, "ns", ns, "duration", time.Since(reconcileStart))
+
+	return nil
+}
+
+// buildOwnerIndex builds a map of ownerUID → owned resources using the
+// informer lister cache (in-memory, no network calls). Resources whose
+// informer is not yet synced are silently skipped — they will appear on
+// the next reconcile cycle once the watch stream has caught up.
+func buildOwnerIndex(factory dao.Factory, ns string) (map[types.UID][]*unstructured.Unstructured, error) {
+	totalStart := time.Now()
+
+	// Collect all namespaced, listable GVRs first.
+	gvrScanStart := time.Now()
+	var gvrs []*client.GVR
+	for _, gvr := range dao.MetaAccess.AllGVRs() {
+		meta, err := dao.MetaAccess.MetaFor(gvr)
+		if err != nil || dao.IsK9sMeta(meta) || !meta.Namespaced {
+			continue
+		}
+		if !client.Can(meta.Verbs, "view") {
+			continue
+		}
+		gvrs = append(gvrs, gvr)
+	}
+	slog.Debug("OwnerTree: GVR scan", "duration", time.Since(gvrScanStart), "gvrCount", len(gvrs))
+
+	// Read from the informer lister cache — zero network calls.
+	listerStart := time.Now()
+	index := make(map[types.UID][]*unstructured.Unstructured)
+	totalObjs := 0
+	skipped := 0
+	for _, gvr := range gvrs {
+		inf, err := factory.ForResource(ns, gvr)
+		if err != nil || inf == nil {
+			slog.Debug("OwnerTree: no informer", slogs.GVR, gvr, slogs.Error, err)
+			skipped++
+			continue
+		}
+		if !inf.Informer().HasSynced() {
+			slog.Debug("OwnerTree: informer not yet synced, skipping", slogs.GVR, gvr)
+			skipped++
+			continue
+		}
+		var objs []runtime.Object
+		if client.IsClusterScoped(ns) {
+			objs, err = inf.Lister().List(labels.Everything())
+		} else {
+			objs, err = inf.Lister().ByNamespace(ns).List(labels.Everything())
+		}
+		if err != nil {
+			slog.Debug("OwnerTree: lister error", slogs.GVR, gvr, slogs.Error, err)
+			continue
+		}
+		totalObjs += len(objs)
+		for _, o := range objs {
+			u, ok := o.(*unstructured.Unstructured)
+			if !ok {
+				continue
+			}
+			for _, ref := range u.GetOwnerReferences() {
+				index[ref.UID] = append(index[ref.UID], u)
+			}
+		}
+	}
+	slog.Debug("OwnerTree: index built from cache",
+		"duration", time.Since(listerStart),
+		"gvrCount", len(gvrs),
+		"skipped", skipped,
+		"objects", totalObjs,
+		"entries", len(index),
+	)
+	slog.Debug("OwnerTree: buildOwnerIndex total", "duration", time.Since(totalStart))
+	return index, nil
+}
+
+// buildOwnerChildren recursively adds children to a tree node using the
+// ownerIndex reverse map.
+func buildOwnerChildren(parent *xray.TreeNode, uid types.UID, ownerIndex map[types.UID][]*unstructured.Unstructured) {
+	for _, child := range ownerIndex[uid] {
+		childGVR := gvrFromUnstructured(child)
+		childNode := xray.NewTreeNode(childGVR, resourceFQN(child))
+		childNode.Extras[xray.KindKey] = child.GetKind()
+		setOwnerNodeStatus(childNode, child)
+		buildOwnerChildren(childNode, child.GetUID(), ownerIndex)
+		parent.Add(childNode)
+	}
+}
+
+// gvrFromUnstructured derives the *client.GVR for a given unstructured object.
+// It first tries MetaAccess (for registered resources), and falls back to
+// constructing a best-effort GVR from the object's APIVersion and Kind.
+func gvrFromUnstructured(u *unstructured.Unstructured) *client.GVR {
+	apiVersion := u.GetAPIVersion()
+	kind := u.GetKind()
+
+	gv, err := schema.ParseGroupVersion(apiVersion)
+	if err == nil {
+		if gvr, _, found := dao.MetaAccess.GVK2GVR(gv, kind); found {
+			return gvr
+		}
+	}
+
+	// Fallback: build a best-effort GVR string: group/version/resources.
+	resource := strings.ToLower(kind) + "s"
+	if err != nil {
+		return client.NewGVR(resource)
+	}
+	if gv.Group == "" {
+		return client.NewGVR(gv.Version + "/" + resource)
+	}
+	return client.NewGVR(gv.Group + "/" + gv.Version + "/" + resource)
+}
+
+// resourceFQN returns a FQN (namespace/name or just name for cluster-scoped)
+// for an unstructured object.
+func resourceFQN(u *unstructured.Unstructured) string {
+	ns := u.GetNamespace()
+	if ns == "" {
+		return u.GetName()
+	}
+	return client.FQN(ns, u.GetName())
+}
+
+// setOwnerNodeStatus inspects the status conditions of an unstructured
+// resource and sets the tree node's StatusKey and InfoKey accordingly.
+func setOwnerNodeStatus(node *xray.TreeNode, u *unstructured.Unstructured) {
+	conditions, found, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if !found || len(conditions) == 0 {
+		// No conditions — try a simple phase field.
+		if phase, ok, _ := unstructured.NestedString(u.Object, "status", "phase"); ok && phase != "" {
+			node.Extras[xray.InfoKey] = phase
+			switch strings.ToLower(phase) {
+			case "failed", "error", "terminating":
+				node.Extras[xray.StatusKey] = xray.ToastStatus
+			}
+		}
+		return
+	}
+
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		status, _, _ := unstructured.NestedString(cond, "status")
+		reason, _, _ := unstructured.NestedString(cond, "reason")
+
+		if status != "True" {
+			node.Extras[xray.StatusKey] = xray.ToastStatus
+			if reason != "" {
+				node.Extras[xray.InfoKey] = reason
+			}
+			return
+		}
+		if reason != "" {
+			node.Extras[xray.InfoKey] = reason
+		}
+	}
+}
+
+func (t *OwnerTree) fireTreeChanged(root *xray.TreeNode) {
+	for _, l := range t.listeners {
+		l.TreeChanged(root)
+	}
+}
+
+func (t *OwnerTree) fireTreeLoadFailed(err error) {
+	for _, l := range t.listeners {
+		l.TreeLoadFailed(err)
+	}
+}
+
+func ownerRxMatch(q, path string) bool {
+	rx := regexp.MustCompile(`(?i)` + q)
+	tokens := strings.Split(path, "::")
+	for _, t := range tokens {
+		if rx.MatchString(t) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/model/tree_iface.go
+++ b/internal/model/tree_iface.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package model
+
+import (
+	"context"
+	"time"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/xray"
+)
+
+// TreeModel represents a generic tree data model used by the Xray view.
+type TreeModel interface {
+	// SetRefreshRate sets the model refresh rate.
+	SetRefreshRate(time.Duration)
+
+	// SetNamespace sets the active namespace.
+	SetNamespace(string)
+
+	// GetNamespace returns the current namespace.
+	GetNamespace() string
+
+	// AddListener adds a tree listener.
+	AddListener(TreeListener)
+
+	// Watch starts watching for changes.
+	Watch(context.Context)
+
+	// Peek returns the current tree root.
+	Peek() *xray.TreeNode
+
+	// ClearFilter clears the current filter.
+	ClearFilter()
+
+	// SetFilter sets the current filter.
+	SetFilter(string)
+
+	// ToYAML returns the YAML representation of a resource.
+	ToYAML(ctx context.Context, gvr *client.GVR, path string) (string, error)
+
+	// Describe returns a text description of a resource.
+	Describe(ctx context.Context, gvr *client.GVR, path string) (string, error)
+}

--- a/internal/slogs/keys.go
+++ b/internal/slogs/keys.go
@@ -228,4 +228,13 @@ const (
 
 	// Minimum tracks a minimum value logger key.
 	Minimum = "minimum"
+
+	// Entries tracks an entries logger key.
+	Entries = "entries"
+
+	// UID tracks a UID logger key.
+	UID = "uid"
+
+	// ChildrenInIndex tracks a children in index logger key.
+	ChildrenInIndex = "childrenInIndex"
 )

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -213,6 +213,14 @@ func (a *App) suggestCommand() model.SuggestionFunc {
 			}
 		}
 
+		if res, ok := cmd.NewInterpreter(s).OwnersResourceArg(); ok {
+			for alias := range maps.Keys(a.command.alias.Alias) {
+				if suggest, ok := cmd.ShouldAddSuggest(res, alias); ok {
+					entries = append(entries, suggest)
+				}
+			}
+		}
+
 		namespaceNames, err := a.factory.Client().ValidNamespaceNames()
 		if err != nil {
 			slog.Error("Failed to obtain list of namespaces", slogs.Error, err)

--- a/internal/view/cmd/args.go
+++ b/internal/view/cmd/args.go
@@ -64,7 +64,7 @@ func newArgs(p *Interpreter, aa []string) args {
 					arguments[topicKey] = a
 				}
 
-			case p.IsXrayCmd():
+			case p.IsXrayCmd(), p.IsOwnersCmd():
 				if _, ok := arguments[topicKey]; ok {
 					arguments[nsKey] = strings.ToLower(a)
 				} else {

--- a/internal/view/cmd/helpers.go
+++ b/internal/view/cmd/helpers.go
@@ -70,9 +70,12 @@ func SuggestSubCommand(command string, namespaces client.NamespaceNames, context
 		return nil
 
 	case p.IsXrayCmd(), p.IsOwnersCmd():
-		_, ns, ok := p.XrayArgs()
+		var ns string
+		var ok bool
 		if p.IsOwnersCmd() {
 			_, ns, ok = p.OwnersArgs()
+		} else {
+			_, ns, ok = p.XrayArgs()
 		}
 		if !ok || ns == "" {
 			return nil

--- a/internal/view/cmd/helpers.go
+++ b/internal/view/cmd/helpers.go
@@ -69,8 +69,11 @@ func SuggestSubCommand(command string, namespaces client.NamespaceNames, context
 	case p.IsCowCmd(), p.IsHelpCmd(), p.IsAliasCmd(), p.IsBailCmd(), p.IsDirCmd():
 		return nil
 
-	case p.IsXrayCmd():
+	case p.IsXrayCmd(), p.IsOwnersCmd():
 		_, ns, ok := p.XrayArgs()
+		if p.IsOwnersCmd() {
+			_, ns, ok = p.OwnersArgs()
+		}
 		if !ok || ns == "" {
 			return nil
 		}

--- a/internal/view/cmd/interpreter.go
+++ b/internal/view/cmd/interpreter.go
@@ -190,6 +190,11 @@ func (c *Interpreter) IsXrayCmd() bool {
 	return xrayCmd.Has(c.cmd)
 }
 
+// IsOwnersCmd returns true if owners/owner-tree cmd is detected.
+func (c *Interpreter) IsOwnersCmd() bool {
+	return ownersCmd.Has(c.cmd)
+}
+
 // IsContextCmd returns true if context cmd is detected.
 func (c *Interpreter) IsContextCmd() bool {
 	return contextCmd.Has(c.cmd)
@@ -261,6 +266,29 @@ func (c *Interpreter) RBACArgs() (subject, verb string, ok bool) {
 // XrayArgs return the gvr and ns if any.
 func (c *Interpreter) XrayArgs() (cmd, namespace string, ok bool) {
 	if !c.IsXrayCmd() {
+		return
+	}
+	gvr, ok1 := c.args[topicKey]
+	if !ok1 {
+		return
+	}
+
+	ns, ok2 := c.args[nsKey]
+	switch {
+	case ok1 && ok2:
+		cmd, namespace, ok = gvr, ns, true
+	case ok1 && !ok2:
+		cmd, namespace, ok = gvr, "", true
+	default:
+		return
+	}
+
+	return
+}
+
+// OwnersArgs returns the gvr and optional namespace for an owners command.
+func (c *Interpreter) OwnersArgs() (cmd, namespace string, ok bool) {
+	if !c.IsOwnersCmd() {
 		return
 	}
 	gvr, ok1 := c.args[topicKey]

--- a/internal/view/cmd/interpreter.go
+++ b/internal/view/cmd/interpreter.go
@@ -286,6 +286,27 @@ func (c *Interpreter) XrayArgs() (cmd, namespace string, ok bool) {
 	return
 }
 
+// OwnersResourceArg returns the partial resource type being typed for an
+// owners command, when the resource type is not yet complete.
+func (c *Interpreter) OwnersResourceArg() (string, bool) {
+	if !c.IsOwnersCmd() {
+		return "", false
+	}
+	// A trailing space or a namespace arg means the resource type is complete.
+	if strings.HasSuffix(c.line, " ") {
+		return "", false
+	}
+	if _, ok := c.args[nsKey]; ok {
+		return "", false
+	}
+	res, ok := c.args[topicKey]
+	if !ok || res == "" {
+		return "", false
+	}
+
+	return res, true
+}
+
 // OwnersArgs returns the gvr and optional namespace for an owners command.
 func (c *Interpreter) OwnersArgs() (cmd, namespace string, ok bool) {
 	if !c.IsOwnersCmd() {

--- a/internal/view/cmd/types.go
+++ b/internal/view/cmd/types.go
@@ -74,4 +74,9 @@ var (
 		"xr",
 		"xray",
 	)
+	ownersCmd = sets.New(
+		"owners",
+		"own",
+		"ot",
+	)
 )

--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -172,6 +172,34 @@ func (c *Command) xrayCmd(p *cmd.Interpreter, pushCmd bool) error {
 	return c.exec(p, client.XGVR, NewXray(gvr), true, pushCmd)
 }
 
+// ownersCmd handles the `owners <gvr> [-n namespace]` command.
+// It opens an OwnerReference-based tree view for any resource type.
+func (c *Command) ownersCmd(p *cmd.Interpreter, pushCmd bool) error {
+	arg, cns, ok := p.OwnersArgs()
+	if !ok {
+		return errors.New("invalid command. use `owners <resource>`")
+	}
+	if c.alias == nil {
+		return fmt.Errorf("no connection available")
+	}
+	gvr, ok := c.alias.Resolve(cmd.NewInterpreter(arg))
+	if !ok {
+		return fmt.Errorf("invalid resource name: %q", arg)
+	}
+	ns := c.app.Config.ActiveNamespace()
+	if cns != "" {
+		ns = cns
+	}
+	if err := c.app.Config.SetActiveNamespace(client.CleanseNamespace(ns)); err != nil {
+		return err
+	}
+	if err := c.app.switchNS(ns); err != nil {
+		return err
+	}
+
+	return c.exec(p, client.XGVR, NewOwnerXray(gvr), true, pushCmd)
+}
+
 // Run execs the command by showing associated display.
 func (c *Command) run(p *cmd.Interpreter, fqn string, clearStack, pushCmd bool) error {
 	if c.specialCmd(p, pushCmd) {
@@ -285,6 +313,10 @@ func (c *Command) specialCmd(p *cmd.Interpreter, pushCmd bool) bool {
 		}
 	case p.IsXrayCmd():
 		if err := c.xrayCmd(p, pushCmd); err != nil {
+			c.app.Flash().Err(err)
+		}
+	case p.IsOwnersCmd():
+		if err := c.ownersCmd(p, pushCmd); err != nil {
 			c.app.Flash().Err(err)
 		}
 	case p.IsRBACCmd():

--- a/internal/view/xray.go
+++ b/internal/view/xray.go
@@ -42,7 +42,7 @@ type Xray struct {
 	app      *App
 	gvr      *client.GVR
 	meta     *metav1.APIResource
-	model    *model.Tree
+	model    model.TreeModel
 	cancelFn context.CancelFunc
 	envFn    EnvFunc
 }
@@ -53,6 +53,15 @@ func NewXray(gvr *client.GVR) ResourceViewer {
 		gvr:   gvr,
 		Tree:  ui.NewTree(),
 		model: model.NewTree(gvr),
+	}
+}
+
+// NewOwnerXray returns an Xray view backed by an OwnerReference-based tree model.
+func NewOwnerXray(gvr *client.GVR) ResourceViewer {
+	return &Xray{
+		gvr:   gvr,
+		Tree:  ui.NewTree(),
+		model: model.NewOwnerTree(gvr),
 	}
 }
 

--- a/internal/view/xray.go
+++ b/internal/view/xray.go
@@ -45,6 +45,7 @@ type Xray struct {
 	model    model.TreeModel
 	cancelFn context.CancelFunc
 	envFn    EnvFunc
+	title    string
 }
 
 // NewXray returns a new view.
@@ -53,6 +54,7 @@ func NewXray(gvr *client.GVR) ResourceViewer {
 		gvr:   gvr,
 		Tree:  ui.NewTree(),
 		model: model.NewTree(gvr),
+		title: xrayTitle,
 	}
 }
 
@@ -62,6 +64,7 @@ func NewOwnerXray(gvr *client.GVR) ResourceViewer {
 		gvr:   gvr,
 		Tree:  ui.NewTree(),
 		model: model.NewOwnerTree(gvr),
+		title: "Owners",
 	}
 }
 
@@ -93,7 +96,7 @@ func (x *Xray) Init(ctx context.Context) error {
 	x.SetBorderColor(x.app.Styles.Xray().FgColor.Color())
 	x.SetBorderFocusColor(x.app.Styles.Frame().Border.FocusColor.Color())
 	x.SetGraphicsColor(x.app.Styles.Xray().GraphicColor.Color())
-	x.SetTitle(fmt.Sprintf(" %s-%s ", xrayTitle, cases.Title(language.Und, cases.NoLower).String(x.gvr.R())))
+	x.SetTitle(fmt.Sprintf(" %s-%s ", x.title, cases.Title(language.Und, cases.NoLower).String(x.gvr.R())))
 
 	x.model.SetRefreshRate(x.app.Config.K9s.RefreshDuration())
 	x.model.SetNamespace(client.CleanseNamespace(x.app.Config.ActiveNamespace()))
@@ -710,7 +713,7 @@ func (x *Xray) UpdateTitle() {
 }
 
 func (x *Xray) styleTitle() string {
-	base := fmt.Sprintf("%s-%s", xrayTitle, cases.Title(language.Und, cases.NoLower).String(x.gvr.R()))
+	base := fmt.Sprintf("%s-%s", x.title, cases.Title(language.Und, cases.NoLower).String(x.gvr.R()))
 	ns := x.model.GetNamespace()
 	if client.IsAllNamespaces(ns) {
 		ns = client.NamespaceAll

--- a/internal/xray/tree_node.go
+++ b/internal/xray/tree_node.go
@@ -31,6 +31,9 @@ const (
 	// InfoKey state map key.
 	InfoKey = "info"
 
+	// KindKey stores the resource Kind for display.
+	KindKey = "kind"
+
 	// OkStatus stands for all is cool.
 	OkStatus = "ok"
 
@@ -426,7 +429,10 @@ func (t TreeNode) toTitle() (title string) {
 		}
 	}()
 
-	categ := category(t.GVR)
+	categ := t.Extras[KindKey]
+	if categ == "" {
+		categ = category(t.GVR)
+	}
 	if categ == "" {
 		title = fmt.Sprintf(topTitleFmt, color, n)
 	} else {
@@ -465,7 +471,11 @@ func (t TreeNode) toEmojiTitle() (title string) {
 		}
 	}()
 
-	title = fmt.Sprintf(colorFmt, toEmoji(t.GVR), color, n)
+	if kind, ok := t.Extras[KindKey]; ok && kind != "" {
+		title = fmt.Sprintf(titleFmt, kind, color, n)
+	} else {
+		title = fmt.Sprintf(colorFmt, toEmoji(t.GVR), color, n)
+	}
 	if !t.IsLeaf() {
 		title += fmt.Sprintf("[white::d](%d[-::d])[-::-]", t.CountChildren())
 	}

--- a/internal/xray/tree_node.go
+++ b/internal/xray/tree_node.go
@@ -415,12 +415,15 @@ const (
 func (t TreeNode) toTitle() (title string) {
 	_, n := client.Namespaced(t.ID)
 	color, status := "white", "OK"
+	infoColor := "antiquewhite"
 	if v, ok := t.Extras[StatusKey]; ok {
 		switch v {
+		case CompletedStatus:
+			infoColor = "green"
 		case ToastStatus:
-			color, status = "orangered", toast
+			infoColor, color, status = "orangered", "orangered", toast
 		case MissingRefStatus:
-			color, status = "orange", toast+"_REF"
+			infoColor, color, status = "orange", "orange", toast+"_REF"
 		}
 	}
 	defer func() {
@@ -447,7 +450,7 @@ func (t TreeNode) toTitle() (title string) {
 	if !ok {
 		return
 	}
-	title += fmt.Sprintf(" [antiquewhite::][%s][::]", info)
+	title += fmt.Sprintf(" [%s::][%s][::]", infoColor, info)
 
 	return
 }
@@ -457,12 +460,15 @@ const colorFmt = "%s [%s::b]%s[::]"
 func (t TreeNode) toEmojiTitle() (title string) {
 	_, n := client.Namespaced(t.ID)
 	color, status := "white", "OK"
+	infoColor := "antiquewhite"
 	if v, ok := t.Extras[StatusKey]; ok {
 		switch v {
+		case CompletedStatus:
+			infoColor = "green"
 		case ToastStatus:
-			color, status = "orangered", toast
+			infoColor, color, status = "orangered", "orangered", toast
 		case MissingRefStatus:
-			color, status = "orange", toast+"_REF"
+			infoColor, color, status = "orange", "orange", toast+"_REF"
 		}
 	}
 	defer func() {
@@ -484,7 +490,7 @@ func (t TreeNode) toEmojiTitle() (title string) {
 	if !ok {
 		return
 	}
-	title += fmt.Sprintf(" [antiquewhite::][%s][::]", info)
+	title += fmt.Sprintf(" [%s::][%s][::]", infoColor, info)
 
 	return
 }


### PR DESCRIPTION
We are working on an internal developer platform  backed by kubernetes operator.
All platform custom resources are related using OwnerReferences.
We use kubctl tree plugin to see the hierarchical view. 
We have implemented the same view using k9s and xray treeview infrastructure.

The PR is in early stage. But we hope the this feature would gain interest in the community.
<img width="1897" height="821" alt="image" src="https://github.com/user-attachments/assets/7bfdb80b-72f0-4113-b194-4de880001789" />

