### PR TITLE
don't kill connection when metrics discovery fails but cluster is reachable

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -74,8 +74,10 @@ func InitConnection(config *Config, log *slog.Logger) (*APIClient, error) {
 	if err := a.supportsMetricsResources(); err != nil {
 		slog.Warn("Fail to locate metrics-server", slogs.Error, err)
 		if !errors.Is(err, noMetricServerErr) && !errors.Is(err, metricsUnsupportedErr) {
-			a.connOK = false
-			return &a, err
+			if !a.CheckConnectivity() {
+				return &a, err
+			}
+			slog.Warn("Metrics discovery failed but cluster is reachable, continuing", slogs.Error, err)
 		}
 	}
 	return &a, nil

--- a/internal/client/switch_context_test.go
+++ b/internal/client/switch_context_test.go
@@ -207,3 +207,38 @@ func TestInitConnectionStoresDialClient(t *testing.T) {
 	assert.NotNil(t, a.getClient(),
 		"InitConnection should store a Dial client for reuse")
 }
+
+func TestInitConnectionBrokenDiscoveryButReachable(t *testing.T) {
+	// Simulate a scenario where discovery (e.g. /apis) fails (stale cache, corrupt
+	// response, etc.) but the cluster is otherwise reachable via /version.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(version.Info{
+			Major:      "1",
+			Minor:      "28",
+			GitVersion: "v1.28.0",
+		})
+	})
+	mux.HandleFunc("/api", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"kind":"APIVersions","versions":["v1"]}`))
+	})
+	mux.HandleFunc("/apis", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "simulated stale discovery failure", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	t.Setenv("HOME", t.TempDir())
+
+	kubeconfig := writeSwitchTestKubeconfig(t, srv.URL, srv.URL)
+	flags := genericclioptions.NewConfigFlags(false)
+	flags.KubeConfig = &kubeconfig
+	ctx := testContext1
+	flags.Context = &ctx
+
+	a, err := InitConnection(NewConfig(flags), slog.Default())
+	require.NoError(t, err)
+	assert.True(t, a.ConnectionOK(),
+		"InitConnection should remain connected when discovery fails but cluster is reachable")
+}


### PR DESCRIPTION
## what happened

stale `~/.kube/cache/discovery` entries (mine were from 2024) can make `supportsMetricsResources()` blow up with an unexpected error during `InitConnection`. this sets `connOK=false` and then every API call short-circuits with "no connection to cached dial" — k9s is completely bricked for that cluster.

meanwhile `kubectl` works perfectly fine against the same kubeconfig because client-go's discovery client knows how to invalidate stale cache entries.

## the fix

instead of immediately giving up when metrics discovery fails unexpectedly, fall back to `CheckConnectivity()` which hits `/version` directly. if the cluster responds, carry on without metrics. if it's truly unreachable, fail as before.

- `rm -rf ~/.kube/cache/discovery` is no longer needed as a workaround
- related to #3471 and #644 (same `connOK` gets stuck false pattern)

## test

added `TestInitConnectionBrokenDiscoveryButReachable` — sets up a server where `/apis` returns 500 but `/version` works, asserts `ConnectionOK()` stays true.