### PR TITLE
fix: remove all formatting when matching the column name in function HeaderIndex

### DIFF
--- a/internal/view/table.go
+++ b/internal/view/table.go
@@ -73,6 +73,26 @@ func (t *Table) SetCommand(i *cmd.Interpreter) {
 	t.command = i
 }
 
+// stripFormatTags removes all formatting tags ([...]) from a string.
+func stripFormatTags(s string) string {
+	var result strings.Builder
+	inTag := false
+	for _, ch := range s {
+		if ch == '[' {
+			inTag = true
+			continue
+		}
+		if ch == ']' {
+			inTag = false
+			continue
+		}
+		if !inTag {
+			result.WriteRune(ch)
+		}
+	}
+	return result.String()
+}
+
 // HeaderIndex returns index of a given column or false if not found.
 func (t *Table) HeaderIndex(colName string) (int, bool) {
 	for i := range t.GetColumnCount() {
@@ -80,10 +100,7 @@ func (t *Table) HeaderIndex(colName string) (int, bool) {
 		if h == nil {
 			continue
 		}
-		s := h.Text
-		if idx := strings.Index(s, "["); idx > 0 {
-			s = s[:idx]
-		}
+		s := stripFormatTags(h.Text)
 		if s == colName {
 			return i, true
 		}


### PR DESCRIPTION
Fixes https://github.com/derailed/k9s/issues/3875