### PR TITLE
fix: de-escape tview bracket sequences in log save/copy output

### DIFF
--- a/internal/view/helpers.go
+++ b/internal/view/helpers.go
@@ -45,7 +45,7 @@ func aliases(m *v1.APIResource, aa sets.Set[string]) sets.Set[string] {
 	return ss
 }
 
-var bracketRX = regexp.MustCompile(`\[(.+)\[\]`)
+var bracketRX = regexp.MustCompile(`\[([^\[\]]+)\[\]`)
 
 func sanitizeEsc(s string) string {
 	return bracketRX.ReplaceAllString(s, `[$1]`)

--- a/internal/view/helpers_test.go
+++ b/internal/view/helpers_test.go
@@ -342,6 +342,18 @@ func Test_sanitizeEsc(t *testing.T) {
 			s: "[fred[]",
 			e: "[fred]",
 		},
+		"multi-tags": {
+			s: "[INFO[]: some text [WARN[]: more",
+			e: "[INFO]: some text [WARN]: more",
+		},
+		"multi-tags-adjacent": {
+			s: "[INFO[] [blah-blah[] Testing",
+			e: "[INFO] [blah-blah] Testing",
+		},
+		"mixed-content": {
+			s: `{"foo":["bar"[]} Server on [::[]:5000`,
+			e: `{"foo":["bar"]} Server on [::]:5000`,
+		},
 	}
 
 	for k, u := range uu {

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -420,7 +420,7 @@ func (l *Log) filterCmd(evt *tcell.EventKey) *tcell.EventKey {
 
 // SaveCmd dumps the logs to file.
 func (l *Log) SaveCmd(*tcell.EventKey) *tcell.EventKey {
-	path, err := saveData(l.app.Config.K9s.ContextScreenDumpDir(), l.model.GetPath(), l.logs.GetText(true))
+	path, err := saveData(l.app.Config.K9s.ContextScreenDumpDir(), l.model.GetPath(), sanitizeEsc(l.logs.GetText(true)))
 	if err != nil {
 		l.app.Flash().Err(err)
 		return nil

--- a/internal/view/logger.go
+++ b/internal/view/logger.go
@@ -155,7 +155,7 @@ func (l *Logger) resetCmd(evt *tcell.EventKey) *tcell.EventKey {
 }
 
 func (l *Logger) saveCmd(*tcell.EventKey) *tcell.EventKey {
-	if path, err := saveYAML(l.app.Config.K9s.ContextScreenDumpDir(), l.title, l.GetText(true)); err != nil {
+	if path, err := saveYAML(l.app.Config.K9s.ContextScreenDumpDir(), l.title, sanitizeEsc(l.GetText(true))); err != nil {
 		l.app.Flash().Err(err)
 	} else {
 		l.app.Flash().Infof("Log %s saved successfully!", path)


### PR DESCRIPTION
This fixes #3051 and #3099. Both were auto-closed by the stale bot although I tried to keep the first one open for a while.

tview's GetText(true) strips color tags but doesn't de-escape bracket sequences (e.g. [INFO[] back to [INFO]) when dynamicColors is enabled. The existing sanitizeEsc workaround had a greedy regex that failed with multiple escape sequences per line, and was not applied to log save paths.

Here's a screenshot of the issue but it can happen elsewhere on log lines, especially if you log a json with multiple arrays in it:
<img width="786" height="384" alt="image" src="https://github.com/user-attachments/assets/b6d02f23-5bef-4ac4-892c-8abadd227bac" />

