### PR TITLE
fix: stable AGE column sorting via raw timestamp comparison

### DIFF
--- a/internal/model1/helpers.go
+++ b/internal/model1/helpers.go
@@ -179,7 +179,7 @@ func Less(isNumber, isDuration, isCapacity bool, id1, id2, v1, v2 string) bool {
 
 func lessDuration(s1, s2 string) bool {
 	d1, d2 := durationToSeconds(s1), durationToSeconds(s2)
-	return d1 <= d2
+	return d1 < d2
 }
 
 func lessCapacity(s1, s2 string) bool {

--- a/internal/model1/row.go
+++ b/internal/model1/row.go
@@ -3,10 +3,13 @@
 
 package model1
 
+import "time"
+
 // Row represents a collection of columns.
 type Row struct {
 	ID     string
 	Fields Fields
+	Age    time.Time
 }
 
 // NewRow returns a new row with initialized fields.
@@ -50,6 +53,7 @@ func (r Row) Clone() Row {
 	return Row{
 		ID:     r.ID,
 		Fields: r.Fields.Clone(),
+		Age:    r.Age,
 	}
 }
 

--- a/internal/model1/row_event.go
+++ b/internal/model1/row_event.go
@@ -303,12 +303,22 @@ func (r RowEventSorter) Swap(i, j int) {
 }
 
 func (r RowEventSorter) Less(i, j int) bool {
-	f1, f2 := r.Events.events[i].Row.Fields, r.Events.events[j].Row.Fields
-	id1, id2 := r.Events.events[i].Row.ID, r.Events.events[j].Row.ID
+	e1, e2 := r.Events.events[i], r.Events.events[j]
+	// Use raw timestamp for duration columns when available (avoids precision loss from humanized strings)
+	if r.IsDuration && !e1.Row.Age.IsZero() && !e2.Row.Age.IsZero() {
+		// Smaller duration = more recently created = later timestamp.
+		// Asc (↑): youngest first → later timestamp first → e2.Before(e1).
+		// Desc (↓): oldest first → earlier timestamp first → e1.Before(e2).
+		if r.Asc {
+			return e2.Row.Age.Before(e1.Row.Age)
+		}
+		return e1.Row.Age.Before(e2.Row.Age)
+	}
+	f1, f2 := e1.Row.Fields, e2.Row.Fields
+	id1, id2 := e1.Row.ID, e2.Row.ID
 	less := Less(r.IsNumber, r.IsDuration, r.IsCapacity, id1, id2, f1[r.Index], f2[r.Index])
 	if r.Asc {
 		return less
 	}
-
 	return !less
 }

--- a/internal/model1/row_event.go
+++ b/internal/model1/row_event.go
@@ -39,7 +39,7 @@ func NewRowEventWithDeltas(row Row, delta DeltaRow) RowEvent {
 }
 
 // Clone returns a row event deep copy.
-func (r RowEvent) Clone() RowEvent {
+func (r RowEvent) Clone() RowEvent { //nolint:gocritic
 	return RowEvent{
 		Kind:   r.Kind,
 		Row:    r.Row.Clone(),
@@ -48,7 +48,7 @@ func (r RowEvent) Clone() RowEvent {
 }
 
 // Customize returns a new subset based on the given column indices.
-func (r RowEvent) Customize(cols []int) RowEvent {
+func (r RowEvent) Customize(cols []int) RowEvent { //nolint:gocritic
 	delta := r.Deltas
 	if !r.Deltas.IsBlank() {
 		delta = make(DeltaRow, len(cols))
@@ -63,7 +63,7 @@ func (r RowEvent) Customize(cols []int) RowEvent {
 }
 
 // ExtractHeaderLabels extract collection of fields into header.
-func (r RowEvent) ExtractHeaderLabels(labelCol int) []string {
+func (r RowEvent) ExtractHeaderLabels(labelCol int) []string { //nolint:gocritic
 	hh, _ := sortLabels(labelize(r.Row.Fields[labelCol]))
 	return hh
 }
@@ -128,12 +128,12 @@ func (r *RowEvents) At(i int) (RowEvent, bool) {
 	return r.events[i], true
 }
 
-func (r *RowEvents) Set(i int, re RowEvent) {
+func (r *RowEvents) Set(i int, re RowEvent) { //nolint:gocritic
 	r.events[i] = re
 	r.index[re.Row.ID] = i
 }
 
-func (r *RowEvents) Add(re RowEvent) {
+func (r *RowEvents) Add(re RowEvent) { //nolint:gocritic
 	r.events = append(r.events, re)
 	r.index[re.Row.ID] = len(r.events) - 1
 }
@@ -193,7 +193,7 @@ func (r *RowEvents) Clone() *RowEvents {
 }
 
 // Upsert add or update a row if it exists.
-func (r *RowEvents) Upsert(re RowEvent) {
+func (r *RowEvents) Upsert(re RowEvent) { //nolint:gocritic
 	if idx, ok := r.FindIndex(re.Row.ID); ok {
 		r.events[idx] = re
 	} else {

--- a/internal/model1/row_event.go
+++ b/internal/model1/row_event.go
@@ -69,7 +69,7 @@ func (r RowEvent) ExtractHeaderLabels(labelCol int) []string { //nolint:gocritic
 }
 
 // Labelize returns a new row event based on labels.
-func (r RowEvent) Labelize(cols []int, labelCol int, labels []string) RowEvent {
+func (r RowEvent) Labelize(cols []int, labelCol int, labels []string) RowEvent { //nolint:gocritic
 	return RowEvent{
 		Kind:   r.Kind,
 		Deltas: r.Deltas.Labelize(cols, labelCol),
@@ -78,7 +78,7 @@ func (r RowEvent) Labelize(cols []int, labelCol int, labels []string) RowEvent {
 }
 
 // Diff returns true if the row changed.
-func (r RowEvent) Diff(re RowEvent, ageCol int) bool {
+func (r RowEvent) Diff(re RowEvent, ageCol int) bool { //nolint:gocritic
 	if r.Kind != re.Kind {
 		return true
 	}

--- a/internal/model1/row_event_test.go
+++ b/internal/model1/row_event_test.go
@@ -422,17 +422,50 @@ func TestRowEventsSort(t *testing.T) {
 	}{
 		"age_time": {
 			re: model1.NewRowEventsWithEvts(
-				model1.RowEvent{Row: model1.Row{ID: "A", Fields: model1.Fields{"1", "2", testTime().Add(20 * time.Second).String()}}},
-				model1.RowEvent{Row: model1.Row{ID: "B", Fields: model1.Fields{"0", "2", testTime().Add(10 * time.Second).String()}}},
-				model1.RowEvent{Row: model1.Row{ID: "C", Fields: model1.Fields{"10", "2", testTime().String()}}},
+				model1.RowEvent{Row: model1.Row{ID: "A", Fields: model1.Fields{"1", "2", "15d"}, Age: testTime().Add(-15 * 24 * time.Hour)}},
+				model1.RowEvent{Row: model1.Row{ID: "B", Fields: model1.Fields{"0", "2", "170m"}, Age: testTime().Add(-170 * time.Minute)}},
+				model1.RowEvent{Row: model1.Row{ID: "C", Fields: model1.Fields{"10", "2", "6d21h"}, Age: testTime().Add(-6*24*time.Hour - 21*time.Hour)}},
 			),
 			col:      2,
 			asc:      true,
 			duration: true,
 			e: model1.NewRowEventsWithEvts(
-				model1.RowEvent{Row: model1.Row{ID: "C", Fields: model1.Fields{"10", "2", testTime().String()}}},
-				model1.RowEvent{Row: model1.Row{ID: "B", Fields: model1.Fields{"0", "2", testTime().Add(10 * time.Second).String()}}},
-				model1.RowEvent{Row: model1.Row{ID: "A", Fields: model1.Fields{"1", "2", testTime().Add(20 * time.Second).String()}}},
+				model1.RowEvent{Row: model1.Row{ID: "B", Fields: model1.Fields{"0", "2", "170m"}, Age: testTime().Add(-170 * time.Minute)}},
+				model1.RowEvent{Row: model1.Row{ID: "C", Fields: model1.Fields{"10", "2", "6d21h"}, Age: testTime().Add(-6*24*time.Hour - 21*time.Hour)}},
+				model1.RowEvent{Row: model1.Row{ID: "A", Fields: model1.Fields{"1", "2", "15d"}, Age: testTime().Add(-15 * 24 * time.Hour)}},
+			),
+		},
+		"age_duration_desc": {
+			re: model1.NewRowEventsWithEvts(
+				model1.RowEvent{Row: model1.Row{ID: "A", Fields: model1.Fields{"1", "2", "170m"}, Age: testTime().Add(-170 * time.Minute)}},
+				model1.RowEvent{Row: model1.Row{ID: "B", Fields: model1.Fields{"0", "2", "15d"}, Age: testTime().Add(-15 * 24 * time.Hour)}},
+				model1.RowEvent{Row: model1.Row{ID: "C", Fields: model1.Fields{"10", "2", "14d"}, Age: testTime().Add(-14 * 24 * time.Hour)}},
+				model1.RowEvent{Row: model1.Row{ID: "D", Fields: model1.Fields{"5", "2", "6d21h"}, Age: testTime().Add(-6*24*time.Hour - 21*time.Hour)}},
+			),
+			col:      2,
+			asc:      false,
+			duration: true,
+			e: model1.NewRowEventsWithEvts(
+				model1.RowEvent{Row: model1.Row{ID: "B", Fields: model1.Fields{"0", "2", "15d"}, Age: testTime().Add(-15 * 24 * time.Hour)}},
+				model1.RowEvent{Row: model1.Row{ID: "C", Fields: model1.Fields{"10", "2", "14d"}, Age: testTime().Add(-14 * 24 * time.Hour)}},
+				model1.RowEvent{Row: model1.Row{ID: "D", Fields: model1.Fields{"5", "2", "6d21h"}, Age: testTime().Add(-6*24*time.Hour - 21*time.Hour)}},
+				model1.RowEvent{Row: model1.Row{ID: "A", Fields: model1.Fields{"1", "2", "170m"}, Age: testTime().Add(-170 * time.Minute)}},
+			),
+		},
+		"age_duration_same_string": {
+			re: model1.NewRowEventsWithEvts(
+				model1.RowEvent{Row: model1.Row{ID: "X", Fields: model1.Fields{"1", "2", "6d21h"}, Age: testTime().Add(-6*24*time.Hour - 21*time.Hour - 30*time.Minute)}},
+				model1.RowEvent{Row: model1.Row{ID: "Y", Fields: model1.Fields{"0", "2", "6d21h"}, Age: testTime().Add(-6*24*time.Hour - 21*time.Hour - 10*time.Minute)}},
+				model1.RowEvent{Row: model1.Row{ID: "Z", Fields: model1.Fields{"10", "2", "6d21h"}, Age: testTime().Add(-6*24*time.Hour - 21*time.Hour - 50*time.Minute)}},
+			),
+			col:      2,
+			asc:      true,
+			duration: true,
+			// asc=true → youngest first: Y (-10m offset = most recent), X (-30m), Z (-50m = oldest)
+		e: model1.NewRowEventsWithEvts(
+				model1.RowEvent{Row: model1.Row{ID: "Y", Fields: model1.Fields{"0", "2", "6d21h"}, Age: testTime().Add(-6*24*time.Hour - 21*time.Hour - 10*time.Minute)}},
+				model1.RowEvent{Row: model1.Row{ID: "X", Fields: model1.Fields{"1", "2", "6d21h"}, Age: testTime().Add(-6*24*time.Hour - 21*time.Hour - 30*time.Minute)}},
+				model1.RowEvent{Row: model1.Row{ID: "Z", Fields: model1.Fields{"10", "2", "6d21h"}, Age: testTime().Add(-6*24*time.Hour - 21*time.Hour - 50*time.Minute)}},
 			),
 		},
 		"col0": {

--- a/internal/model1/row_event_test.go
+++ b/internal/model1/row_event_test.go
@@ -462,7 +462,7 @@ func TestRowEventsSort(t *testing.T) {
 			asc:      true,
 			duration: true,
 			// asc=true → youngest first: Y (-10m offset = most recent), X (-30m), Z (-50m = oldest)
-		e: model1.NewRowEventsWithEvts(
+			e: model1.NewRowEventsWithEvts(
 				model1.RowEvent{Row: model1.Row{ID: "Y", Fields: model1.Fields{"0", "2", "6d21h"}, Age: testTime().Add(-6*24*time.Hour - 21*time.Hour - 10*time.Minute)}},
 				model1.RowEvent{Row: model1.Row{ID: "X", Fields: model1.Fields{"1", "2", "6d21h"}, Age: testTime().Add(-6*24*time.Hour - 21*time.Hour - 30*time.Minute)}},
 				model1.RowEvent{Row: model1.Row{ID: "Z", Fields: model1.Fields{"10", "2", "6d21h"}, Age: testTime().Add(-6*24*time.Hour - 21*time.Hour - 50*time.Minute)}},

--- a/internal/model1/row_test.go
+++ b/internal/model1/row_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/derailed/k9s/internal/model1"
 	"github.com/stretchr/testify/assert"
@@ -334,37 +333,37 @@ func TestRowsSortDuration(t *testing.T) {
 		},
 		"years": {
 			rows: model1.Rows{
-				{Fields: []string{testTime().Add(-365 * 24 * time.Hour).String(), "blee"}},
-				{Fields: []string{testTime().String(), "duh"}},
+				{Fields: []string{"1y", "blee"}},
+				{Fields: []string{"2m", "duh"}},
 			},
 			col: 0,
 			asc: true,
 			e: model1.Rows{
-				{Fields: []string{testTime().String(), "duh"}},
-				{Fields: []string{testTime().Add(-365 * 24 * time.Hour).String(), "blee"}},
+				{Fields: []string{"2m", "duh"}},
+				{Fields: []string{"1y", "blee"}},
 			},
 		},
 		"durationAsc": {
 			rows: model1.Rows{
-				{Fields: []string{testTime().Add(10 * time.Second).String(), "duh"}},
-				{Fields: []string{testTime().String(), "blee"}},
+				{Fields: []string{"2m10s", "duh"}},
+				{Fields: []string{"2m", "blee"}},
 			},
 			col: 0,
 			asc: true,
 			e: model1.Rows{
-				{Fields: []string{testTime().String(), "blee"}},
-				{Fields: []string{testTime().Add(10 * time.Second).String(), "duh"}},
+				{Fields: []string{"2m", "blee"}},
+				{Fields: []string{"2m10s", "duh"}},
 			},
 		},
 		"durationDesc": {
 			rows: model1.Rows{
-				{Fields: []string{testTime().Add(10 * time.Second).String(), "duh"}},
-				{Fields: []string{testTime().String(), "blee"}},
+				{Fields: []string{"2m", "blee"}},
+				{Fields: []string{"2m10s", "duh"}},
 			},
 			col: 0,
 			e: model1.Rows{
-				{Fields: []string{testTime().Add(10 * time.Second).String(), "duh"}},
-				{Fields: []string{testTime().String(), "blee"}},
+				{Fields: []string{"2m10s", "duh"}},
+				{Fields: []string{"2m", "blee"}},
 			},
 		},
 	}

--- a/internal/model1/table_data.go
+++ b/internal/model1/table_data.go
@@ -84,11 +84,11 @@ func NewTableDataFromTable(td *TableData) *TableData {
 	return t
 }
 
-func (t *TableData) AddRow(re RowEvent) {
+func (t *TableData) AddRow(re RowEvent) { //nolint:gocritic
 	t.rowEvents.Add(re)
 }
 
-func (t *TableData) SetRow(idx int, re RowEvent) {
+func (t *TableData) SetRow(idx int, re RowEvent) { //nolint:gocritic
 	t.rowEvents.Set(idx, re)
 }
 

--- a/internal/render/cm.go
+++ b/internal/render/cm.go
@@ -70,6 +70,7 @@ func (ConfigMap) defaultRow(o any, r *model1.Row) error {
 		"",
 		ToAge(cm.GetCreationTimestamp()),
 	}
+	r.Age = cm.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/container.go
+++ b/internal/render/container.go
@@ -140,6 +140,7 @@ func (c Container) defaultRow(cr ContainerRes, r *model1.Row) error {
 		AsStatus(c.diagnose(state, ready)),
 		ToAge(cr.Age),
 	}
+	r.Age = cr.Age.Time
 
 	return nil
 }

--- a/internal/render/cr.go
+++ b/internal/render/cr.go
@@ -65,6 +65,7 @@ func (ClusterRole) defaultRow(raw *unstructured.Unstructured, r *model1.Row) err
 		mapToStr(cr.Labels),
 		ToAge(cr.GetCreationTimestamp()),
 	}
+	r.Age = cr.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/crb.go
+++ b/internal/render/crb.go
@@ -72,6 +72,7 @@ func (ClusterRoleBinding) defaultRow(raw *unstructured.Unstructured, r *model1.R
 		mapToStr(crb.Labels),
 		ToAge(crb.GetCreationTimestamp()),
 	}
+	r.Age = crb.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/crd.go
+++ b/internal/render/crd.go
@@ -95,6 +95,7 @@ func (c CustomResourceDefinition) defaultRow(raw *unstructured.Unstructured, r *
 		AsStatus(c.diagnose(crd.Name, crd.Spec.Versions)),
 		ToAge(crd.GetCreationTimestamp()),
 	}
+	r.Age = crd.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/cronjob.go
+++ b/internal/render/cronjob.go
@@ -93,6 +93,7 @@ func (CronJob) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
 		"",
 		ToAge(cj.GetCreationTimestamp()),
 	}
+	r.Age = cj.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/dp.go
+++ b/internal/render/dp.go
@@ -103,6 +103,7 @@ func (d Deployment) defaultRow(raw *unstructured.Unstructured, r *model1.Row) er
 		AsStatus(d.diagnose(dp.Status.Replicas, dp.Status.AvailableReplicas)),
 		ToAge(dp.GetCreationTimestamp()),
 	}
+	r.Age = dp.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/ds.go
+++ b/internal/render/ds.go
@@ -82,6 +82,7 @@ func (d DaemonSet) defaultRow(raw *unstructured.Unstructured, r *model1.Row) err
 		AsStatus(d.diagnose(ds.Status.DesiredNumberScheduled, ds.Status.NumberReady)),
 		ToAge(ds.GetCreationTimestamp()),
 	}
+	r.Age = ds.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/ep.go
+++ b/internal/render/ep.go
@@ -68,6 +68,7 @@ func (e Endpoints) defaultRow(o any, ns string, r *model1.Row) error {
 		missing(toEPs(ep.Subsets)),
 		ToAge(ep.GetCreationTimestamp()),
 	}
+	r.Age = ep.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/eps.go
+++ b/internal/render/eps.go
@@ -72,6 +72,7 @@ func (e EndpointSlice) defaultRow(o any, ns string, r *model1.Row) error {
 		toEPss(eps.Endpoints),
 		ToAge(eps.GetCreationTimestamp()),
 	}
+	r.Age = eps.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/generic.go
+++ b/internal/render/generic.go
@@ -58,6 +58,7 @@ func (Generic) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
 		"",
 		ToAge(raw.GetCreationTimestamp()),
 	}
+	r.Age = raw.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/job.go
+++ b/internal/render/job.go
@@ -84,6 +84,7 @@ func (j Job) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
 		AsStatus(j.diagnose(ready, &job.Status)),
 		ToAge(job.GetCreationTimestamp()),
 	}
+	r.Age = job.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/node.go
+++ b/internal/render/node.go
@@ -163,6 +163,7 @@ func (n Node) defaultRow(nwm *NodeWithMetrics, r *model1.Row) error {
 		AsStatus(n.diagnose(statuses)),
 		ToAge(no.GetCreationTimestamp()),
 	}
+	r.Age = no.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/np.go
+++ b/internal/render/np.go
@@ -94,6 +94,7 @@ func (NetworkPolicy) defaultRow(raw *unstructured.Unstructured, r *model1.Row) e
 		"",
 		ToAge(np.GetCreationTimestamp()),
 	}
+	r.Age = np.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/ns.go
+++ b/internal/render/ns.go
@@ -92,6 +92,7 @@ func (n Namespace) defaultRow(raw *unstructured.Unstructured, r *model1.Row) err
 		AsStatus(n.diagnose(ns.Status.Phase)),
 		ToAge(ns.GetCreationTimestamp()),
 	}
+	r.Age = ns.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/pdb.go
+++ b/internal/render/pdb.go
@@ -83,6 +83,7 @@ func (p PodDisruptionBudget) defaultRow(raw *unstructured.Unstructured, r *model
 		AsStatus(p.diagnose(pdb.Spec.MinAvailable, pdb.Status.CurrentHealthy)),
 		ToAge(pdb.GetCreationTimestamp()),
 	}
+	r.Age = pdb.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -206,6 +206,7 @@ func (p *Pod) defaultRow(pwm *PodWithMetrics, row *model1.Row) error {
 		AsStatus(p.diagnose(phase, cReady, allCounts, ready, rgr, rgt)),
 		ToAge(pwm.Raw.GetCreationTimestamp()),
 	}
+	row.Age = pwm.Raw.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/portforward.go
+++ b/internal/render/portforward.go
@@ -75,6 +75,7 @@ func (PortForward) Render(o any, _ string, r *model1.Row) error {
 	r.ID = pf.ID()
 	ns, n := client.Namespaced(r.ID)
 
+	pfAge := pf.Age()
 	r.Fields = model1.Fields{
 		ns,
 		trimContainer(n),
@@ -84,8 +85,9 @@ func (PortForward) Render(o any, _ string, r *model1.Row) error {
 		AsThousands(int64(pf.Config.C)),
 		AsThousands(int64(pf.Config.N)),
 		"",
-		ToAge(metav1.Time{Time: pf.Age()}),
+		ToAge(metav1.Time{Time: pfAge}),
 	}
+	r.Age = pfAge
 
 	return nil
 }

--- a/internal/render/pv.go
+++ b/internal/render/pv.go
@@ -125,6 +125,7 @@ func (p PersistentVolume) defaultRow(raw *unstructured.Unstructured, r *model1.R
 		AsStatus(p.diagnose(phase)),
 		ToAge(pv.GetCreationTimestamp()),
 	}
+	r.Age = pv.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/pvc.go
+++ b/internal/render/pvc.go
@@ -98,6 +98,7 @@ func (p PersistentVolumeClaim) defaultRow(raw *unstructured.Unstructured, r *mod
 		AsStatus(p.diagnose(string(phase))),
 		ToAge(pvc.GetCreationTimestamp()),
 	}
+	r.Age = pvc.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/ro.go
+++ b/internal/render/ro.go
@@ -67,6 +67,7 @@ func (Role) defaultRow(raw *unstructured.Unstructured, row *model1.Row) error {
 		"",
 		ToAge(ro.GetCreationTimestamp()),
 	}
+	row.Age = ro.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/rob.go
+++ b/internal/render/rob.go
@@ -76,6 +76,7 @@ func (RoleBinding) defaultRow(raw *unstructured.Unstructured, row *model1.Row) e
 		"",
 		ToAge(rb.GetCreationTimestamp()),
 	}
+	row.Age = rb.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/rs.go
+++ b/internal/render/rs.go
@@ -95,6 +95,7 @@ func (r ReplicaSet) defaultRow(raw *unstructured.Unstructured, row *model1.Row) 
 		AsStatus(r.diagnose(&rs)),
 		ToAge(rs.GetCreationTimestamp()),
 	}
+	row.Age = rs.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/sa.go
+++ b/internal/render/sa.go
@@ -70,6 +70,7 @@ func (ServiceAccount) defaultRow(raw *unstructured.Unstructured, r *model1.Row) 
 		"",
 		ToAge(sa.GetCreationTimestamp()),
 	}
+	r.Age = sa.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/sc.go
+++ b/internal/render/sc.go
@@ -75,6 +75,7 @@ func (s StorageClass) defaultRow(raw *unstructured.Unstructured, r *model1.Row) 
 		"",
 		ToAge(sc.GetCreationTimestamp()),
 	}
+	r.Age = sc.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/secret.go
+++ b/internal/render/secret.go
@@ -70,6 +70,7 @@ func (Secret) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
 		"",
 		ToAge(raw.GetCreationTimestamp()),
 	}
+	r.Age = raw.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/sts.go
+++ b/internal/render/sts.go
@@ -84,6 +84,7 @@ func (s StatefulSet) defaultRow(raw *unstructured.Unstructured, r *model1.Row) e
 		AsStatus(s.diagnose(desired, sts.Status.Replicas, sts.Status.ReadyReplicas)),
 		ToAge(sts.GetCreationTimestamp()),
 	}
+	r.Age = sts.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/svc.go
+++ b/internal/render/svc.go
@@ -81,6 +81,7 @@ func (s Service) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error
 		AsStatus(s.diagnose()),
 		ToAge(svc.GetCreationTimestamp()),
 	}
+	r.Age = svc.GetCreationTimestamp().Time
 
 	return nil
 }

--- a/internal/render/table.go
+++ b/internal/render/table.go
@@ -69,7 +69,7 @@ func (t *Table) defaultHeader() model1.Header {
 	}
 	h := make(model1.Header, 0, len(t.table.ColumnDefinitions))
 	for i, c := range t.table.ColumnDefinitions {
-		if c.Name == ageTableCol {
+		if strings.EqualFold(c.Name, ageTableCol) {
 			t.setAgeIndex(i)
 			continue
 		}
@@ -157,6 +157,19 @@ func (t *Table) defaultRow(row *metav1.TableRow, ns string, r *model1.Row) error
 	} else if ageIdx > 0 {
 		slog.Warn("No Duration detected on age field")
 		r.Fields = append(r.Fields, NAValue)
+	}
+
+	// Populate raw timestamp from object metadata when available.
+	switch {
+	case row.Object.Object != nil:
+		if m, _ := meta.Accessor(row.Object.Object); m != nil {
+			r.Age = m.GetCreationTimestamp().Time
+		}
+	case row.Object.Raw != nil:
+		var pm metav1.PartialObjectMetadata
+		if err := json.Unmarshal(row.Object.Raw, &pm); err == nil {
+			r.Age = pm.GetCreationTimestamp().Time
+		}
 	}
 
 	return nil

--- a/internal/render/workload.go
+++ b/internal/render/workload.go
@@ -59,6 +59,7 @@ func (Workload) Render(o any, _ string, r *model1.Row) error {
 		return fmt.Errorf("expected WorkloadRes but got %T", o)
 	}
 
+	ageTime := res.Row.Cells[6].(metav1.Time)
 	r.ID = fmt.Sprintf("%s|%s|%s", res.Row.Cells[0].(string), res.Row.Cells[1].(string), res.Row.Cells[2].(string))
 	r.Fields = model1.Fields{
 		res.Row.Cells[0].(string),
@@ -67,8 +68,9 @@ func (Workload) Render(o any, _ string, r *model1.Row) error {
 		res.Row.Cells[3].(string),
 		res.Row.Cells[4].(string),
 		res.Row.Cells[5].(string),
-		ToAge(res.Row.Cells[6].(metav1.Time)),
+		ToAge(ageTime),
 	}
+	r.Age = ageTime.Time
 
 	return nil
 }

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -503,7 +503,7 @@ func (t *Table) UpdateUI(cdata, data *model1.TableData) {
 	t.UpdateTitle()
 }
 
-func (t *Table) buildRow(r int, re, ore model1.RowEvent, h model1.Header, pads MaxyPad) {
+func (t *Table) buildRow(r int, re, ore model1.RowEvent, h model1.Header, pads MaxyPad) { //nolint:gocritic
 	color := model1.DefaultColorer
 	if t.colorerFn != nil {
 		color = t.colorerFn


### PR DESCRIPTION
Closes #3834

## Problem

Sorting by AGE (and `First Seen`/`Last Seen`) is unstable. When multiple resources share the same humanized age string (e.g. `12m`), the sort has no way to distinguish them and order becomes undefined/bouncy on each refresh. Additionally, `lessDuration` used `<=` which violates Go's sort contract when two values are equal, causing completely undefined behavior from the sort algorithm.

## Solution

Implements the approach suggested by @derailed in #3838: stash a `time.Time` on each `Row` and use it directly during sort comparisons. Display is unchanged — users still see `12m`, `6d21h` etc.

- Add `Age time.Time` to `Row` struct (zero value = not set, so non-time columns are unaffected)
- Populate `r.Age` from `GetCreationTimestamp()` in all renderers
- Populate `r.Age` from object metadata in the generic `Table` renderer (covers all CRDs)
- Update `RowEventSorter.Less` to compare raw timestamps when available, falling back to string comparison for backwards compatibility
- Fix `lessDuration` `<=` → `<` as a safety net for the fallback path
- Fix case-insensitive AGE column detection in `Table` renderer — CRDs that define their column as `name: AGE` (uppercase) were being sorted as plain text via NaturalLess instead of as durations

Credit to @uozalp for the original investigation in #3838.

## Notes

Adding `time.Time` to `Row` grows `RowEvent` to 96 bytes, triggering `gocritic/hugeParam` on existing value-receiver methods. These methods were intentionally designed with value semantics; changing them to pointer receivers would be a broader refactor out of scope for this fix. Suppressed with `//nolint:gocritic` for now.