### PR TITLE
fix: clarify plugin hotkey conflict error and update flux example (#3886)

### DIFF
--- a/internal/view/actions.go
+++ b/internal/view/actions.go
@@ -147,9 +147,13 @@ func pluginActions(r Runner, aa *ui.KeyActions) error {
 			errs = errors.Join(errs, err)
 			continue
 		}
-		if _, ok := aa.Get(key); ok {
+		if existingAction, ok := aa.Get(key); ok {
 			if !pp.Plugins[k].Override {
-				errs = errors.Join(errs, fmt.Errorf("duplicate plugin key found for %q in %q", pp.Plugins[k].ShortCut, k))
+				if existingAction.Opts.Plugin {
+					errs = errors.Join(errs, fmt.Errorf("duplicate plugin key found for %q in %q", pp.Plugins[k].ShortCut, k))
+				} else {
+					errs = errors.Join(errs, fmt.Errorf("plugin %q key %q conflicts with built-in shortcut (use 'override: true' to force)", k, pp.Plugins[k].ShortCut))
+				}
 				continue
 			}
 			slog.Debug("Plugin overrode action shortcut",

--- a/plugins/flux.yaml
+++ b/plugins/flux.yaml
@@ -263,6 +263,7 @@ plugins:
   # credits: https://github.com/fluxcd/flux2/discussions/2494
   get-suspended-helmreleases:
     shortCut: Shift-S
+    override: true
     confirm: false
     description: Suspended Helm Releases
     scopes:
@@ -280,6 +281,7 @@ plugins:
         | less -K
   get-suspended-kustomizations:
     shortCut: Shift-S
+    override: true
     confirm: false
     description: Suspended Kustomizations
     scopes:

--- a/plugins/flux.yaml
+++ b/plugins/flux.yaml
@@ -303,6 +303,7 @@ plugins:
   # credits: https://github.com/fluxcd/flux2/discussions/2494
   get-suspended-helmreleases:
     shortCut: Shift-S
+    override: true
     confirm: false
     description: Suspended Helm Releases
     scopes:
@@ -320,6 +321,7 @@ plugins:
         | less -K
   get-suspended-kustomizations:
     shortCut: Shift-S
+    override: true
     confirm: false
     description: Suspended Kustomizations
     scopes:


### PR DESCRIPTION
Fixes #3886 

**Describe the bug**
Previously, when a plugin defined a hotkey that conflicted with a built-in k9s shortcut (like `Shift-S`), k9s would misleadingly log a `duplicate plugin key found` error. This caused confusion, as users thought their plugins were conflicting with each other across different scopes. 

**To Reproduce**
Load the `flux.yaml` plugin which maps `Shift-S` without the `override: true` flag.

**Expected behavior**
This PR does two things:
1. Clarifies the error message so it accurately informs the user that the plugin conflicts with a *built-in* shortcut, and directly suggests using `override: true` to fix it.
2. Updates the official `plugins/flux.yaml` example to uncomment `override: true` for the `Shift-S` hotkeys, preventing this confusing error for new users out of the box.