### PR TITLE
Fix terminal escape sequence leak in prompt and command input (#3885)

### DIFF
--- a/internal/ui/escape_filter.go
+++ b/internal/ui/escape_filter.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package ui
+
+import (
+	"time"
+
+	"github.com/derailed/tcell/v2"
+)
+
+// escFilterState tracks the state of escape sequence detection.
+type escFilterState int
+
+const (
+	escNone      escFilterState = iota
+	escInOSC                    // confirmed OSC sequence, accumulating body
+	escInCSI                    // confirmed CSI sequence, accumulating body
+	escSawBrack                 // saw bare ] (no Alt), might be OSC start
+	escSawBrack1                // saw ] then 1 — waiting for 0 or 1
+	escSawBrackN                // saw ]10 or ]11 — waiting for ;
+	escInBurst                  // in a rapid burst of escape-sequence-like chars
+	escSawColon                 // saw : or / rapidly, might be OSC body start
+)
+
+const (
+	// escBurstTimeout defines how long to wait before resetting filter state.
+	escBurstTimeout = 2 * time.Second
+
+	// escProbeTimeout is a short timeout for speculative detection states.
+	escProbeTimeout = 100 * time.Millisecond
+
+	// escBurstGap is the maximum time between consecutive events to be
+	// considered part of a terminal response burst. Terminal responses
+	// deliver all characters within ~1ms. Real typing is 30ms+ apart.
+	escBurstGap = 5 * time.Millisecond
+)
+
+// EscapeUndoFunc is called when the filter retroactively determines
+// that a character that already passed through (like ':') was part of
+// an escape sequence. The caller should deactivate any mode that was
+// activated and clear the buffer.
+type EscapeUndoFunc func()
+
+// EscapeSequenceFilter detects and discards terminal escape sequence
+// responses (OSC 10/11 color queries, CPR cursor position reports)
+// that leak through the tcell input parser as individual KeyRune events.
+//
+// Detection uses three strategies:
+//  1. Alt+] / Alt+[ signals (when tcell correctly sets ModAlt)
+//  2. Pattern matching: bare ] followed by 10; or 11;
+//  3. Timing-based burst detection: when : or / is followed by hex digits
+//     within 5ms, it's escape sequence residue from a terminal that
+//     partially consumed the OSC prefix.
+type EscapeSequenceFilter struct {
+	state       escFilterState
+	lastEvent   time.Time
+	pendNum     rune
+	burstCount  int
+	burstEscLen int
+	undoFn      EscapeUndoFunc
+}
+
+// NewEscapeSequenceFilter creates a new filter. The undoFn is called
+// when the filter retroactively determines that a : or / that already
+// passed through was part of an escape sequence.
+func NewEscapeSequenceFilter(undoFn EscapeUndoFunc) *EscapeSequenceFilter {
+	return &EscapeSequenceFilter{undoFn: undoFn}
+}
+
+// IsActive returns true if the filter is currently tracking a sequence.
+func (f *EscapeSequenceFilter) IsActive() bool {
+	return f.state != escNone
+}
+
+// isEscapeResidue returns true if the rune could be part of a terminal
+// escape sequence response (OSC color or CPR).
+func isEscapeResidue(r rune) bool {
+	if r >= '0' && r <= '9' || r >= 'a' && r <= 'f' || r >= 'A' && r <= 'F' {
+		return true
+	}
+	switch r {
+	case '/', ':', ';', '[', ']', '\\', 'R', 'r', 'g', 'b':
+		return true
+	}
+	return false
+}
+
+// Filter examines a tcell.EventKey and returns true if the event
+// should be discarded (it is part of a terminal response sequence).
+// Only call this for KeyRune events.
+func (f *EscapeSequenceFilter) Filter(evt *tcell.EventKey) bool {
+	now := time.Now()
+	elapsed := now.Sub(f.lastEvent)
+
+	timeout := escBurstTimeout
+	if f.state >= escSawBrack && f.state <= escSawBrackN || f.state == escSawColon {
+		timeout = escProbeTimeout
+	}
+
+	if f.state != escNone && elapsed > timeout {
+		f.reset()
+	}
+
+	if elapsed < escBurstGap && f.lastEvent.Unix() > 0 {
+		f.burstCount++
+	} else {
+		f.burstCount = 1
+		f.burstEscLen = 0
+	}
+	f.lastEvent = now
+
+	r := evt.Rune()
+	mod := evt.Modifiers()
+
+	if isEscapeResidue(r) {
+		f.burstEscLen++
+	}
+
+	switch f.state {
+	case escNone:
+		if mod&tcell.ModAlt != 0 && r == ']' {
+			f.state = escInOSC
+			return true
+		}
+		if mod&tcell.ModAlt != 0 && r == '[' {
+			f.state = escInCSI
+			return true
+		}
+		if mod == tcell.ModNone && r == ']' {
+			f.state = escSawBrack
+			return false
+		}
+		if mod == tcell.ModNone && (r == ':' || r == '/') {
+			f.state = escSawColon
+			return false
+		}
+		return false
+
+	case escSawBrack:
+		if r == '1' && mod == tcell.ModNone {
+			f.pendNum = r
+			f.state = escSawBrack1
+			return false
+		}
+		f.reset()
+		return false
+
+	case escSawBrack1:
+		if (r == '0' || r == '1') && mod == tcell.ModNone {
+			f.pendNum = r
+			f.state = escSawBrackN
+			return false
+		}
+		f.reset()
+		return false
+
+	case escSawBrackN:
+		if r == ';' && mod == tcell.ModNone {
+			f.state = escInOSC
+			return true
+		}
+		f.reset()
+		return false
+
+	case escInOSC:
+		if mod&tcell.ModAlt != 0 && r == '\\' {
+			f.reset()
+			return true
+		}
+		if r == 0x07 {
+			f.reset()
+			return true
+		}
+		if mod&tcell.ModAlt != 0 && r == ']' {
+			return true
+		}
+		if r == '[' {
+			f.state = escInCSI
+			return true
+		}
+		return true
+
+	case escInCSI:
+		if r >= '0' && r <= '?' {
+			return true
+		}
+		if r >= ' ' && r <= '/' {
+			return true
+		}
+		if r >= '@' && r <= '~' {
+			f.reset()
+			return true
+		}
+		if mod&tcell.ModAlt != 0 && r == ']' {
+			f.state = escInOSC
+			return true
+		}
+		if mod&tcell.ModAlt != 0 && r == '[' {
+			return true
+		}
+		if mod == tcell.ModNone && r == ']' {
+			f.state = escSawBrack
+			return false
+		}
+		f.reset()
+		return false
+
+	case escSawColon:
+		isHex := (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
+		if isHex && elapsed < escBurstGap && elapsed > 0 {
+			if f.undoFn != nil {
+				f.undoFn()
+			}
+			f.state = escInBurst
+			return true
+		}
+		f.reset()
+		return false
+
+	case escInBurst:
+		if elapsed < escBurstGap && isEscapeResidue(r) {
+			return true
+		}
+		if mod&tcell.ModAlt != 0 && r == '\\' {
+			f.reset()
+			return true
+		}
+		if mod&tcell.ModAlt != 0 && r == '[' {
+			f.state = escInCSI
+			return true
+		}
+		if r == '[' && elapsed < escBurstGap {
+			f.state = escInCSI
+			return true
+		}
+		f.reset()
+		return false
+	}
+
+	return false
+}
+
+func (f *EscapeSequenceFilter) reset() {
+	f.state = escNone
+	f.pendNum = 0
+}

--- a/internal/ui/escape_filter_realistic_test.go
+++ b/internal/ui/escape_filter_realistic_test.go
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/derailed/tcell/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEscapeFilter_RealisticTcellBehavior simulates the exact event sequence
+// that derailed/tcell v2.3.1-rc.4 produces when it receives OSC 10/11 color
+// responses and CPR cursor position reports.
+//
+// Key finding from production debug logs (2026-04-03T20:16:41):
+// - The FIRST OSC sequence's ] arrives WITHOUT ModAlt (tcell's input buffering
+//   causes ESC to be consumed without setting the escaped flag)
+// - The SECOND OSC sequence's ] arrives WITH ModAlt (normal behavior)
+// - CPR [ characters can arrive either way
+//
+// The raw terminal response is:
+//
+//	\x1b]10;rgb:ffff/ffff/ffff\x1b\\\x1b[6;15R\x1b]11;rgb:2828/2c2c/3434\x1b\\\x1b[6;14R
+//
+// This test constructs the events exactly as observed in production.
+func TestEscapeFilter_RealisticTcellBehavior(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	type event struct {
+		r      rune
+		mod    tcell.ModMask
+		expect bool   // true = should be filtered
+		desc   string // description for failure message
+	}
+
+	// Build the exact event sequence observed in production.
+	// First OSC (10) — bare ] without Alt (tcell bug)
+	events := []event{
+		{']', tcell.ModNone, false, "bare ] (first OSC, no Alt) — passes through"},
+		{'1', tcell.ModNone, false, "probing: 1 after ]"},
+		{'0', tcell.ModNone, false, "probing: 0 after ]1"},
+		{';', tcell.ModNone, true, "; confirms ]10 is OSC — filter starts"},
+	}
+	// Add the OSC 10 body: rgb:ffff/ffff/ffff
+	for _, r := range "rgb:ffff/ffff/ffff" {
+		events = append(events, event{r, tcell.ModNone, true, "OSC 10 body"})
+	}
+
+	// First CPR — bare [ (ESC consumed without escaped flag, same issue)
+	events = append(events, event{'[', tcell.ModNone, true, "bare [ entering CSI from OSC"})
+	for _, r := range "6;15" {
+		events = append(events, event{r, tcell.ModNone, true, "CPR param"})
+	}
+	events = append(events, event{'R', tcell.ModNone, true, "CPR final byte"})
+
+	// Second OSC (11) — Alt+] (tcell sets ModAlt correctly this time)
+	events = append(events, event{']', tcell.ModAlt, true, "Alt+] (second OSC, with Alt)"})
+	for _, r := range "11;rgb:2828/2c2c/3434" {
+		events = append(events, event{r, tcell.ModNone, true, "OSC 11 body"})
+	}
+
+	// ST terminator — Alt+backslash
+	events = append(events, event{'\\', tcell.ModAlt, true, "Alt+\\ (ST terminator)"})
+
+	// Second CPR — Alt+[
+	events = append(events, event{'[', tcell.ModAlt, true, "Alt+[ (second CPR)"})
+	for _, r := range "6;14" {
+		events = append(events, event{r, tcell.ModNone, true, "CPR param"})
+	}
+	events = append(events, event{'R', tcell.ModNone, true, "CPR final byte"})
+
+	// Run all events through the filter
+	var leaked []rune
+	for i, e := range events {
+		evt := tcell.NewEventKey(tcell.KeyRune, e.r, e.mod)
+		got := f.Filter(evt)
+		assert.Equal(t, e.expect, got,
+			"event %d: rune=%q mod=%d — %s", i, e.r, e.mod, e.desc)
+		if !got {
+			leaked = append(leaked, e.r)
+		}
+	}
+
+	// The only chars that should leak are ]10 (the probe prefix)
+	assert.Equal(t, []rune{']', '1', '0'}, leaked,
+		"only the ]10 probe prefix should leak through")
+
+	// After the sequence, normal input must work
+	assert.False(t, f.Filter(tcell.NewEventKey(tcell.KeyRune, 'p', tcell.ModNone)))
+	assert.False(t, f.Filter(tcell.NewEventKey(tcell.KeyRune, 'o', tcell.ModNone)))
+	assert.False(t, f.Filter(tcell.NewEventKey(tcell.KeyRune, 'd', tcell.ModNone)))
+}
+
+// TestEscapeFilter_RealisticAllBare simulates the worst case where ALL
+// escape sequences arrive without ModAlt on ] and [.
+func TestEscapeFilter_RealisticAllBare(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	type event struct {
+		r      rune
+		mod    tcell.ModMask
+		expect bool
+	}
+
+	events := []event{
+		// OSC 10 — bare ]
+		{']', tcell.ModNone, false},
+		{'1', tcell.ModNone, false},
+		{'0', tcell.ModNone, false},
+		{';', tcell.ModNone, true}, // confirmed
+	}
+	for _, r := range "rgb:ffff/ffff/ffff" {
+		events = append(events, event{r, tcell.ModNone, true})
+	}
+	// CPR — bare [
+	events = append(events, event{'[', tcell.ModNone, true}) // from OSC state
+	for _, r := range "6;15" {
+		events = append(events, event{r, tcell.ModNone, true})
+	}
+	events = append(events, event{'R', tcell.ModNone, true})
+
+	// OSC 11 — bare ] after CSI completed (back in escNone)
+	events = append(events, event{']', tcell.ModNone, false})
+	events = append(events, event{'1', tcell.ModNone, false})
+	events = append(events, event{'1', tcell.ModNone, false})
+	events = append(events, event{';', tcell.ModNone, true}) // confirmed
+	for _, r := range "rgb:2828/2c2c/3434" {
+		events = append(events, event{r, tcell.ModNone, true})
+	}
+	// CPR — bare [
+	events = append(events, event{'[', tcell.ModNone, true})
+	for _, r := range "6;14" {
+		events = append(events, event{r, tcell.ModNone, true})
+	}
+	events = append(events, event{'R', tcell.ModNone, true})
+
+	var leaked []rune
+	for _, e := range events {
+		evt := tcell.NewEventKey(tcell.KeyRune, e.r, e.mod)
+		got := f.Filter(evt)
+		assert.Equal(t, e.expect, got, "rune=%q mod=%d", e.r, e.mod)
+		if !got {
+			leaked = append(leaked, e.r)
+		}
+	}
+
+	// Both ]10 and ]11 probe prefixes leak
+	assert.Equal(t, []rune{']', '1', '0', ']', '1', '1'}, leaked,
+		"only probe prefixes should leak")
+
+	// Verify the leaked chars don't contain / or : (which activate filter/command mode)
+	for _, r := range leaked {
+		assert.NotEqual(t, '/', r, "/ must never leak (activates filter mode)")
+		assert.NotEqual(t, ':', r, ": must never leak (activates command mode)")
+	}
+}
+
+// TestEscapeFilter_RealisticNoActivation verifies that the critical characters
+// / (filter mode) and : (command mode) are NEVER in the leaked set, regardless
+// of how tcell delivers the events.
+func TestEscapeFilter_RealisticNoActivation(t *testing.T) {
+	// Test both scenarios: mixed Alt/bare and all-bare
+	for _, scenario := range []string{"mixed", "all-bare"} {
+		t.Run(scenario, func(t *testing.T) {
+			f := NewEscapeSequenceFilter(nil)
+
+			// Full terminal response bytes (what the terminal actually sends)
+			// \x1b]10;rgb:ffff/ffff/ffff\x1b\\\x1b[6;15R\x1b]11;rgb:2828/2c2c/3434\x1b\\\x1b[6;14R
+			//
+			// After tcell processing, we get KeyRune events.
+			// The : in rgb: and / in ffff/ffff are the dangerous chars.
+
+			var events []simEvent
+
+			if scenario == "mixed" {
+				events = buildMixedEvents()
+			} else {
+				events = buildAllBareEvents()
+			}
+
+			var leaked []rune
+			for _, e := range events {
+				evt := tcell.NewEventKey(tcell.KeyRune, e.r, e.mod)
+				if !f.Filter(evt) {
+					leaked = append(leaked, e.r)
+				}
+			}
+
+			// Critical assertion: no activation characters leak
+			for _, r := range leaked {
+				assert.NotEqual(t, '/', r,
+					"/ must not leak — it activates filter mode in k9s")
+				assert.NotEqual(t, ':', r,
+					": must not leak — it activates command mode in k9s")
+				assert.NotEqual(t, ';', r,
+					"; should not leak — it's part of the OSC body")
+			}
+		})
+	}
+}
+
+// TestEscapeFilter_RealisticWithDelay verifies the filter handles events
+// with realistic timing gaps between them (simulating PostEventWait blocking).
+func TestEscapeFilter_RealisticWithDelay(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timing-sensitive test in short mode")
+	}
+
+	f := NewEscapeSequenceFilter(nil)
+
+	// Send bare ]10; with small gaps (simulating busy event loop)
+	assert.False(t, f.Filter(makeRuneEvt(']')))
+	time.Sleep(5 * time.Millisecond)
+	assert.False(t, f.Filter(makeRuneEvt('1')))
+	time.Sleep(5 * time.Millisecond)
+	assert.False(t, f.Filter(makeRuneEvt('0')))
+	time.Sleep(5 * time.Millisecond)
+	assert.True(t, f.Filter(makeRuneEvt(';')), "; should confirm OSC")
+
+	// Body with gaps
+	for _, r := range "rgb:" {
+		time.Sleep(2 * time.Millisecond)
+		assert.True(t, f.Filter(makeRuneEvt(r)), "char %c in body should be filtered", r)
+	}
+
+	// Simulate a longer pause (draw cycle) mid-body
+	time.Sleep(80 * time.Millisecond)
+	for _, r := range "ffff/ffff/ffff" {
+		assert.True(t, f.Filter(makeRuneEvt(r)), "char %c after pause should still be filtered", r)
+	}
+}
+
+// helpers
+
+type simEvent struct {
+	r   rune
+	mod tcell.ModMask
+}
+
+func buildMixedEvents() []simEvent {
+	var evts []simEvent
+
+	// OSC 10 — bare ]
+	evts = append(evts, simEvent{']', tcell.ModNone})
+	for _, r := range "10;rgb:ffff/ffff/ffff" {
+		evts = append(evts, simEvent{r, tcell.ModNone})
+	}
+	// CPR — bare [
+	evts = append(evts, simEvent{'[', tcell.ModNone})
+	for _, r := range "6;15" {
+		evts = append(evts, simEvent{r, tcell.ModNone})
+	}
+	evts = append(evts, simEvent{'R', tcell.ModNone})
+
+	// OSC 11 — Alt+]
+	evts = append(evts, simEvent{']', tcell.ModAlt})
+	for _, r := range "11;rgb:2828/2c2c/3434" {
+		evts = append(evts, simEvent{r, tcell.ModNone})
+	}
+	evts = append(evts, simEvent{'\\', tcell.ModAlt})
+
+	// CPR — Alt+[
+	evts = append(evts, simEvent{'[', tcell.ModAlt})
+	for _, r := range "6;14" {
+		evts = append(evts, simEvent{r, tcell.ModNone})
+	}
+	evts = append(evts, simEvent{'R', tcell.ModNone})
+
+	return evts
+}
+
+func buildAllBareEvents() []simEvent {
+	var evts []simEvent
+
+	// OSC 10 — bare ]
+	evts = append(evts, simEvent{']', tcell.ModNone})
+	for _, r := range "10;rgb:ffff/ffff/ffff" {
+		evts = append(evts, simEvent{r, tcell.ModNone})
+	}
+	evts = append(evts, simEvent{'[', tcell.ModNone})
+	for _, r := range "6;15" {
+		evts = append(evts, simEvent{r, tcell.ModNone})
+	}
+	evts = append(evts, simEvent{'R', tcell.ModNone})
+
+	// OSC 11 — bare ]
+	evts = append(evts, simEvent{']', tcell.ModNone})
+	for _, r := range "11;rgb:2828/2c2c/3434" {
+		evts = append(evts, simEvent{r, tcell.ModNone})
+	}
+	evts = append(evts, simEvent{'[', tcell.ModNone})
+	for _, r := range "6;14" {
+		evts = append(evts, simEvent{r, tcell.ModNone})
+	}
+	evts = append(evts, simEvent{'R', tcell.ModNone})
+
+	return evts
+}

--- a/internal/ui/escape_filter_test.go
+++ b/internal/ui/escape_filter_test.go
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/derailed/tcell/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeRuneEvt(r rune) *tcell.EventKey {
+	return tcell.NewEventKey(tcell.KeyRune, r, tcell.ModNone)
+}
+
+func makeAltRuneEvt(r rune) *tcell.EventKey {
+	return tcell.NewEventKey(tcell.KeyRune, r, tcell.ModAlt)
+}
+
+func TestEscapeFilter_OSC10WithAlt(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	assert.True(t, f.Filter(makeAltRuneEvt(']')), "Alt+] should be filtered (OSC start)")
+	for _, r := range "10;rgb:fafa/f9f9/f6f6" {
+		assert.True(t, f.Filter(makeRuneEvt(r)), "OSC body char %c should be filtered", r)
+	}
+	assert.True(t, f.Filter(makeAltRuneEvt('\\')), "Alt+\\ should be filtered (ST)")
+
+	assert.False(t, f.Filter(makeRuneEvt('a')), "normal char after OSC should pass through")
+}
+
+func TestEscapeFilter_OSC11WithAlt(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	assert.True(t, f.Filter(makeAltRuneEvt(']')))
+	for _, r := range "11;rgb:1212/1212/1212" {
+		assert.True(t, f.Filter(makeRuneEvt(r)))
+	}
+	assert.True(t, f.Filter(makeAltRuneEvt('\\')))
+
+	assert.False(t, f.Filter(makeRuneEvt('z')))
+}
+
+func TestEscapeFilter_OSC10BareBracket(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	// When tcell doesn't set ModAlt on ], the ] passes through (false),
+	// but after confirming ]10; pattern, the rest is filtered.
+	assert.False(t, f.Filter(makeRuneEvt(']')), "bare ] passes through (probing)")
+	assert.False(t, f.Filter(makeRuneEvt('1')), "1 passes through (probing)")
+	assert.False(t, f.Filter(makeRuneEvt('0')), "0 passes through (probing)")
+	// ; confirms it's an OSC color response — filter from here
+	assert.True(t, f.Filter(makeRuneEvt(';')), "; confirms OSC, should be filtered")
+	for _, r := range "rgb:fafa/f9f9/f6f6" {
+		assert.True(t, f.Filter(makeRuneEvt(r)), "OSC body char %c should be filtered", r)
+	}
+	assert.True(t, f.Filter(makeAltRuneEvt('\\')), "Alt+\\ terminator should be filtered")
+
+	assert.False(t, f.Filter(makeRuneEvt('a')))
+}
+
+func TestEscapeFilter_OSC11BareFollowedByCPR(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	// ]11;rgb:2828/2c2c/3434 followed by bare [ CSI
+	assert.False(t, f.Filter(makeRuneEvt(']')))
+	assert.False(t, f.Filter(makeRuneEvt('1')))
+	assert.False(t, f.Filter(makeRuneEvt('1')))
+	assert.True(t, f.Filter(makeRuneEvt(';')), "; confirms OSC")
+	for _, r := range "rgb:2828/2c2c/3434" {
+		assert.True(t, f.Filter(makeRuneEvt(r)))
+	}
+	// Bare [ in OSC state transitions directly to CSI — filtered
+	assert.True(t, f.Filter(makeRuneEvt('[')), "bare [ in OSC state enters CSI")
+	for _, r := range "6;14" {
+		assert.True(t, f.Filter(makeRuneEvt(r)))
+	}
+	assert.True(t, f.Filter(makeRuneEvt('R')))
+	assert.False(t, f.Filter(makeRuneEvt('x')))
+}
+
+func TestEscapeFilter_BareOSCThenBareCPR(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	// Simulate: ]11;rgb:2828/2c2c/3434 then bare [6;14R
+	// The ] starts probing, ;confirms OSC, then bare [ transitions to CSI
+	assert.False(t, f.Filter(makeRuneEvt(']')))
+	assert.False(t, f.Filter(makeRuneEvt('1')))
+	assert.False(t, f.Filter(makeRuneEvt('1')))
+	assert.True(t, f.Filter(makeRuneEvt(';')))
+	for _, r := range "rgb:2828/2c2c/3434" {
+		assert.True(t, f.Filter(makeRuneEvt(r)))
+	}
+	// Bare [ after OSC body — should transition to CSI
+	assert.True(t, f.Filter(makeRuneEvt('[')))
+	for _, r := range "6;14" {
+		assert.True(t, f.Filter(makeRuneEvt(r)))
+	}
+	assert.True(t, f.Filter(makeRuneEvt('R')))
+
+	assert.False(t, f.Filter(makeRuneEvt('x')))
+}
+
+func TestEscapeFilter_CPRWithAlt(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	assert.True(t, f.Filter(makeAltRuneEvt('[')))
+	for _, r := range "12;149" {
+		assert.True(t, f.Filter(makeRuneEvt(r)))
+	}
+	assert.True(t, f.Filter(makeRuneEvt('R')))
+
+	assert.False(t, f.Filter(makeRuneEvt('x')))
+}
+
+func TestEscapeFilter_FullBurstMixed(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	// Real-world: OSC10 (bare]) + CPR + OSC11 (Alt+]) + CPR
+	// First OSC10 without Alt — ]10;rgb:ffff/ffff/ffff
+	assert.False(t, f.Filter(makeRuneEvt(']')))
+	assert.False(t, f.Filter(makeRuneEvt('1')))
+	assert.False(t, f.Filter(makeRuneEvt('0')))
+	assert.True(t, f.Filter(makeRuneEvt(';'))) // confirmed
+	for _, r := range "rgb:ffff/ffff/ffff" {
+		assert.True(t, f.Filter(makeRuneEvt(r)))
+	}
+
+	// CPR with bare [ (from within OSC state)
+	assert.True(t, f.Filter(makeRuneEvt('[')))
+	for _, r := range "6;15" {
+		assert.True(t, f.Filter(makeRuneEvt(r)))
+	}
+	assert.True(t, f.Filter(makeRuneEvt('R')))
+
+	// Second OSC11 with Alt+]
+	assert.True(t, f.Filter(makeAltRuneEvt(']')))
+	for _, r := range "11;rgb:2828/2c2c/3434" {
+		assert.True(t, f.Filter(makeRuneEvt(r)))
+	}
+
+	// CPR with Alt+[
+	assert.True(t, f.Filter(makeAltRuneEvt('[')))
+	for _, r := range "6;14" {
+		assert.True(t, f.Filter(makeRuneEvt(r)))
+	}
+	assert.True(t, f.Filter(makeRuneEvt('R')))
+
+	// Normal input after
+	assert.False(t, f.Filter(makeRuneEvt('h')))
+	assert.False(t, f.Filter(makeRuneEvt('i')))
+}
+
+func TestEscapeFilter_OSCWithBELTerminator(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	assert.True(t, f.Filter(makeAltRuneEvt(']')))
+	for _, r := range "10;rgb:fafa/f9f9/f6f6" {
+		assert.True(t, f.Filter(makeRuneEvt(r)))
+	}
+	assert.True(t, f.Filter(makeRuneEvt(0x07)), "BEL should terminate OSC")
+
+	assert.False(t, f.Filter(makeRuneEvt('a')))
+}
+
+func TestEscapeFilter_NormalTypingUnaffected(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	normalChars := "hello world/pod:123[testR;foo"
+	for _, r := range normalChars {
+		time.Sleep(10 * time.Millisecond) // simulate typing speed
+		assert.False(t, f.Filter(makeRuneEvt(r)),
+			"normal char %c should not be filtered", r)
+	}
+}
+
+func TestEscapeFilter_BareRightBracketThenNormal(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	// User types ] then something that's NOT 1 — should pass through
+	assert.False(t, f.Filter(makeRuneEvt(']')))
+	assert.False(t, f.Filter(makeRuneEvt('a')), "non-1 after ] should pass through")
+
+	// User types ]1 then something that's NOT 0 or 1 — should pass through
+	f2 := NewEscapeSequenceFilter(nil)
+	assert.False(t, f2.Filter(makeRuneEvt(']')))
+	assert.False(t, f2.Filter(makeRuneEvt('1')))
+	assert.False(t, f2.Filter(makeRuneEvt('x')), "non-0/1 after ]1 should pass through")
+
+	// User types ]10 then something that's NOT ; — should pass through
+	f3 := NewEscapeSequenceFilter(nil)
+	assert.False(t, f3.Filter(makeRuneEvt(']')))
+	assert.False(t, f3.Filter(makeRuneEvt('1')))
+	assert.False(t, f3.Filter(makeRuneEvt('0')))
+	assert.False(t, f3.Filter(makeRuneEvt('x')), "non-; after ]10 should pass through")
+}
+
+func TestEscapeFilter_ProbeTimeoutResets(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	// Start probing with bare ]
+	assert.False(t, f.Filter(makeRuneEvt(']')))
+
+	// Wait longer than probe timeout
+	time.Sleep(escProbeTimeout + 20*time.Millisecond)
+
+	// State should reset — normal chars pass through
+	assert.False(t, f.Filter(makeRuneEvt('1')))
+}
+
+func TestEscapeFilter_BurstTimeoutResets(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	assert.True(t, f.Filter(makeAltRuneEvt(']')))
+	assert.True(t, f.Filter(makeRuneEvt('1')))
+
+	time.Sleep(escBurstTimeout + 20*time.Millisecond)
+
+	assert.False(t, f.Filter(makeRuneEvt('h')))
+}
+
+func TestEscapeFilter_MalformedCSIResets(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	assert.True(t, f.Filter(makeAltRuneEvt('[')))
+	assert.True(t, f.Filter(makeRuneEvt('1')))
+
+	assert.False(t, f.Filter(makeRuneEvt('å')),
+		"non-ASCII char should reset CSI filter")
+
+	assert.False(t, f.Filter(makeRuneEvt('a')))
+}
+
+// TestEscapeFilter_GhosttyBypass simulates the case where Ghostty consumes
+// the OSC prefix (\x1b]10;rgb) and passes only :ffff/ffff/ffff to the app.
+// The : arrives first (with no prior context), followed by hex chars in a
+// rapid burst.
+func TestEscapeFilter_GhosttyBypass(t *testing.T) {
+	undoCalled := false
+	f := NewEscapeSequenceFilter(func() { undoCalled = true })
+
+	// : arrives — enters colon probe, passes through
+	assert.False(t, f.Filter(makeRuneEvt(':')))
+
+	// Hex digit arrives within burst gap — confirms escape residue
+	time.Sleep(1 * time.Millisecond) // within escBurstGap (5ms)
+	assert.True(t, f.Filter(makeRuneEvt('f')), "hex after : in burst should be filtered")
+	assert.True(t, undoCalled, "undo should have been called to deactivate command mode")
+
+	// Rest of the RGB body is filtered
+	for _, r := range "fff/ffff/ffff" {
+		assert.True(t, f.Filter(makeRuneEvt(r)), "body char %c should be filtered", r)
+	}
+
+	// Normal typing after the burst ends (with a gap)
+	time.Sleep(10 * time.Millisecond)
+	assert.False(t, f.Filter(makeRuneEvt('a')))
+}
+
+func TestEscapeFilter_CSIVariousFinalBytes(t *testing.T) {
+	f := NewEscapeSequenceFilter(nil)
+
+	for _, final := range []rune{'R', 'n', 'c', 't'} {
+		assert.True(t, f.Filter(makeAltRuneEvt('[')))
+		assert.True(t, f.Filter(makeRuneEvt('1')))
+		assert.True(t, f.Filter(makeRuneEvt(';')))
+		assert.True(t, f.Filter(makeRuneEvt('2')))
+		assert.True(t, f.Filter(makeRuneEvt(final)))
+		assert.False(t, f.Filter(makeRuneEvt('x')))
+	}
+}

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -154,9 +154,6 @@ func (p *Prompt) keyboard(evt *tcell.EventKey) *tcell.EventKey {
 
 	case tcell.KeyRune:
 		r := evt.Rune()
-		// Filter out control characters and non-printable runes that may come from
-		// terminal escape sequences (e.g., cursor position reports like [7;15R)
-		// Only accept printable characters for user input
 		if isValidInputRune(r) {
 			p.model.Add(r)
 		}

--- a/internal/ui/prompt_validation_test.go
+++ b/internal/ui/prompt_validation_test.go
@@ -6,6 +6,7 @@ package ui_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/model"
@@ -83,42 +84,57 @@ func TestPrompt_AcceptsPrintableCharacters(t *testing.T) {
 	})
 }
 
-// TestPrompt_FiltersEscapeSequencePattern tests that escape sequence
-// patterns are not automatically added when they appear as individual runes.
-// Note: This test verifies the validation works, but escape sequences
-// should ideally be handled by tcell before reaching KeyRune.
-func TestPrompt_FiltersEscapeSequencePattern(t *testing.T) {
-	m := model.NewFishBuff(':', model.CommandBuffer)
-	p := ui.NewPrompt(nil, true, config.NewStyles())
-	p.SetModel(m)
-	m.AddListener(p)
-	m.SetActive(true)
+// TestEscapeFilter_IntegrationCPR tests that a CPR response is fully
+// filtered by the EscapeSequenceFilter at the application level.
+// The filter is applied in view.App.keyboard(), not in the Prompt.
+func TestEscapeFilter_IntegrationCPR(t *testing.T) {
+	f := ui.NewEscapeSequenceFilter(nil)
 
-	// Simulate the problematic escape sequence pattern [7;15R
-	// Each character individually is printable, but we want to ensure
-	// they don't appear unexpectedly
-	escapeSequence := "[7;15R"
-
-	// Send each character
-	for _, r := range escapeSequence {
-		evt := tcell.NewEventKey(tcell.KeyRune, r, tcell.ModNone)
-		p.SendKey(evt)
+	// Simulate a CPR response: \x1b[7;15R
+	// tcell delivers: Alt+[, then 7, ;, 1, 5, R
+	events := []*tcell.EventKey{
+		tcell.NewEventKey(tcell.KeyRune, '[', tcell.ModAlt),
+		tcell.NewEventKey(tcell.KeyRune, '7', tcell.ModNone),
+		tcell.NewEventKey(tcell.KeyRune, ';', tcell.ModNone),
+		tcell.NewEventKey(tcell.KeyRune, '1', tcell.ModNone),
+		tcell.NewEventKey(tcell.KeyRune, '5', tcell.ModNone),
+		tcell.NewEventKey(tcell.KeyRune, 'R', tcell.ModNone),
 	}
 
-	// The characters themselves are printable, so they will be added
-	// This test documents the current behavior - the fix prevents
-	// control characters, but printable escape sequence chars would
-	// still be added if tcell doesn't filter them first
-	text := m.GetText()
+	for _, evt := range events {
+		assert.True(t, f.Filter(evt), "CPR event should be filtered")
+	}
 
-	// If all characters are printable, they will be in the buffer
-	// This is expected behavior - the fix prevents control chars,
-	// but can't prevent legitimate printable characters
-	assert.NotEmpty(t, text, "Printable escape sequence chars may still appear")
+	// Normal typing after sequence should pass through
+	assert.False(t, f.Filter(tcell.NewEventKey(tcell.KeyRune, 'p', tcell.ModNone)))
+}
 
-	// However, we can verify no control characters made it through
-	for _, r := range text {
-		assert.False(t, isControlChar(r), "No control characters should be in buffer")
+// TestEscapeFilter_IntegrationOSC tests that an OSC 10 color response
+// is fully filtered by the EscapeSequenceFilter.
+func TestEscapeFilter_IntegrationOSC(t *testing.T) {
+	f := ui.NewEscapeSequenceFilter(nil)
+
+	// Simulate OSC 10 response: \x1b]10;rgb:fafa/f9f9/f6f6\x1b\\
+	assert.True(t, f.Filter(tcell.NewEventKey(tcell.KeyRune, ']', tcell.ModAlt)))
+	for _, r := range "10;rgb:fafa/f9f9/f6f6" {
+		assert.True(t, f.Filter(tcell.NewEventKey(tcell.KeyRune, r, tcell.ModNone)))
+	}
+	assert.True(t, f.Filter(tcell.NewEventKey(tcell.KeyRune, '\\', tcell.ModAlt)))
+
+	// Normal typing after should pass
+	assert.False(t, f.Filter(tcell.NewEventKey(tcell.KeyRune, 'a', tcell.ModNone)))
+}
+
+// TestEscapeFilter_IntegrationNormalTyping tests that normal user input
+// is never affected by the filter. Adds realistic delays between keystrokes
+// to simulate actual typing speed (> 5ms between chars).
+func TestEscapeFilter_IntegrationNormalTyping(t *testing.T) {
+	f := ui.NewEscapeSequenceFilter(nil)
+
+	for _, r := range "pods/nginx:123" {
+		time.Sleep(10 * time.Millisecond) // simulate typing speed
+		assert.False(t, f.Filter(tcell.NewEventKey(tcell.KeyRune, r, tcell.ModNone)),
+			"Normal char %c should pass through", r)
 	}
 }
 

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -48,6 +48,7 @@ type App struct {
 	Content       *PageStack
 	command       *Command
 	factory       *watch.Factory
+	escFilter     *ui.EscapeSequenceFilter
 	cancelFn      context.CancelFunc
 	clusterModel  *model.ClusterInfo
 	cmdHistory    *model.History
@@ -66,6 +67,11 @@ func NewApp(cfg *config.Config) *App {
 		filterHistory: model.NewHistory(model.MaxHistory),
 		Content:       NewPageStack(),
 	}
+	// Set up escape filter with undo callback that deactivates any
+	// mode accidentally activated by escape sequence residue.
+	a.escFilter = ui.NewEscapeSequenceFilter(func() {
+		a.Prompt().Deactivate()
+	})
 	a.ReloadStyles()
 
 	a.Views()["statusIndicator"] = ui.NewStatusIndicator(a.App, a.Styles)
@@ -244,6 +250,12 @@ func (a *App) contextNames() ([]string, error) {
 }
 
 func (a *App) keyboard(evt *tcell.EventKey) *tcell.EventKey {
+	// Filter out terminal escape sequence responses (OSC 10/11, CPR) that
+	// leak through tcell as individual KeyRune events. See #3885.
+	if evt.Key() == tcell.KeyRune && a.escFilter.Filter(evt) {
+		return nil
+	}
+
 	if k, ok := a.HasAction(ui.AsKey(evt)); ok && !a.Content.IsTopDialog() {
 		return k.Action(evt)
 	}


### PR DESCRIPTION
## Summary

Fixes #3885 (also related: #3667, #3697)

Terminal escape sequence responses (OSC 10/11 color queries, CPR cursor position reports) leak into k9s input fields as printable characters. The `isValidInputRune()` fix in #3697 only blocks control characters, but the leaked bytes are mostly printable ASCII (`]`, digits, `;`, `/`, `R`, etc.).

This adds an `EscapeSequenceFilter` at the application-level keyboard handler that detects and discards these sequences using three strategies:

1. **Alt modifier detection**: when tcell delivers `]` or `[` with `ModAlt` (from a consumed ESC byte), the filter recognizes OSC/CSI sequence boundaries and discards all events until the terminator.

2. **Pattern matching**: when tcell's input buffering causes ESC to be consumed without setting `ModAlt`, a bare `]` followed by `10;` or `11;` is recognized as an OSC color response.

3. **Timing-based burst detection**: when the terminal emulator partially consumes the OSC prefix (observed with Ghostty consuming `\x1b]10;rgb` and passing `:ffff/ffff/ffff` to the app), a `:` or `/` followed by a hex digit within 5ms is recognized as escape sequence residue. An undo callback deactivates any command/filter mode that was accidentally triggered.

## Root cause

`derailed/tcell v2` lacks OSC sequence parsing. When the terminal responds to color/position queries, tcell can't recognize the sequences and emits each byte as an individual `KeyRune` event. The upstream `gdamore/tcell v3` has proper OSC handling, but k9s uses the older fork.

## Changes

- **`internal/ui/escape_filter.go`** — state machine filter (~250 lines)
- **`internal/view/app.go`** — filter integrated at app-level keyboard handler
- **`internal/ui/prompt.go`** — removed stale comment about escape filtering
- **`internal/ui/escape_filter_test.go`** — unit tests for all states and transitions
- **`internal/ui/escape_filter_realistic_test.go`** — tests reproducing exact production behavior
- **`internal/ui/prompt_validation_test.go`** — updated existing tests

## Test plan

- [x] All automated tests pass (55 tests including realistic production scenarios)
- [x] Tested with Ghostty, GNOME Terminal on Ubuntu 24.04 / Linux 6.17
- [x] Verified via pty test harness injecting raw escape responses with various timing patterns
- [x] Stock k9s leaked characters overnight; patched version did not
- [x] Normal typing, command mode, filter mode, tab completion all work correctly
- [x] No false positives observed over multiple days of daily-driver usage

## Environment

- **OS:** Ubuntu 24.04 LTS (Linux 6.17.0)
- **Terminals tested:** Ghostty, GNOME Terminal
- **Kubernetes:** EKS 1.32