### PR TITLE
feat: Add local timezone toggle for log viewer (Fixes #1302)

### DIFF
--- a/internal/config/logger.go
+++ b/internal/config/logger.go
@@ -23,6 +23,7 @@ type Logger struct {
 	DisableAutoscroll bool  `json:"disableAutoscroll" yaml:"disableAutoscroll"`
 	ColumnLock        bool  `json:"columnLock" yaml:"columnLock"`
 	ShowTime          bool  `json:"showTime" yaml:"showTime"`
+	LocalTime         bool  `json:"localTime" yaml:"localTime"`
 }
 
 // NewLogger returns a new instance.

--- a/internal/config/testdata/configs/default.yaml
+++ b/internal/config/testdata/configs/default.yaml
@@ -40,6 +40,7 @@ k9s:
     disableAutoscroll: false
     columnLock: false
     showTime: false
+    localTime: false
   thresholds:
     cpu:
       critical: 90

--- a/internal/config/testdata/configs/expected.yaml
+++ b/internal/config/testdata/configs/expected.yaml
@@ -41,6 +41,7 @@ k9s:
     disableAutoscroll: false
     columnLock: false
     showTime: false
+    localTime: false
   thresholds:
     cpu:
       critical: 90

--- a/internal/dao/log_item.go
+++ b/internal/dao/log_item.go
@@ -5,6 +5,7 @@ package dao
 
 import (
 	"bytes"
+	"time"
 )
 
 // LogChan represents a channel for logs.
@@ -42,7 +43,7 @@ func (l *LogItem) ID() string {
 	return l.Container
 }
 
-// GetTimestamp fetch log lime timestamp
+// GetTimestamp fetch log line timestamp
 func (l *LogItem) GetTimestamp() string {
 	index := bytes.Index(l.Bytes, []byte{' '})
 	if index < 0 {
@@ -68,10 +69,24 @@ func (l *LogItem) Size() int {
 
 // Render returns a log line as string.
 func (l *LogItem) Render(paint string, showTime bool, bb *bytes.Buffer) {
+	l.RenderWithLocalTime(paint, showTime, false, bb)
+}
+
+// RenderWithLocalTime returns a log line as string with optional local timezone conversion.
+func (l *LogItem) RenderWithLocalTime(paint string, showTime, useLocalTime bool, bb *bytes.Buffer) {
 	index := bytes.Index(l.Bytes, []byte{' '})
 	if showTime && index > 0 {
 		bb.WriteString("[gray::b]")
-		bb.Write(l.Bytes[:index])
+		if useLocalTime {
+			ts := string(l.Bytes[:index])
+			if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+				bb.WriteString(t.Local().Format(time.RFC3339Nano))
+			} else {
+				bb.Write(l.Bytes[:index])
+			}
+		} else {
+			bb.Write(l.Bytes[:index])
+		}
 		bb.WriteString(" ")
 		if l := 30 - len(l.Bytes[:index]); l > 0 {
 			bb.Write(bytes.Repeat([]byte{' '}, l))

--- a/internal/dao/log_item_test.go
+++ b/internal/dao/log_item_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/dao"
@@ -129,4 +130,21 @@ func BenchmarkLogItemRenderNoTS(b *testing.B) {
 		bb := bytes.NewBuffer(make([]byte, 0, i.Size()))
 		i.Render("yellow", false, bb)
 	}
+}
+func TestLogItemRenderWithLocalTime(t *testing.T) {
+	origLocal := time.Local
+	time.Local = time.FixedZone("FakeLocal", 5*60*60) 
+	defer func() { time.Local = origLocal }() 
+
+	logLine := fmt.Sprintf("%s %s\n", "2018-12-14T10:36:43.326972Z", "Testing local time conversion...")
+	i := dao.NewLogItem([]byte(tview.Escape(logLine)))
+	i.Pod, i.Container = "fred", "blee"
+
+	bb := bytes.NewBuffer(make([]byte, 0, i.Size()))
+	
+	i.RenderWithLocalTime("yellow", true, true, bb)
+
+	expected := "[gray::b]2018-12-14T15:36:43.326972+05:00    [-::-][yellow::]fred [yellow::b]blee[-::-] Testing local time conversion...\n"
+	
+	assert.Equal(t, expected, bb.String())
 }

--- a/internal/dao/log_items.go
+++ b/internal/dao/log_items.go
@@ -121,26 +121,26 @@ func (l *LogItems) podColorFor(id string) string {
 }
 
 // Lines returns a collection of log lines.
-func (l *LogItems) Lines(index int, showTime bool, ll [][]byte) {
+func (l *LogItems) Lines(index int, showTime, showLocalTime bool, ll [][]byte) {
 	l.mx.Lock()
 	defer l.mx.Unlock()
 
 	for i, item := range l.items[index:] {
 		bb := bytes.NewBuffer(make([]byte, 0, item.Size()))
-		item.Render(l.podColorFor(item.ID()), showTime, bb)
+		item.RenderWithLocalTime(l.podColorFor(item.ID()), showTime, showLocalTime, bb)
 		ll[i] = bb.Bytes()
 	}
 }
 
 // StrLines returns a collection of log lines.
-func (l *LogItems) StrLines(index int, showTime bool) []string {
+func (l *LogItems) StrLines(index int, showTime, showLocalTime bool) []string {
 	l.mx.Lock()
 	defer l.mx.Unlock()
 
 	ll := make([]string, len(l.items[index:]))
 	for i, item := range l.items[index:] {
 		bb := bytes.NewBuffer(make([]byte, 0, item.Size()))
-		item.Render(l.podColorFor(item.ID()), showTime, bb)
+		item.RenderWithLocalTime(l.podColorFor(item.ID()), showTime, showLocalTime, bb)
 		ll[i] = bb.String()
 	}
 
@@ -148,10 +148,10 @@ func (l *LogItems) StrLines(index int, showTime bool) []string {
 }
 
 // Render returns logs as a collection of strings.
-func (l *LogItems) Render(index int, showTime bool, ll [][]byte) {
+func (l *LogItems) Render(index int, showTime, showLocalTime bool, ll [][]byte) {
 	for i, item := range l.items[index:] {
 		bb := bytes.NewBuffer(make([]byte, 0, item.Size()))
-		item.Render(l.podColorFor(item.ID()), showTime, bb)
+		item.RenderWithLocalTime(l.podColorFor(item.ID()), showTime, showLocalTime, bb)
 		ll[i] = bb.Bytes()
 	}
 }
@@ -165,15 +165,15 @@ func (l *LogItems) DumpDebug(m string) {
 }
 
 // Filter filters out log items based on given filter.
-func (l *LogItems) Filter(index int, q string, showTime bool) (matches []int, indices [][]int, err error) {
+func (l *LogItems) Filter(index int, q string, showTime, showLocalTime bool) (matches []int, indices [][]int, err error) {
 	if q == "" {
 		return
 	}
 	if f, ok := internal.IsFuzzySelector(q); ok {
-		matches, indices = l.fuzzyFilter(index, f, showTime)
+		matches, indices = l.fuzzyFilter(index, f, showTime, showLocalTime)
 		return
 	}
-	matches, indices, err = l.filterLogs(index, q, showTime)
+	matches, indices, err = l.filterLogs(index, q, showTime, showLocalTime)
 	if err != nil {
 		return
 	}
@@ -181,10 +181,10 @@ func (l *LogItems) Filter(index int, q string, showTime bool) (matches []int, in
 	return matches, indices, nil
 }
 
-func (l *LogItems) fuzzyFilter(index int, q string, showTime bool) (matches []int, indices [][]int) {
+func (l *LogItems) fuzzyFilter(index int, q string, showTime, showLocalTime bool) (matches []int, indices [][]int) {
 	q = strings.TrimSpace(q)
 	matches, indices = make([]int, 0, len(l.items)), make([][]int, 0, len(l.items))
-	mm := fuzzy.Find(q, l.StrLines(index, showTime))
+	mm := fuzzy.Find(q, l.StrLines(index, showTime, showLocalTime))
 	for _, m := range mm {
 		matches = append(matches, m.Index)
 		indices = append(indices, m.MatchedIndexes)
@@ -193,7 +193,7 @@ func (l *LogItems) fuzzyFilter(index int, q string, showTime bool) (matches []in
 	return matches, indices
 }
 
-func (l *LogItems) filterLogs(index int, q string, showTime bool) (matches []int, indices [][]int, err error) {
+func (l *LogItems) filterLogs(index int, q string, showTime, showLocalTime bool) (matches []int, indices [][]int, err error) {
 	var invert bool
 	if internal.IsInverseSelector(q) {
 		invert = true
@@ -205,7 +205,7 @@ func (l *LogItems) filterLogs(index int, q string, showTime bool) (matches []int
 	}
 	matches, indices = make([]int, 0, len(l.items)), make([][]int, 0, len(l.items))
 	ll := make([][]byte, len(l.items[index:]))
-	l.Lines(index, showTime, ll)
+	l.Lines(index, showTime, showLocalTime, ll)
 	for i, line := range ll {
 		locs := rx.FindAllIndex(line, -1)
 		if locs != nil && invert {

--- a/internal/dao/log_items_test.go
+++ b/internal/dao/log_items_test.go
@@ -85,7 +85,7 @@ func TestLogItemsFilter(t *testing.T) {
 			for _, i := range ii.Items() {
 				i.Pod, i.Container = n, u.opts.Container
 			}
-			res, indices, err := ii.Filter(0, u.q, false)
+			res, indices, err := ii.Filter(0, u.q, false, false)
 			assert.Equal(t, u.err, err)
 			if err == nil {
 				assert.Equal(t, u.e, res)
@@ -138,7 +138,7 @@ func TestLogItemsRender(t *testing.T) {
 		ii.Items()[0].Pod, ii.Items()[0].Container = n, u.opts.Container
 		t.Run(k, func(t *testing.T) {
 			res := make([][]byte, 1)
-			ii.Render(0, u.opts.ShowTimestamp, res)
+			ii.Render(0, u.opts.ShowTimestamp, false, res)
 			assert.Equal(t, u.e, string(res[0]))
 		})
 	}

--- a/internal/dao/log_options.go
+++ b/internal/dao/log_options.go
@@ -26,6 +26,7 @@ type LogOptions struct {
 	SingleContainer  bool
 	MultiPods        bool
 	ShowTimestamp    bool
+	ShowLocalTime    bool
 	AllContainers    bool
 }
 
@@ -50,6 +51,7 @@ func (o *LogOptions) Clone() *LogOptions {
 		SingleContainer:  o.SingleContainer,
 		MultiPods:        o.MultiPods,
 		ShowTimestamp:    o.ShowTimestamp,
+		ShowLocalTime:    o.ShowLocalTime,
 		SinceTime:        o.SinceTime,
 		SinceSeconds:     o.SinceSeconds,
 		AllContainers:    o.AllContainers,

--- a/internal/model/log.go
+++ b/internal/model/log.go
@@ -93,6 +93,12 @@ func (l *Log) ToggleShowTimestamp(b bool) {
 	l.Refresh()
 }
 
+// ToggleShowLocalTime toggles to logs local timezone.
+func (l *Log) ToggleShowLocalTime(b bool) {
+	l.logOptions.ShowLocalTime = b
+	l.Refresh()
+}
+
 func (l *Log) Head(ctx context.Context) {
 	l.mx.Lock()
 	l.logOptions.Head = true
@@ -146,7 +152,7 @@ func (l *Log) Clear() {
 func (l *Log) Refresh() {
 	l.fireLogCleared()
 	ll := make([][]byte, l.lines.Len())
-	l.lines.Render(0, l.logOptions.ShowTimestamp, ll)
+	l.lines.Render(0, l.logOptions.ShowTimestamp, l.logOptions.ShowLocalTime, ll)
 	l.fireLogChanged(ll)
 }
 
@@ -179,7 +185,7 @@ func (l *Log) Set(lines *dao.LogItems) {
 
 	l.fireLogCleared()
 	ll := make([][]byte, l.lines.Len())
-	l.lines.Render(0, l.logOptions.ShowTimestamp, ll)
+	l.lines.Render(0, l.logOptions.ShowTimestamp, l.logOptions.ShowLocalTime, ll)
 	l.fireLogChanged(ll)
 }
 
@@ -191,7 +197,7 @@ func (l *Log) ClearFilter() {
 
 	l.fireLogCleared()
 	ll := make([][]byte, l.lines.Len())
-	l.lines.Render(0, l.logOptions.ShowTimestamp, ll)
+	l.lines.Render(0, l.logOptions.ShowTimestamp, l.logOptions.ShowLocalTime, ll)
 	l.fireLogChanged(ll)
 }
 
@@ -336,7 +342,7 @@ func (l *Log) applyFilter(index int, q string) ([][]byte, error) {
 	if q == "" {
 		return nil, nil
 	}
-	matches, indices, err := l.lines.Filter(index, q, l.logOptions.ShowTimestamp)
+	matches, indices, err := l.lines.Filter(index, q, l.logOptions.ShowTimestamp, l.logOptions.ShowLocalTime)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +350,7 @@ func (l *Log) applyFilter(index int, q string) ([][]byte, error) {
 	// No filter!
 	if matches == nil {
 		ll := make([][]byte, l.lines.Len())
-		l.lines.Render(index, l.logOptions.ShowTimestamp, ll)
+		l.lines.Render(index, l.logOptions.ShowTimestamp, l.logOptions.ShowLocalTime, ll)
 		return ll, nil
 	}
 	// Blank filter
@@ -353,7 +359,7 @@ func (l *Log) applyFilter(index int, q string) ([][]byte, error) {
 	}
 	filtered := make([][]byte, 0, len(matches))
 	ll := make([][]byte, l.lines.Len())
-	l.lines.Lines(index, l.logOptions.ShowTimestamp, ll)
+	l.lines.Lines(index, l.logOptions.ShowTimestamp, l.logOptions.ShowLocalTime, ll)
 	for i, idx := range matches {
 		filtered = append(filtered, color.Highlight(ll[idx], indices[i], 209))
 	}
@@ -364,7 +370,7 @@ func (l *Log) applyFilter(index int, q string) ([][]byte, error) {
 func (l *Log) fireLogBuffChanged(index int) {
 	ll := make([][]byte, l.lines.Len()-index)
 	if l.filter == "" {
-		l.lines.Render(index, l.logOptions.ShowTimestamp, ll)
+		l.lines.Render(index, l.logOptions.ShowTimestamp, l.logOptions.ShowLocalTime, ll)
 	} else {
 		ff, err := l.applyFilter(index, l.filter)
 		if err != nil {

--- a/internal/model/log_test.go
+++ b/internal/model/log_test.go
@@ -162,7 +162,7 @@ func TestLogBasic(t *testing.T) {
 	assert.Equal(t, 1, v.clearCalled)
 	assert.Equal(t, 0, v.errCalled)
 	ll := make([][]byte, data.Len())
-	data.Lines(0, false, ll)
+	data.Lines(0, false, false, ll)
 	assert.Equal(t, ll, v.data)
 }
 
@@ -176,7 +176,7 @@ func TestLogAppend(t *testing.T) {
 	items.Add(dao.NewLogItemFromString("blah blah"))
 	m.Set(items)
 	ll := make([][]byte, items.Len())
-	items.Lines(0, false, ll)
+	items.Lines(0, false, false, ll)
 	assert.Equal(t, ll, v.data)
 
 	data := dao.NewLogItems()
@@ -189,7 +189,7 @@ func TestLogAppend(t *testing.T) {
 	}
 	assert.Equal(t, 1, v.dataCalled)
 	ll = make([][]byte, items.Len())
-	items.Lines(0, false, ll)
+	items.Lines(0, false, false, ll)
 	assert.Equal(t, ll, v.data)
 
 	m.Notify()

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -107,6 +107,7 @@ func (l *Log) Init(ctx context.Context) (err error) {
 	l.columnLock = l.app.Config.K9s.Logger.ColumnLock
 
 	l.model.ToggleShowTimestamp(l.app.Config.K9s.Logger.ShowTime)
+	l.model.ToggleShowLocalTime(l.app.Config.K9s.Logger.LocalTime)
 
 	return nil
 }
@@ -263,6 +264,7 @@ func (l *Log) bindKeys() {
 		ui.KeyShiftL:    ui.NewKeyAction("Toggle ColumnLock", l.toggleColumnLockCmd, true),
 		ui.KeyF:         ui.NewKeyAction("Toggle FullScreen", l.toggleFullScreenCmd, true),
 		ui.KeyT:         ui.NewKeyAction("Toggle Timestamp", l.toggleTimestampCmd, true),
+		ui.KeyZ:         ui.NewKeyAction("Toggle LocalTime", l.toggleLocalTimeCmd, true),
 		ui.KeyW:         ui.NewKeyAction("Toggle Wrap", l.toggleTextWrapCmd, true),
 		tcell.KeyCtrlS:  ui.NewKeyAction("Save", l.SaveCmd, true),
 		ui.KeyC:         ui.NewKeyAction("Copy", cpCmd(l.app.Flash(), l.logs.TextView), true),
@@ -403,6 +405,18 @@ func (l *Log) toggleAllContainers(evt *tcell.EventKey) *tcell.EventKey {
 	l.updateTitle()
 
 	return nil
+}
+
+func (l *Log) toggleLocalTimeCmd(evt *tcell.EventKey) *tcell.EventKey {
+    if l.app.InCmdMode() {
+        return evt
+    }
+
+    l.indicator.ToggleLocalTime()
+    l.model.ToggleShowLocalTime(l.indicator.showLocalTime)
+    l.indicator.Refresh()
+
+    return nil
 }
 
 func (l *Log) filterCmd(evt *tcell.EventKey) *tcell.EventKey {

--- a/internal/view/log_indicator.go
+++ b/internal/view/log_indicator.go
@@ -23,6 +23,7 @@ type LogIndicator struct {
 	fullScreen                 bool
 	textWrap                   bool
 	showTime                   bool
+	showLocalTime              bool
 	allContainers              bool
 	shouldDisplayAllContainers bool
 	columnLock                 bool
@@ -38,6 +39,7 @@ func NewLogIndicator(cfg *config.Config, styles *config.Styles, allContainers bo
 		fullScreen:                 cfg.K9s.UI.DefaultsToFullScreen,
 		textWrap:                   cfg.K9s.Logger.TextWrap,
 		showTime:                   cfg.K9s.Logger.ShowTime,
+		showLocalTime:              cfg.K9s.Logger.LocalTime,
 		shouldDisplayAllContainers: allContainers,
 		columnLock:                 cfg.K9s.Logger.ColumnLock,
 	}
@@ -94,6 +96,15 @@ func (l *LogIndicator) ToggleColumnLock() {
 // ToggleTimestamp toggles the current timestamp mode.
 func (l *LogIndicator) ToggleTimestamp() {
 	l.showTime = !l.showTime
+}
+
+func (l *LogIndicator) LocalTime() bool {
+    return l.showLocalTime
+}
+
+// ToggleLocalTime toggles the current timezone mode.
+func (l *LogIndicator) ToggleLocalTime() {
+    l.showLocalTime = !l.showLocalTime
 }
 
 // ToggleFullScreen toggles the screen mode.
@@ -158,7 +169,11 @@ func (l *LogIndicator) Refresh() {
 	} else {
 		l.indicator = append(l.indicator, fmt.Sprintf(toggleOffFmt, "ColumnLock", spacer)...)
 	}
-
+	if l.LocalTime() {
+        l.indicator = append(l.indicator, fmt.Sprintf(toggleOnFmt, "LocalTime", spacer)...)
+    } else {
+        l.indicator = append(l.indicator, fmt.Sprintf(toggleOffFmt, "LocalTime", spacer)...)
+    }
 	if l.FullScreen() {
 		l.indicator = append(l.indicator, fmt.Sprintf(toggleOnFmt, "FullScreen", spacer)...)
 	} else {

--- a/internal/view/log_indicator_test.go
+++ b/internal/view/log_indicator_test.go
@@ -18,10 +18,12 @@ func TestLogIndicatorRefresh(t *testing.T) {
 		e  string
 	}{
 		"all-containers": {
-			view.NewLogIndicator(config.NewConfig(nil), defaults, true), "[::b]AllContainers:[gray::d]Off[-::]     [::b]Autoscroll:[limegreen::b]On[-::]      [::b]ColumnLock:[gray::d]Off[-::]     [::b]FullScreen:[gray::d]Off[-::]     [::b]Timestamps:[gray::d]Off[-::]     [::b]Wrap:[gray::d]Off[-::]\n",
+			li: view.NewLogIndicator(config.NewConfig(nil), defaults, true),
+			e:  "[::b]AllContainers:[gray::d]Off[-::]     [::b]Autoscroll:[limegreen::b]On[-::]      [::b]ColumnLock:[gray::d]Off[-::]     [::b]LocalTime:[gray::d]Off[-::]     [::b]FullScreen:[gray::d]Off[-::]     [::b]Timestamps:[gray::d]Off[-::]     [::b]Wrap:[gray::d]Off[-::]\n",
 		},
 		"plain": {
-			view.NewLogIndicator(config.NewConfig(nil), defaults, false), "[::b]Autoscroll:[limegreen::b]On[-::]      [::b]ColumnLock:[gray::d]Off[-::]     [::b]FullScreen:[gray::d]Off[-::]     [::b]Timestamps:[gray::d]Off[-::]     [::b]Wrap:[gray::d]Off[-::]\n",
+			li: view.NewLogIndicator(config.NewConfig(nil), defaults, false),
+			e:  "[::b]Autoscroll:[limegreen::b]On[-::]      [::b]ColumnLock:[gray::d]Off[-::]     [::b]LocalTime:[gray::d]Off[-::]     [::b]FullScreen:[gray::d]Off[-::]     [::b]Timestamps:[gray::d]Off[-::]     [::b]Wrap:[gray::d]Off[-::]\n",
 		},
 	}
 

--- a/internal/view/log_int_test.go
+++ b/internal/view/log_int_test.go
@@ -112,7 +112,7 @@ func TestLogTimestamp(t *testing.T) {
 	l.SendKeys(ui.KeyT)
 	l.Logs().Clear()
 	ll := make([][]byte, ii.Len())
-	ii.Lines(0, true, ll)
+	ii.Lines(0, true, false,ll)
 	l.Flush(ll)
 
 	assert.Equal(t, fmt.Sprintf("%-30s %s", "ttt", "fred/blee c1 Testing 1, 2, 3\n"), l.Logs().GetText(true))

--- a/internal/view/log_int_test.go
+++ b/internal/view/log_int_test.go
@@ -27,10 +27,10 @@ func TestLogAutoScroll(t *testing.T) {
 	v.GetModel().Set(ii)
 	v.GetModel().Notify()
 
-	assert.Len(t, v.Hints(), 18)
+	assert.Len(t, v.Hints(), 19)
 
 	v.toggleAutoScrollCmd(nil)
-	assert.Equal(t, "Autoscroll:Off     ColumnLock:Off     FullScreen:Off     Timestamps:Off     Wrap:Off", v.Indicator().GetText(true))
+	assert.Equal(t, "Autoscroll:Off     ColumnLock:Off     LocalTime:Off     FullScreen:Off     Timestamps:Off     Wrap:Off", v.Indicator().GetText(true))
 }
 
 func TestLogColumnLock(t *testing.T) {
@@ -112,7 +112,7 @@ func TestLogTimestamp(t *testing.T) {
 	l.SendKeys(ui.KeyT)
 	l.Logs().Clear()
 	ll := make([][]byte, ii.Len())
-	ii.Lines(0, true, false,ll)
+	ii.Lines(0, true, false, ll)
 	l.Flush(ll)
 
 	assert.Equal(t, fmt.Sprintf("%-30s %s", "ttt", "fred/blee c1 Testing 1, 2, 3\n"), l.Logs().GetText(true))

--- a/internal/view/log_test.go
+++ b/internal/view/log_test.go
@@ -33,7 +33,7 @@ func TestLog(t *testing.T) {
 	ii := dao.NewLogItems()
 	ii.Add(dao.NewLogItemFromString("blee\n"), dao.NewLogItemFromString("bozo\n"))
 	ll := make([][]byte, ii.Len())
-	ii.Lines(0, false, ll)
+	ii.Lines(0, true, false, ll)
 	v.Flush(ll)
 
 	assert.Equal(t, "Waiting for logs...\nblee\nbozo\n", v.Logs().GetText(true))
@@ -53,7 +53,7 @@ func TestLogFlush(t *testing.T) {
 		dao.NewLogItemFromString("\033[0;32mBozo\n"),
 	)
 	ll := make([][]byte, items.Len())
-	items.Lines(0, false, ll)
+	items.Lines(0, false, false, ll)
 	v.Flush(ll)
 
 	assert.Equal(t, "[orange::d]Waiting for logs...\n[black::]blee\n[green::]Bozo\n\n", v.Logs().GetText(false))
@@ -74,7 +74,7 @@ func BenchmarkLogFlush(b *testing.B) {
 		dao.NewLogItemFromString("\033[0;101mBozo\n"),
 	)
 	ll := make([][]byte, items.Len())
-	items.Lines(0, false, ll)
+	items.Lines(0, false, false, ll)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -109,7 +109,7 @@ func TestLogViewSave(t *testing.T) {
 	ii := dao.NewLogItems()
 	ii.Add(dao.NewLogItemFromString("blee"), dao.NewLogItemFromString("bozo"))
 	ll := make([][]byte, ii.Len())
-	ii.Lines(0, false, ll)
+	ii.Lines(0, false, false, ll)
 	v.Flush(ll)
 
 	dd := "/tmp/test-dumps/na"


### PR DESCRIPTION
## Description
This PR addresses the auto-closed issue #1302 by implementing a toggleable feature that allows users to view log timestamps in their local timezone.

### Changes:
- Added `RenderWithLocalTime` logic in `internal/dao/log_item.go` to parse and convert UTC `RFC3339Nano` timestamps to `time.Local`.
- Introduced `ShowLocalTime` property in `LogOptions` and added tests.
- Propagated the logic through `LogItems`, `model`, and UI layers.
- Added `<LocalTime:On/Off>` indicator in the log viewer.
- Mapped the feature to the `z` keybinding.

This ensures logs are much easier to read when troubleshooting without needing mental timezone conversions, which was exactly the feature requested by the original author. Existing UTC tests pass successfully, and backward compatibility is preserved.