### PR TITLE
fix: reset styles before loading skin on context switch

### DIFF
--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -276,6 +276,7 @@ func (c *Configurator) loadSkinFile(synchronizer) {
 
 	skinFile := config.SkinFileFromName(skin)
 	slog.Debug("Loading skin file", slogs.Skin, skinFile)
+	c.Styles.Reset(invert)
 	if err := c.Styles.Load(skinFile, invert); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			slog.Warn("Skin file not found in skins dir",


### PR DESCRIPTION
### Problem: 
Switching contexts via :ctx from a skin with many explicit color fields (e.g. a red prod theme) to one with fewer fields (e.g. a minimal transparent theme) leaves stale colors from the previous skin

### Cause: 
loadSkinFile() calls Styles.Load() which uses yaml.Unmarshal to merge onto the existing struct — fields not present in the new skin file persist from the previous one

### Fix: 
Call Styles.Reset() before Styles.Load() so each skin load starts from stock defaults

### Verified with: 
debug logs confirming the correct skin file is loaded but UI doesn't update, and that this fix resolves it