### PR TITLE
Fix k9s crash/freeze after cluster disconnect during idle

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -312,7 +313,27 @@ func (a *APIClient) CheckConnectivity() bool {
 		a.connOK = false
 		return a.connOK
 	}
-	cfg.Timeout = a.config.CallTimeout()
+
+	// Quick TCP dial to check basic reachability before creating a
+	// full API client. This avoids blocking on stale TLS sessions.
+	if cfg.Host != "" {
+		host := cfg.Host
+		if strings.HasPrefix(host, "https://") {
+			host = strings.TrimPrefix(host, "https://")
+			if !strings.Contains(host, ":") {
+				host += ":443"
+			}
+		}
+		conn, err := net.DialTimeout("tcp", host, 5*time.Second)
+		if err != nil {
+			slog.Error("TCP dial failed", "host", host, slogs.Error, err)
+			a.setConnOK(false)
+			return a.getConnOK()
+		}
+		conn.Close()
+	}
+
+	cfg.Timeout = 10 * time.Second
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		slog.Error("Unable to connect to api server", slogs.Error, err)

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -16,7 +16,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
 	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/config"
@@ -365,27 +364,21 @@ func (a *App) clusterUpdater(ctx context.Context) {
 	}
 
 	if err := a.refreshCluster(ctx); err != nil {
-		slog.Error("Cluster updater failed!", slogs.Error, err)
-		return
+		slog.Warn("Initial cluster refresh failed, will keep retrying...", slogs.Error, err)
 	}
 
-	bf := model.NewExpBackOff(ctx, clusterRefresh, 2*time.Minute)
-	delay := clusterRefresh
+	// Simple retry loop: check every clusterRefresh (15s).
+	// No exponential backoff, no bailout. The connectivity check
+	// itself has a 10s timeout, so each iteration takes at most ~25s.
+	// This ensures k9s detects recovery quickly after any disconnect.
 	for {
 		select {
 		case <-ctx.Done():
 			slog.Debug("ClusterInfo updater canceled!")
 			return
-		case <-time.After(delay):
+		case <-time.After(clusterRefresh):
 			if err := a.refreshCluster(ctx); err != nil {
-				slog.Error("Cluster updates failed. Giving up ;(", slogs.Error, err)
-				if delay = bf.NextBackOff(); delay == backoff.Stop {
-					a.BailOut(1)
-					return
-				}
-			} else {
-				bf.Reset()
-				delay = clusterRefresh
+				slog.Warn("Cluster update failed, retrying...", slogs.Error, err)
 			}
 		}
 	}
@@ -400,6 +393,7 @@ func (a *App) refreshCluster(context.Context) error {
 	if ok := a.Conn().CheckConnectivity(); ok {
 		if atomic.LoadInt32(&a.conRetry) > 0 {
 			atomic.StoreInt32(&a.conRetry, 0)
+			slog.Info("✅ Kubernetes connectivity OK")
 			a.Status(model.FlashInfo, "K8s connectivity OK")
 			if c != nil {
 				c.Start()
@@ -413,18 +407,10 @@ func (a *App) refreshCluster(context.Context) error {
 		c.Stop()
 	}
 
-	count, maxConnRetry := atomic.LoadInt32(&a.conRetry), a.Config.K9s.MaxConnRetry
-	if count >= maxConnRetry {
-		slog.Error("Conn check failed. Bailing out!",
-			slogs.Retry, count,
-			slogs.MaxRetries, maxConnRetry,
-		)
-		ExitStatus = fmt.Sprintf("Lost K8s connection (%d). Bailing out!", count)
-		a.BailOut(1)
-	}
+	count := atomic.LoadInt32(&a.conRetry)
 	if count > 0 {
-		a.Status(model.FlashWarn, fmt.Sprintf("Dial K8s Toast [%d/%d]", count, maxConnRetry))
-		return fmt.Errorf("conn check failed (%d/%d)", count, maxConnRetry)
+		a.Status(model.FlashWarn, fmt.Sprintf("Dial K8s Toast [%d]", count))
+		return fmt.Errorf("conn check failed (%d)", count)
 	}
 
 	// Reload alias


### PR DESCRIPTION
## Summary

Fixes #3922

k9s exits after a cluster disconnect during idle because the cluster updater goroutine exits on its first failed connectivity check, and `BailOut` terminates the app after 5 retry failures.

## Changes

**`internal/view/app.go`**:
- `clusterUpdater()`: don't exit the goroutine on initial `refreshCluster()` failure — warn and enter the retry loop
- Replace exponential backoff + BailOut with a simple 15s retry loop that never exits. The user can Ctrl+C to quit if the cluster is truly gone.
- Log "connectivity OK" when connection is restored after a disconnect

**`internal/client/client.go`**:
- `CheckConnectivity()`: add TCP dial pre-check (5s timeout) before the full API version check — fast-fails when the server is unreachable instead of blocking for 120s
- Reduce HTTP timeout from 120s (`CallTimeout`) to 10s for connectivity checks

## Root cause

Three issues in the cluster updater:

1. **Goroutine exits on first failure**: `clusterUpdater()` calls `refreshCluster()` before the retry loop. If it fails, the goroutine returns — killing all reconnection.

2. **BailOut on retry exhaustion**: `refreshCluster()` exits the app when `conRetry >= MaxConnRetry` (5). With ~15-25s per check, k9s dies after ~75-125s.

3. **120s connectivity timeout**: `CheckConnectivity()` blocks for 2 minutes per failed check, making recovery extremely slow.

## Test plan

- [x] Automated disconnect/reconnect tests: 8/8 pass (0/8 on stock k9s)
- [x] 60s disconnect → recovery within 1s of API server availability
- [x] k9s stays alive during any disconnect duration
- [x] Normal operation (navigation, filtering, context switch) unaffected
- [x] Tested with EKS 1.32 and vcluster 0.25.2

## Test methodology

Automated script that:
1. Starts k9s against a [vcluster](https://github.com/loft-sh/vcluster)
2. Scales the vcluster API server to 0 replicas (instant disconnect)
3. Waits 60s while checking k9s is still alive
4. Scales back to 3 replicas and waits for rollout
5. Verifies k9s detects recovery and logs "connectivity OK"