### PR TITLE
fix: populate pod count in Node.Get() for single-node view

### DIFF
--- a/internal/dao/node.go
+++ b/internal/dao/node.go
@@ -152,7 +152,14 @@ func (n *Node) Get(ctx context.Context, path string) (runtime.Object, error) {
 		nmx, _ = client.DialMetrics(n.Client()).FetchNodeMetrics(ctx, path)
 	}
 
-	return &render.NodeWithMetrics{Raw: raw, MX: nmx}, nil
+	podCount := -1
+	if shouldCountPods, _ := ctx.Value(internal.KeyPodCounting).(bool); shouldCountPods {
+		if pp, err := n.GetPods(path); err == nil {
+			podCount = len(pp)
+		}
+	}
+
+	return &render.NodeWithMetrics{Raw: raw, MX: nmx, PodCount: podCount}, nil
 }
 
 // List returns a collection of node resources.


### PR DESCRIPTION
## Summary

- When navigating to a node view from a pod (pressing `o`), the node always showed **0 pods** regardless of actual pod count
- Root cause: `Node.Get()` (used for single-instance views) never populated the `PodCount` field on `NodeWithMetrics`, so it defaulted to `0`
- `Node.List()` already had pod counting logic, but `Get()` was missing it
- Fix: reuse the existing `GetPods()` method in `Get()` to count pods when pod counting is enabled

## Test plan

- [ ] Open k9s, navigate to pods view
- [ ] Press `o` on any pod to open the node view
- [ ] Verify the PODS column shows the correct non-zero count
- [ ] Verify the normal nodes list view (`shift+n`) still shows correct pod counts
- [ ] Verify with `disablePodCounting: true` in config that PODS shows `n/a`