### PR TITLE
Fix connectivity hang issue #3471

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -313,6 +313,9 @@ func (a *APIClient) CheckConnectivity() bool {
 		return a.connOK
 	}
 	cfg.Timeout = a.config.CallTimeout()
+	if cfg.Timeout > 5*time.Second {
+		cfg.Timeout = 5 * time.Second
+	}
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		slog.Error("Unable to connect to api server", slogs.Error, err)

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	// DefaultCallTimeoutDuration is the default api server call timeout duration.
-	DefaultCallTimeoutDuration time.Duration = 120 * time.Second
+	DefaultCallTimeoutDuration time.Duration = 30 * time.Second
 
 	// UsePersistentConfig caches client config to avoid reloads.
 	UsePersistentConfig = true

--- a/internal/model/cluster_info.go
+++ b/internal/model/cluster_info.go
@@ -43,7 +43,9 @@ type ClusterMeta struct {
 	K9sVer, K9sLatest string
 	K8sVer           string
 	Cpu, Mem, Ephemeral int
-	Connectivity     bool
+
+	// Connectivity tracks cluster connectivity status.
+	Connectivity bool
 }
 
 // NewClusterMeta returns a new instance.

--- a/internal/model/cluster_info.go
+++ b/internal/model/cluster_info.go
@@ -38,24 +38,26 @@ type ClusterInfoListener interface {
 
 // ClusterMeta represents cluster meta data.
 type ClusterMeta struct {
-	Context, Cluster    string
-	User                string
-	K9sVer, K9sLatest   string
-	K8sVer              string
+	Context, Cluster string
+	User             string
+	K9sVer, K9sLatest string
+	K8sVer           string
 	Cpu, Mem, Ephemeral int
+	Connectivity     bool
 }
 
 // NewClusterMeta returns a new instance.
 func NewClusterMeta() *ClusterMeta {
 	return &ClusterMeta{
-		Context:   client.NA,
-		Cluster:   client.NA,
-		User:      client.NA,
-		K9sVer:    client.NA,
-		K8sVer:    client.NA,
-		Cpu:       0,
-		Mem:       0,
-		Ephemeral: 0,
+		Context:      client.NA,
+		Cluster:      client.NA,
+		User:         client.NA,
+		K9sVer:       client.NA,
+		K8sVer:       client.NA,
+		Cpu:          0,
+		Mem:          0,
+		Ephemeral:    0,
+		Connectivity: true,
 	}
 }
 
@@ -70,7 +72,8 @@ func (c *ClusterMeta) Deltas(n *ClusterMeta) bool {
 		c.User != n.User ||
 		c.K8sVer != n.K8sVer ||
 		c.K9sVer != n.K9sVer ||
-		c.K9sLatest != n.K9sLatest
+		c.K9sLatest != n.K9sLatest ||
+		c.Connectivity != n.Connectivity
 }
 
 // ClusterInfo models cluster metadata.
@@ -131,7 +134,8 @@ func (c *ClusterInfo) Reset(f dao.Factory) {
 // Refresh fetches the latest cluster meta.
 func (c *ClusterInfo) Refresh() {
 	data := NewClusterMeta()
-	if c.factory.Client().ConnectionOK() {
+	data.Connectivity = c.factory.Client().ConnectionOK()
+	if data.Connectivity {
 		data.Context = c.cluster.ContextName()
 		data.Cluster = c.cluster.ClusterName()
 		data.User = c.cluster.UserName()

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -391,7 +391,7 @@ func (a *App) clusterUpdater(ctx context.Context) {
 	}
 }
 
-func (a *App) refreshCluster(context.Context) error {
+func (a *App) refreshCluster(ctx context.Context) error {
 	if a.Conn() == nil || a.factory == nil || a.clusterModel == nil {
 		return nil
 	}
@@ -408,9 +408,14 @@ func (a *App) refreshCluster(context.Context) error {
 			a.ClearStatus(true)
 		}
 		a.factory.ValidatePortForwards()
-	} else if c != nil {
+	} else {
+		if atomic.LoadInt32(&a.conRetry) == 0 {
+			a.Status(model.FlashErr, "K8s connectivity Lost!")
+			if c != nil {
+				c.Stop()
+			}
+		}
 		atomic.AddInt32(&a.conRetry, 1)
-		c.Stop()
 	}
 
 	count, maxConnRetry := atomic.LoadInt32(&a.conRetry), a.Config.K9s.MaxConnRetry
@@ -478,6 +483,8 @@ func (a *App) switchContext(ci *cmd.Interpreter, force bool) error {
 			a.Config.SetActiveView(client.PodGVR.String())
 		}
 		ns := a.Config.ActiveNamespace()
+		atomic.StoreInt32(&a.conRetry, 0)
+		a.ClearStatus(true)
 		if !a.Conn().IsValidNamespace(ns) {
 			slog.Warn("Unable to validate namespace", slogs.Namespace, ns)
 			if err := a.Config.SetActiveNamespace(ns); err != nil {
@@ -574,6 +581,10 @@ func (a *App) Run() error {
 // Status reports a new app status for display.
 func (a *App) Status(l model.FlashLevel, msg string) {
 	a.QueueUpdateDraw(func() {
+		if atomic.LoadInt32(&a.conRetry) > 0 {
+			l = model.FlashErr
+			msg = "K8s connectivity Lost!"
+		}
 		if a.showHeader {
 			a.setLogo(l, msg)
 		} else {
@@ -590,7 +601,19 @@ func (a *App) IsBenchmarking() bool {
 // ClearStatus reset logo back to normal.
 func (a *App) ClearStatus(flash bool) {
 	a.QueueUpdate(func() {
+		if atomic.LoadInt32(&a.conRetry) > 0 {
+			if a.showHeader {
+				a.setLogo(model.FlashErr, "K8s connectivity Lost!")
+			} else {
+				a.setIndicator(model.FlashErr, "K8s connectivity Lost!")
+			}
+			if flash {
+				a.Flash().Clear()
+			}
+			return
+		}
 		a.Logo().Reset()
+		a.statusIndicator().Reset()
 		if flash {
 			a.Flash().Clear()
 		}

--- a/internal/view/cluster_info.go
+++ b/internal/view/cluster_info.go
@@ -65,7 +65,7 @@ func (c *ClusterInfo) hasMetrics() bool {
 }
 
 func (c *ClusterInfo) layout() {
-	for row, section := range []string{"Context", "Cluster", "User", "K9s Rev", "K8s Rev", "CPU", "MEM"} {
+	for row, section := range []string{"Context", "Cluster", "User", "K9s Rev", "K8s Rev", "CPU", "MEM", "Connectivity"} {
 		c.SetCell(row, 0, c.sectionCell(section))
 		c.SetCell(row, 1, c.infoCell(render.NAValue))
 	}
@@ -130,12 +130,19 @@ func (c *ClusterInfo) ClusterInfoChanged(prev, curr *model.ClusterMeta) {
 		row = c.setCell(row, curr.K8sVer)
 		if c.hasMetrics() {
 			row = c.setCell(row, ui.AsPercDelta(prev.Cpu, curr.Cpu))
-			_ = c.setCell(row, ui.AsPercDelta(prev.Mem, curr.Mem))
+			row = c.setCell(row, ui.AsPercDelta(prev.Mem, curr.Mem))
 			c.setDefCon(curr.Cpu, curr.Mem)
 		} else {
 			row = c.setCell(row, c.warnCell(render.NAValue, true))
-			_ = c.setCell(row, c.warnCell(render.NAValue, true))
+			row = c.setCell(row, c.warnCell(render.NAValue, true))
 		}
+
+		status := "[lawngreen::b]OK"
+		if !curr.Connectivity {
+			status = "[orangered::l]Lost"
+		}
+		c.setCell(row, status)
+
 		c.updateStyle()
 	})
 }


### PR DESCRIPTION
Fix for issue [Context switch no longer possible if connection is lost #3471
 ](https://github.com/derailed/k9s/issues/3471)

To K9S Maintainer:
Im a DevOps enigneer that has basic development skills in GoLang, I love k9s and use it all the time. I use VPN on a regular basis so i experience connectivity frequently.
I wanted to contribute this fix to k9s to help out, but i used Gemini PRO to generate this so i understand if you will regect this PR.

**k9s was crashing when connectivity issues hit — this PR fixes that.**

Tightened up default timeouts so things feel snappier, pulled the connectivity checks in SwitchContext out of the critical path into a background check (capped at 5s so it never blocks), and wired up a 'Connectivity' status indicator in the UI so users actually know what's going on instead of seeing a crash.

**Testing description:**
1. Connect to Azure VPN.
2. Set KUBECTL context to the AKS cluster in the VPN hub and exec k9s.
3. Browse the AKS Cluster via k9s by access deployment, pods, pdb.
4. Disconnected VPN Connection
5. 