### PR TITLE
feat(flashinfo) allow set flash color in theme

### DIFF
--- a/internal/config/styles.go
+++ b/internal/config/styles.go
@@ -119,6 +119,7 @@ type (
 		Menu   Menu   `json:"menu" yaml:"menu"`
 		Crumb  Crumb  `json:"crumbs" yaml:"crumbs"`
 		Status Status `json:"status" yaml:"status"`
+		Flash  Flash  `json:"flash" yaml:"flash"`
 	}
 
 	// Views tracks individual view styles.
@@ -141,6 +142,13 @@ type (
 		HighlightColor Color `json:"highlightColor" yaml:"highlightColor"`
 		KillColor      Color `json:"killColor" yaml:"killColor"`
 		CompletedColor Color `json:"completedColor" yaml:"completedColor"`
+	}
+
+	// Flash tracks flash message styles.
+	Flash struct {
+		InfoColor  Color `json:"infoColor" yaml:"infoColor"`
+		WarnColor  Color `json:"warnColor" yaml:"warnColor"`
+		ErrorColor Color `json:"errorColor" yaml:"errorColor"`
 	}
 
 	// Log tracks Log styles.
@@ -322,6 +330,7 @@ func newFrame() Frame {
 		Menu:   newMenu(),
 		Crumb:  newCrumb(),
 		Status: newStatus(),
+		Flash:  newFlash(),
 	}
 }
 
@@ -357,6 +366,14 @@ func newStatus() Status {
 		HighlightColor: "aqua",
 		KillColor:      "mediumpurple",
 		CompletedColor: "lightslategray",
+	}
+}
+
+func newFlash() Flash {
+	return Flash{
+		InfoColor:  "navajowhite",
+		WarnColor:  "orange",
+		ErrorColor: "orangered",
 	}
 }
 
@@ -549,6 +566,11 @@ func (s *Styles) Title() Title {
 	return s.Frame().Title
 }
 
+// Flash returns flash styles.
+func (s *Styles) Flash() Flash {
+	return s.Frame().Flash
+}
+
 // Charts returns charts styles.
 func (s *Styles) Charts() Charts {
 	return s.K9s.Views.Charts
@@ -638,6 +660,7 @@ func (f *Frame) Invert() {
 	f.Menu.Invert()
 	f.Crumb.Invert()
 	f.Status.Invert()
+	f.Flash.Invert()
 }
 
 // Invert inverts all colors in Title.
@@ -679,6 +702,13 @@ func (s *Status) Invert() {
 	s.HighlightColor = s.HighlightColor.InvertColor()
 	s.KillColor = s.KillColor.InvertColor()
 	s.CompletedColor = s.CompletedColor.InvertColor()
+}
+
+// Invert inverts all colors in Flash.
+func (f *Flash) Invert() {
+	f.InfoColor = f.InfoColor.InvertColor()
+	f.WarnColor = f.WarnColor.InvertColor()
+	f.ErrorColor = f.ErrorColor.InvertColor()
 }
 
 // Invert inverts all colors in Info.

--- a/internal/config/templates/stock-skin.yaml
+++ b/internal/config/templates/stock-skin.yaml
@@ -52,6 +52,10 @@ k9s:
       highlightColor: aqua
       killColor: mediumpurple
       completedColor: lightslategray
+    flash:
+      infoColor: navajowhite
+      warnColor: orange
+      errorColor: orangered
   info:
     sectionColor: white
     fgColor: orange

--- a/internal/ui/flash.go
+++ b/internal/ui/flash.go
@@ -73,7 +73,7 @@ func (f *Flash) SetMessage(m model.LevelMessage) {
 			f.Clear()
 			return
 		}
-		f.SetTextColor(flashColor(m.Level))
+		f.SetTextColor(f.flashColor(m.Level))
 		f.SetText(f.flashEmoji(m.Level) + " " + m.Text)
 	}
 
@@ -101,14 +101,14 @@ func (f *Flash) flashEmoji(l model.FlashLevel) string {
 
 // Helpers...
 
-func flashColor(l model.FlashLevel) tcell.Color {
+func (f *Flash) flashColor(l model.FlashLevel) tcell.Color {
 	//nolint:exhaustive
 	switch l {
 	case model.FlashWarn:
-		return tcell.ColorOrange
+		return f.app.Styles.Flash().WarnColor.Color()
 	case model.FlashErr:
-		return tcell.ColorOrangeRed
+		return f.app.Styles.Flash().ErrorColor.Color()
 	default:
-		return tcell.ColorNavajoWhite
+		return f.app.Styles.Flash().InfoColor.Color()
 	}
 }


### PR DESCRIPTION
<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/k9s_small.png" align="right" width="100" height="auto"/>

<br/>
<br/>
<br/>

**Is your feature request related to a problem? Please describe.**
The Flash message colors are harcoded and not friendly with light theme

<img width="511" height="90" alt="image" src="https://github.com/user-attachments/assets/27c61c3e-8ea3-4d13-a04f-8780b9be90fc" />


**Describe the solution you'd like**
Being able to set the Flash message colors in a theme as such
```
k9s:
  frame: 
    flash:
      infoColor: navajowhite
      warnColor: orange
      errorColor: orangered
```

**Describe alternatives you've considered**
Switching to a dark theme, but no, my terminal is back on white. 

**Additional context**
