### PR TITLE
feat: add Ctrl+T shortcut to toggle read-only mode at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ K9s uses aliases to navigate most K8s resources.
 | Toggle wide columns                                                             | `ctrl-w`                       |                                                                        |
 | Toggle header                                                                   | `ctrl-e`                       |                                                                        |
 | Toggle breadcrumbs                                                              | `ctrl-g`                       |                                                                        |
+| Toggle read-only mode                                                           | `ctrl-t`                       | Session only, does not persist to config                               |
 | Move selected column left                                                       | `shift-left arrow`             |                                                                        |
 | Move selected column right                                                      | `shift-right arrow`            |                                                                        |
 | Sort by selected column                                                         | `shift-o`                      |                                                                        |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,11 @@ func (c *Config) IsReadOnly() bool {
 	return c.K9s.IsReadOnly()
 }
 
+// ToggleReadOnly toggles the read-only mode at runtime.
+func (c *Config) ToggleReadOnly() {
+	c.K9s.ToggleReadOnly()
+}
+
 // ActiveClusterName returns the corresponding cluster name.
 func (c *Config) ActiveClusterName(contextName string) (string, error) {
 	ct, err := c.settings.GetContext(contextName)

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -420,6 +420,29 @@ func (k *K9s) IsReadOnly() bool {
 	return ro
 }
 
+// ToggleReadOnly toggles the read-only mode at runtime.
+func (k *K9s) ToggleReadOnly() {
+	k.mx.Lock()
+	defer k.mx.Unlock()
+
+	v := !k.IsReadOnlyLocked()
+	k.manualReadOnly = &v
+}
+
+// IsReadOnlyLocked returns the readonly setting without locking.
+// Must be called with the mutex held.
+func (k *K9s) IsReadOnlyLocked() bool {
+	ro := k.ReadOnly
+	if k.activeConfig != nil && k.activeConfig.Context != nil && k.activeConfig.Context.ReadOnly != nil {
+		ro = *k.activeConfig.Context.ReadOnly
+	}
+	if k.manualReadOnly != nil {
+		ro = *k.manualReadOnly
+	}
+
+	return ro
+}
+
 // Validate the current configuration.
 func (k *K9s) Validate(c client.Connection, contextName, clusterName string) {
 	if k.RefreshRate <= 0 {

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -425,13 +425,13 @@ func (k *K9s) ToggleReadOnly() {
 	k.mx.Lock()
 	defer k.mx.Unlock()
 
-	v := !k.IsReadOnlyLocked()
+	v := !k.isReadOnlyLocked()
 	k.manualReadOnly = &v
 }
 
-// IsReadOnlyLocked returns the readonly setting without locking.
+// isReadOnlyLocked returns the readonly setting without locking.
 // Must be called with the mutex held.
-func (k *K9s) IsReadOnlyLocked() bool {
+func (k *K9s) isReadOnlyLocked() bool {
 	ro := k.ReadOnly
 	if k.activeConfig != nil && k.activeConfig.Context != nil && k.activeConfig.Context.ReadOnly != nil {
 		ro = *k.activeConfig.Context.ReadOnly

--- a/internal/config/k9s_int_test.go
+++ b/internal/config/k9s_int_test.go
@@ -120,6 +120,39 @@ func Test_k9sOverrides(t *testing.T) {
 	}
 }
 
+func Test_toggleReadOnly(t *testing.T) {
+	uu := map[string]struct {
+		k      *K9s
+		expect []bool
+	}{
+		"from-rw": {
+			k:      &K9s{ReadOnly: false},
+			expect: []bool{true, false, true},
+		},
+		"from-ro": {
+			k:      &K9s{ReadOnly: true},
+			expect: []bool{false, true, false},
+		},
+		"from-manual-override": {
+			k: func() *K9s {
+				v := true
+				return &K9s{ReadOnly: false, manualReadOnly: &v}
+			}(),
+			expect: []bool{false, true, false},
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			for i, expected := range u.expect {
+				u.k.ToggleReadOnly()
+				assert.Equal(t, expected, u.k.IsReadOnly(), "toggle #%d", i+1)
+			}
+		})
+	}
+}
+
 func Test_screenDumpDirOverride(t *testing.T) {
 	uu := map[string]struct {
 		dir string

--- a/internal/ui/indicator.go
+++ b/internal/ui/indicator.go
@@ -47,7 +47,19 @@ func (s *StatusIndicator) StylesChanged(styles *config.Styles) {
 	s.SetTextColor(styles.FgColor())
 }
 
-const statusIndicatorFmt = "[%s::b]K9s [%s::]%s [%s::]%s:%s:%s [%s::]%s[%s::]::[%s::]%s"
+const statusIndicatorFmt = "[%s::b]K9s [%s::]%s [%s::]%s:%s:%s %s [%s::]%s[%s::]::[%s::]%s"
+
+func (s *StatusIndicator) roIndicator() string {
+	ic := ROIndicator(s.app.Config.IsReadOnly(), s.app.Config.K9s.UI.NoIcons)
+	if ic == "" {
+		return ""
+	}
+	if s.app.Config.IsReadOnly() {
+		return "[orangered::b]" + ic
+	}
+
+	return "[lawngreen::]" + ic
+}
 
 // ClusterInfoUpdated notifies the cluster meta was updated.
 func (s *StatusIndicator) ClusterInfoUpdated(data *model.ClusterMeta) {
@@ -61,6 +73,7 @@ func (s *StatusIndicator) ClusterInfoUpdated(data *model.ClusterMeta) {
 			data.Context,
 			data.Cluster,
 			data.K8sVer,
+			s.roIndicator(),
 			s.styles.K9s.Info.CPUColor.String(),
 			render.PrintPerc(data.Cpu),
 			s.styles.Body().FgColor.String(),
@@ -85,6 +98,7 @@ func (s *StatusIndicator) ClusterInfoChanged(prev, cur *model.ClusterMeta) {
 			cur.Context,
 			cur.Cluster,
 			cur.K8sVer,
+			s.roIndicator(),
 			s.styles.K9s.Info.CPUColor.String(),
 			AsPercDelta(prev.Cpu, cur.Cpu),
 			s.styles.Body().FgColor.String(),

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -255,6 +255,7 @@ func (a *App) bindKeys() {
 	a.AddActions(ui.NewKeyActionsFromMap(ui.KeyMap{
 		tcell.KeyCtrlE:     ui.NewSharedKeyAction("ToggleHeader", a.toggleHeaderCmd, false),
 		tcell.KeyCtrlG:     ui.NewSharedKeyAction("ToggleCrumbs", a.toggleCrumbsCmd, false),
+		tcell.KeyCtrlT:     ui.NewSharedKeyAction("ToggleReadOnly", a.toggleReadOnlyCmd, false),
 		ui.KeyHelp:         ui.NewSharedKeyAction("Help", a.helpCmd, false),
 		ui.KeyLeftBracket:  ui.NewSharedKeyAction("Go Back", a.previousCommand, false),
 		ui.KeyRightBracket: ui.NewSharedKeyAction("Go Forward", a.nextCommand, false),
@@ -641,6 +642,32 @@ func (a *App) toggleHeaderCmd(evt *tcell.EventKey) *tcell.EventKey {
 		a.showHeader = !a.showHeader
 		a.toggleHeader(a.showHeader, a.showLogo)
 	})
+
+	return nil
+}
+
+func (a *App) toggleReadOnlyCmd(evt *tcell.EventKey) *tcell.EventKey {
+	if a.Prompt().InCmdMode() {
+		return evt
+	}
+
+	a.Config.ToggleReadOnly()
+	if a.clusterModel != nil {
+		a.clusterModel.Refresh()
+	}
+	if top := a.Content.Top(); top != nil {
+		top.Start()
+	}
+	go func() {
+		<-time.After(500 * time.Millisecond)
+		a.QueueUpdateDraw(func() {
+			if a.Config.IsReadOnly() {
+				a.Flash().Info("Read-Only mode enabled")
+			} else {
+				a.Flash().Info("Read-Write mode enabled")
+			}
+		})
+	}()
 
 	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `Ctrl+T` keyboard shortcut to toggle read-only mode at runtime without restarting k9s

Closes #2613