### PR TITLE
fix: prevent index out of range panic in RowEventSorter.Less

### DIFF
--- a/internal/model1/row.go
+++ b/internal/model1/row.go
@@ -79,7 +79,13 @@ func (s RowSorter) Swap(i, j int) {
 }
 
 func (s RowSorter) Less(i, j int) bool {
-	v1, v2 := s.Rows[i].Fields[s.Index], s.Rows[j].Fields[s.Index]
+	v1, v2 := MissingSortValue, MissingSortValue
+	if s.Index < len(s.Rows[i].Fields) {
+		v1 = s.Rows[i].Fields[s.Index]
+	}
+	if s.Index < len(s.Rows[j].Fields) {
+		v2 = s.Rows[j].Fields[s.Index]
+	}
 	id1, id2 := s.Rows[i].ID, s.Rows[j].ID
 	less := Less(s.IsNumber, s.IsDuration, s.IsCapacity, id1, id2, v1, v2)
 	if s.Asc {

--- a/internal/model1/row_event.go
+++ b/internal/model1/row_event.go
@@ -305,7 +305,16 @@ func (r RowEventSorter) Swap(i, j int) {
 func (r RowEventSorter) Less(i, j int) bool {
 	f1, f2 := r.Events.events[i].Row.Fields, r.Events.events[j].Row.Fields
 	id1, id2 := r.Events.events[i].Row.ID, r.Events.events[j].Row.ID
-	less := Less(r.IsNumber, r.IsDuration, r.IsCapacity, id1, id2, f1[r.Index], f2[r.Index])
+
+	v1, v2 := MissingSortValue, MissingSortValue
+	if r.Index < len(f1) {
+		v1 = f1[r.Index]
+	}
+	if r.Index < len(f2) {
+		v2 = f2[r.Index]
+	}
+
+	less := Less(r.IsNumber, r.IsDuration, r.IsCapacity, id1, id2, v1, v2)
 	if r.Asc {
 		return less
 	}

--- a/internal/model1/row_event_test.go
+++ b/internal/model1/row_event_test.go
@@ -490,6 +490,32 @@ func TestRowEventsSort(t *testing.T) {
 				model1.RowEvent{Row: model1.Row{ID: "ns2/C", Fields: model1.Fields{"C", "2", "3", "0.1Ei"}}},
 			),
 		},
+		"short-row-no-panic": {
+			re: model1.NewRowEventsWithEvts(
+				model1.RowEvent{Row: model1.Row{ID: "A", Fields: model1.Fields{"1", "2", "3"}}},
+				model1.RowEvent{Row: model1.Row{ID: "B", Fields: model1.Fields{"0"}}},
+				model1.RowEvent{Row: model1.Row{ID: "C", Fields: model1.Fields{"10", "2", "3"}}},
+			),
+			col: 2,
+			asc: true,
+			e: model1.NewRowEventsWithEvts(
+				model1.RowEvent{Row: model1.Row{ID: "B", Fields: model1.Fields{"0"}}},
+				model1.RowEvent{Row: model1.Row{ID: "A", Fields: model1.Fields{"1", "2", "3"}}},
+				model1.RowEvent{Row: model1.Row{ID: "C", Fields: model1.Fields{"10", "2", "3"}}},
+			),
+		},
+		"all-short-rows": {
+			re: model1.NewRowEventsWithEvts(
+				model1.RowEvent{Row: model1.Row{ID: "B", Fields: model1.Fields{}}},
+				model1.RowEvent{Row: model1.Row{ID: "A", Fields: model1.Fields{}}},
+			),
+			col: 2,
+			asc: true,
+			e: model1.NewRowEventsWithEvts(
+				model1.RowEvent{Row: model1.Row{ID: "A", Fields: model1.Fields{}}},
+				model1.RowEvent{Row: model1.Row{ID: "B", Fields: model1.Fields{}}},
+			),
+		},
 	}
 
 	for k := range uu {

--- a/internal/model1/row_test.go
+++ b/internal/model1/row_test.go
@@ -462,6 +462,50 @@ func TestRowsSortCapacity(t *testing.T) {
 	}
 }
 
+func TestRowsSortShortRows(t *testing.T) {
+	uu := map[string]struct {
+		rows model1.Rows
+		col  int
+		asc  bool
+		e    model1.Rows
+	}{
+		"short-row-no-panic": {
+			rows: model1.Rows{
+				{ID: "A", Fields: []string{"blee", "duh", "zorg"}},
+				{ID: "B", Fields: []string{"albert"}},
+				{ID: "C", Fields: []string{"fred", "blee", "abc"}},
+			},
+			col: 2,
+			asc: true,
+			e: model1.Rows{
+				{ID: "B", Fields: []string{"albert"}},
+				{ID: "C", Fields: []string{"fred", "blee", "abc"}},
+				{ID: "A", Fields: []string{"blee", "duh", "zorg"}},
+			},
+		},
+		"all-short-rows": {
+			rows: model1.Rows{
+				{ID: "B", Fields: []string{}},
+				{ID: "A", Fields: []string{}},
+			},
+			col: 1,
+			asc: true,
+			e: model1.Rows{
+				{ID: "A", Fields: []string{}},
+				{ID: "B", Fields: []string{}},
+			},
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			u.rows.Sort(u.col, u.asc, false, false, false)
+			assert.Equal(t, u.e, u.rows)
+		})
+	}
+}
+
 func TestLess(t *testing.T) {
 	uu := map[string]struct {
 		isNumber   bool

--- a/internal/model1/types.go
+++ b/internal/model1/types.go
@@ -14,6 +14,10 @@ import (
 const (
 	NAValue = "na"
 
+	// MissingSortValue is used as the sort key when a row has fewer fields
+	// than the column being sorted on (e.g. during degraded API responses).
+	MissingSortValue = ""
+
 	// EventUnchanged notifies listener resource has not changed.
 	EventUnchanged ResEvent = 1 << iota
 


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

Adds bounds checking in `RowEventSorter.Less()` and `RowSorter.Less()` to prevent `runtime error: index out of range` panics when some rows have fewer fields than the column being sorted on.

This can happen when the cluster is in a degraded state (e.g. during a network disconnect or API server restart) and some rows receive partial data from the API server. When the table is sorted (either by user interaction or automatic refresh), the sort comparator accesses a field index that doesn't exist in the short row, causing k9s to crash.

## How does it work

Both `RowEventSorter.Less()` and `RowSorter.Less()` now check `r.Index < len(fields)` before accessing the field slice. When a row has fewer fields than the sort column index, an empty string is used as the sort value, which sorts short rows before populated ones and prevents the panic.

## Which issue(s) this PR fixes

Fixes #3925

## How to test

```go
go test ./internal/model1/ -run "TestRowEventsSort/short-row-no-panic|TestRowEventsSort/all-short-rows|TestRowsSortShortRows" -v
```

New test cases cover:
- Sorting when one row has fewer fields than the sort column (`short-row-no-panic`)
- Sorting when all rows have fewer fields than the sort column (`all-short-rows`)
- Both `RowEventSorter` and `RowSorter` code paths