### PR TITLE
fix: add missing context in flux trace

### DIFF
--- a/plugins/flux.yaml
+++ b/plugins/flux.yaml
@@ -247,7 +247,7 @@ plugins:
       - -c
       - >-
         if [ -n "$RESOURCE_GROUP" ]; then api_endpoint="/apis/$RESOURCE_GROUP/$RESOURCE_VERSION"; else api_endpoint="/api/$RESOURCE_VERSION"; fi;
-        api_resource=$(kubectl get --raw "${api_endpoint}" | jq -r ".resources[] | select(.name==\"$RESOURCE_NAME\")");
+        api_resource=$(kubectl --context $CONTEXT get --raw "${api_endpoint}" | jq -r ".resources[] | select(.name==\"$RESOURCE_NAME\")");
         kind=$(echo ${api_resource} | jq -r '.kind');
         namespace_arg=$(echo ${api_resource} | jq -r "if .namespaced == true then \"--namespace $NAMESPACE\" else \"\" end");
         [ -n "$RESOURCE_GROUP" ] && api_version=$RESOURCE_GROUP/;


### PR DESCRIPTION
A `kubectl` call is missing context in the `flux trace` plugin.