### PR TITLE
Fix panic in RowEventSorter.Less when row fields are shorter than sort index

### DIFF
--- a/internal/model1/row_event.go
+++ b/internal/model1/row_event.go
@@ -304,6 +304,9 @@ func (r RowEventSorter) Swap(i, j int) {
 
 func (r RowEventSorter) Less(i, j int) bool {
 	f1, f2 := r.Events.events[i].Row.Fields, r.Events.events[j].Row.Fields
+	if r.Index >= len(f1) || r.Index >= len(f2) {
+		return i < j
+	}
 	id1, id2 := r.Events.events[i].Row.ID, r.Events.events[j].Row.ID
 	less := Less(r.IsNumber, r.IsDuration, r.IsCapacity, id1, id2, f1[r.Index], f2[r.Index])
 	if r.Asc {

--- a/internal/model1/row_event_test.go
+++ b/internal/model1/row_event_test.go
@@ -469,6 +469,32 @@ func TestRowEventsSort(t *testing.T) {
 				model1.RowEvent{Row: model1.Row{ID: "ns2/C", Fields: model1.Fields{"C", "2", "3"}}},
 			),
 		},
+		"index-out-of-bounds": {
+			re: model1.NewRowEventsWithEvts(
+				model1.RowEvent{Row: model1.Row{ID: "A", Fields: model1.Fields{"1", "2", "3"}}},
+				model1.RowEvent{Row: model1.Row{ID: "B", Fields: model1.Fields{"0", "2"}}},
+				model1.RowEvent{Row: model1.Row{ID: "C", Fields: model1.Fields{"10", "2", "3"}}},
+			),
+			col: 2,
+			asc: true,
+			e: model1.NewRowEventsWithEvts(
+				model1.RowEvent{Row: model1.Row{ID: "A", Fields: model1.Fields{"1", "2", "3"}}},
+				model1.RowEvent{Row: model1.Row{ID: "B", Fields: model1.Fields{"0", "2"}}},
+				model1.RowEvent{Row: model1.Row{ID: "C", Fields: model1.Fields{"10", "2", "3"}}},
+			),
+		},
+		"all-rows-short": {
+			re: model1.NewRowEventsWithEvts(
+				model1.RowEvent{Row: model1.Row{ID: "A", Fields: model1.Fields{"1"}}},
+				model1.RowEvent{Row: model1.Row{ID: "B", Fields: model1.Fields{"0"}}},
+			),
+			col: 5,
+			asc: true,
+			e: model1.NewRowEventsWithEvts(
+				model1.RowEvent{Row: model1.Row{ID: "A", Fields: model1.Fields{"1"}}},
+				model1.RowEvent{Row: model1.Row{ID: "B", Fields: model1.Fields{"0"}}},
+			),
+		},
 		"capacity": {
 			re: model1.NewRowEventsWithEvts(
 				model1.RowEvent{Row: model1.Row{ID: "ns1/B", Fields: model1.Fields{"B", "2", "3", "1Gi"}}},


### PR DESCRIPTION
## Summary

Fixes #3925

k9s panics during table sort when some rows have fewer fields than the sort column index. This happens during degraded cluster connectivity when partial row data is returned from the API server.

## Changes

**`internal/model1/row_event.go`**:
- Add bounds check in `RowEventSorter.Less()` before accessing `f1[r.Index]` / `f2[r.Index]`
- When a row has fewer fields than the sort index, fall back to stable index ordering (`i < j`) so the sort completes without panicking

**`internal/model1/row_event_test.go`**:
- Add `index-out-of-bounds` test: mix of short and full rows sorted on a column that exceeds the short row's field count
- Add `all-rows-short` test: all rows shorter than the sort index — verifies stable ordering and no panic

## Root cause

`RowEventSorter.Less()` accesses `f1[r.Index]` without checking that the row has enough fields. During cluster disconnect/reconnect, some rows can end up with fewer fields than the table header expects.

## Test plan

- [x] New test cases pass: `index-out-of-bounds` and `all-rows-short`
- [x] All existing `TestRowEventsSort` cases still pass (6/6)
- [x] Full `internal/model1` test suite passes