### PR TITLE
Dropdown to disambiguate similar CRDs

### DIFF
--- a/internal/model/fish_buff.go
+++ b/internal/model/fish_buff.go
@@ -93,10 +93,18 @@ func (*FishBuff) AutoSuggests() bool {
 
 // Suggestions returns suggestions.
 func (f *FishBuff) Suggestions() []string {
-	if f.suggestionFn != nil {
-		return f.suggestionFn(string(f.buff))
+	if len(f.suggestions) == 0 {
+		return nil
 	}
-	return nil
+
+	ss := make([]string, len(f.suggestions))
+	copy(ss, f.suggestions)
+	return ss
+}
+
+// SuggestionIndex returns the active suggestion index.
+func (f *FishBuff) SuggestionIndex() int {
+	return f.suggestionIndex
 }
 
 // SetSuggestionFn sets up suggestions.

--- a/internal/model/fish_buff_test.go
+++ b/internal/model/fish_buff_test.go
@@ -70,6 +70,21 @@ func TestFishDelete(t *testing.T) {
 	assert.Equal(t, "blee", c)
 }
 
+func TestFishSuggestions(t *testing.T) {
+	f := model.NewFishBuff(' ', model.FilterBuffer)
+	f.SetSuggestionFn(func(string) sort.StringSlice {
+		return sort.StringSlice{"blee", "brew"}
+	})
+	f.Add('b')
+
+	assert.Equal(t, []string{"blee", "brew"}, f.Suggestions())
+	assert.Equal(t, 0, f.SuggestionIndex())
+
+	_, ok := f.NextSuggestion()
+	assert.True(t, ok)
+	assert.Equal(t, 1, f.SuggestionIndex())
+}
+
 // Helpers...
 
 type mockSuggestionListener struct {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -198,6 +198,11 @@ func (a *App) CmdBuff() *model.FishBuff {
 	return a.cmdBuff
 }
 
+// CommandSuggestions returns the command suggestion overlay.
+func (a *App) CommandSuggestions() *SuggestionDropdown {
+	return a.Prompt().SuggestionDropdown()
+}
+
 // HasCmd check if cmd buffer is active and has a command.
 func (a *App) HasCmd() bool {
 	return a.cmdBuff.IsActive() && !a.cmdBuff.Empty()

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -39,6 +39,15 @@ type Suggester interface {
 	ClearSuggestions()
 }
 
+// SuggestionState exposes current suggestion state.
+type SuggestionState interface {
+	// Suggestions returns the current suggestions.
+	Suggestions() []string
+
+	// SuggestionIndex returns the selected suggestion index.
+	SuggestionIndex() int
+}
+
 // PromptModel represents a prompt buffer.
 type PromptModel interface {
 	// SetText sets the model text.
@@ -85,6 +94,8 @@ type Prompt struct {
 	prefix  rune
 	styles  *config.Styles
 	model   PromptModel
+	kind    model.BufferKind
+	drop    *SuggestionDropdown
 	spacer  int
 	mx      sync.RWMutex
 }
@@ -101,6 +112,7 @@ func NewPrompt(app *App, noIcons bool, styles *config.Styles) *Prompt {
 	if noIcons {
 		p.spacer--
 	}
+	p.drop = NewSuggestionDropdown(&p, styles)
 	p.SetWordWrap(true)
 	p.SetWrap(true)
 	p.SetDynamicColors(true)
@@ -110,6 +122,11 @@ func NewPrompt(app *App, noIcons bool, styles *config.Styles) *Prompt {
 	p.SetInputCapture(p.keyboard)
 
 	return &p
+}
+
+// SuggestionDropdown returns the command suggestion overlay.
+func (p *Prompt) SuggestionDropdown() *SuggestionDropdown {
+	return p.drop
 }
 
 // SendKey sends a keyboard event (testing only!).
@@ -166,35 +183,44 @@ func (p *Prompt) keyboard(evt *tcell.EventKey) *tcell.EventKey {
 		p.model.SetActive(false)
 
 	case tcell.KeyEnter, tcell.KeyCtrlE:
-		p.model.SetText(p.model.GetText(), "", true)
+		p.acceptSuggestion(m, true)
 		p.model.SetActive(false)
 
 	case tcell.KeyCtrlW, tcell.KeyCtrlU:
 		p.model.ClearText(true)
 
 	case tcell.KeyUp:
-		if s, ok := m.NextSuggestion(); ok {
-			p.model.SetText(p.model.GetText(), s, true)
-		}
-
-	case tcell.KeyDown:
 		if s, ok := m.PrevSuggestion(); ok {
 			p.model.SetText(p.model.GetText(), s, true)
 		}
 
-	case tcell.KeyTab, tcell.KeyRight, tcell.KeyCtrlF:
-		if s, ok := m.CurrentSuggestion(); ok {
-			p.model.SetText(p.model.GetText()+s, "", true)
-			m.ClearSuggestions()
+	case tcell.KeyDown:
+		if s, ok := m.NextSuggestion(); ok {
+			p.model.SetText(p.model.GetText(), s, true)
 		}
+
+	case tcell.KeyTab, tcell.KeyRight, tcell.KeyCtrlF:
+		p.acceptSuggestion(m, false)
 	}
 
 	return nil
 }
 
+func (p *Prompt) acceptSuggestion(m Suggester, commandOnly bool) {
+	if s, ok := m.CurrentSuggestion(); ok && (!commandOnly || p.kind == model.CommandBuffer) {
+		p.model.SetText(p.model.GetText()+s, "", true)
+		m.ClearSuggestions()
+		return
+	}
+	p.model.SetText(p.model.GetText(), "", true)
+}
+
 // StylesChanged notifies skin changed.
 func (p *Prompt) StylesChanged(s *config.Styles) {
 	p.styles = s
+	if p.drop != nil {
+		p.drop.styles = s
+	}
 	p.SetBackgroundColor(s.K9s.Prompt.BgColor.Color())
 	p.SetTextColor(s.K9s.Prompt.FgColor.Color())
 }
@@ -210,7 +236,7 @@ func (p *Prompt) InCmdMode() bool {
 func (p *Prompt) activate() {
 	p.Clear()
 	p.SetCursorIndex(len(p.model.GetText()))
-	p.write(p.model.GetText(), p.model.GetSuggestion())
+	p.update(p.model.GetText(), p.model.GetSuggestion())
 	p.model.Notify(false)
 }
 
@@ -230,6 +256,9 @@ func (p *Prompt) Draw(sc tcell.Screen) {
 
 func (p *Prompt) update(text, suggestion string) {
 	p.Clear()
+	if p.showDropdown(text, suggestion) {
+		suggestion = ""
+	}
 	p.write(text, suggestion)
 }
 
@@ -266,6 +295,7 @@ func (p *Prompt) SuggestionChanged(text, suggestion string) {
 // BufferActive indicates the buff activity changed.
 func (p *Prompt) BufferActive(activate bool, kind model.BufferKind) {
 	if activate {
+		p.kind = kind
 		p.ShowCursor(true)
 		p.SetBorder(true)
 		p.SetTextColor(p.styles.FgColor())
@@ -278,7 +308,33 @@ func (p *Prompt) BufferActive(activate bool, kind model.BufferKind) {
 	p.ShowCursor(false)
 	p.SetBorder(false)
 	p.SetBackgroundColor(p.styles.BgColor())
+	if p.drop != nil {
+		p.drop.Clear()
+	}
 	p.Clear()
+}
+
+func (p *Prompt) showDropdown(text, suggestion string) bool {
+	if p.drop == nil || !p.model.IsActive() || p.kind != model.CommandBuffer || suggestion == "" {
+		if p.drop != nil {
+			p.drop.Clear()
+		}
+		return false
+	}
+
+	state, ok := p.model.(SuggestionState)
+	if !ok {
+		p.drop.Clear()
+		return false
+	}
+	suggestions := state.Suggestions()
+	if len(suggestions) == 0 {
+		p.drop.Clear()
+		return false
+	}
+
+	p.drop.Update(text, suggestions, state.SuggestionIndex())
+	return true
 }
 
 func (p *Prompt) prefixesFor(k model.BufferKind) (ic, prefix rune) {

--- a/internal/ui/prompt_test.go
+++ b/internal/ui/prompt_test.go
@@ -4,6 +4,7 @@
 package ui_test
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/derailed/k9s/internal/config"
@@ -98,6 +99,107 @@ func TestPrompt_Deactivate(t *testing.T) {
 		v.Deactivate()
 		assert.False(t, v.InCmdMode())
 	}
+}
+
+func TestPromptCommandSuggestionsUseDropdown(t *testing.T) {
+	m := model.NewFishBuff(':', model.CommandBuffer)
+	m.SetSuggestionFn(func(string) sort.StringSlice {
+		return sort.StringSlice{"line", "lines"}
+	})
+	v := ui.NewPrompt(&ui.App{}, true, config.NewStyles())
+	v.SetModel(m)
+	m.AddListener(v)
+
+	m.SetActive(true)
+	v.SendStrokes("pipe")
+
+	assert.Equal(t, " > [::b]pipe\n", v.GetText(false))
+	assert.True(t, v.SuggestionDropdown().IsActive())
+	assert.Equal(t, []string{"pipeline", "pipelines"}, v.SuggestionDropdown().Items())
+	assert.Equal(t, 0, v.SuggestionDropdown().SelectedIndex())
+}
+
+func TestPromptFilterSuggestionsStayInline(t *testing.T) {
+	m := model.NewFishBuff('/', model.FilterBuffer)
+	m.SetSuggestionFn(func(string) sort.StringSlice {
+		return sort.StringSlice{"line"}
+	})
+	v := ui.NewPrompt(&ui.App{}, true, config.NewStyles())
+	v.SetModel(m)
+	m.AddListener(v)
+
+	m.SetActive(true)
+	v.SendStrokes("pipe")
+
+	assert.Contains(t, v.GetText(false), "line")
+	assert.False(t, v.SuggestionDropdown().IsActive())
+}
+
+func TestPromptCommandNoSuggestionsHidesDropdown(t *testing.T) {
+	m := model.NewFishBuff(':', model.CommandBuffer)
+	m.SetSuggestionFn(func(string) sort.StringSlice {
+		return nil
+	})
+	v := ui.NewPrompt(&ui.App{}, true, config.NewStyles())
+	v.SetModel(m)
+	m.AddListener(v)
+
+	m.SetActive(true)
+	v.SendStrokes("pipe")
+
+	assert.False(t, v.SuggestionDropdown().IsActive())
+}
+
+func TestPromptCommandSuggestionSelectionTracksArrows(t *testing.T) {
+	m := model.NewFishBuff(':', model.CommandBuffer)
+	m.SetSuggestionFn(func(string) sort.StringSlice {
+		return sort.StringSlice{"line", "linerun", "lines"}
+	})
+	v := ui.NewPrompt(&ui.App{}, true, config.NewStyles())
+	v.SetModel(m)
+	m.AddListener(v)
+
+	m.SetActive(true)
+	v.SendStrokes("pipe")
+	v.SendKey(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
+
+	assert.Equal(t, " > [::b]pipe\n", v.GetText(false))
+	assert.Equal(t, 1, v.SuggestionDropdown().SelectedIndex())
+	assert.Equal(t, []string{"pipeline", "pipelinerun", "pipelines"}, v.SuggestionDropdown().Items())
+}
+
+func TestPromptCommandEnterAcceptsSelectedSuggestion(t *testing.T) {
+	m := model.NewFishBuff(':', model.CommandBuffer)
+	m.SetSuggestionFn(func(string) sort.StringSlice {
+		return sort.StringSlice{"line", "linerun"}
+	})
+	v := ui.NewPrompt(&ui.App{}, true, config.NewStyles())
+	v.SetModel(m)
+	m.AddListener(v)
+
+	m.SetActive(true)
+	v.SendStrokes("pipe")
+	v.SendKey(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
+	v.SendKey(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+
+	assert.Equal(t, "pipelinerun", m.GetText())
+	assert.False(t, v.SuggestionDropdown().IsActive())
+}
+
+func TestPromptCommandUpMovesToPreviousSuggestion(t *testing.T) {
+	m := model.NewFishBuff(':', model.CommandBuffer)
+	m.SetSuggestionFn(func(string) sort.StringSlice {
+		return sort.StringSlice{"line", "linerun", "lines"}
+	})
+	v := ui.NewPrompt(&ui.App{}, true, config.NewStyles())
+	v.SetModel(m)
+	m.AddListener(v)
+
+	m.SetActive(true)
+	v.SendStrokes("pipe")
+	v.SendKey(tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone))
+
+	assert.Equal(t, 2, v.SuggestionDropdown().SelectedIndex())
 }
 
 // Tests that, when active, the prompt has the appropriate color

--- a/internal/ui/suggestion_dropdown.go
+++ b/internal/ui/suggestion_dropdown.go
@@ -11,7 +11,7 @@ import (
 	"github.com/derailed/tview"
 )
 
-const maxPromptSuggestions = 5
+const maxPromptSuggestions = 8
 
 // SuggestionDropdown renders command suggestions below the prompt.
 type SuggestionDropdown struct {
@@ -135,7 +135,7 @@ func (d *SuggestionDropdown) Draw(screen tcell.Screen) {
 
 	px, py, pw, ph := d.prompt.GetRect()
 	sw, sh := screen.Size()
-	x, y := px+d.prompt.spacer, py+ph
+	x, y := px+d.prompt.spacer, py+ph-1
 	if x >= sw || y >= sh {
 		return
 	}

--- a/internal/ui/suggestion_dropdown.go
+++ b/internal/ui/suggestion_dropdown.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package ui
+
+import (
+	"sync"
+
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/tcell/v2"
+	"github.com/derailed/tview"
+)
+
+const maxPromptSuggestions = 5
+
+// SuggestionDropdown renders command suggestions below the prompt.
+type SuggestionDropdown struct {
+	*tview.Box
+
+	prompt      *Prompt
+	styles      *config.Styles
+	text        string
+	suggestions []string
+	selected    int
+	active      bool
+	mx          sync.RWMutex
+}
+
+// NewSuggestionDropdown returns a dropdown view for prompt suggestions.
+func NewSuggestionDropdown(p *Prompt, styles *config.Styles) *SuggestionDropdown {
+	d := &SuggestionDropdown{
+		Box:    tview.NewBox(),
+		prompt: p,
+		styles: styles,
+	}
+	d.SetBorder(true)
+	d.SetBackgroundColor(styles.BgColor())
+
+	return d
+}
+
+// Focus keeps keyboard input on the prompt while the overlay is visible.
+func (d *SuggestionDropdown) Focus(delegate func(tview.Primitive)) {
+	if delegate == nil || d.prompt == nil {
+		return
+	}
+	if d.prompt.InCmdMode() {
+		delegate(d.prompt)
+		return
+	}
+	if d.prompt.app != nil {
+		if main := d.prompt.app.Main.GetPrimitive("main"); main != nil {
+			delegate(main)
+		}
+	}
+}
+
+// HasFocus returns false since the overlay never owns keyboard input.
+func (*SuggestionDropdown) HasFocus() bool {
+	return false
+}
+
+// Update refreshes the dropdown state.
+func (d *SuggestionDropdown) Update(text string, suggestions []string, selected int) {
+	d.mx.Lock()
+	defer d.mx.Unlock()
+
+	if len(suggestions) == 0 {
+		d.active = false
+		d.suggestions = nil
+		d.selected = -1
+		d.text = ""
+		return
+	}
+
+	d.text = text
+	d.suggestions = make([]string, len(suggestions))
+	copy(d.suggestions, suggestions)
+	d.selected = selected
+	if d.selected < 0 || d.selected >= len(d.suggestions) {
+		d.selected = 0
+	}
+	d.active = true
+}
+
+// Clear hides the dropdown.
+func (d *SuggestionDropdown) Clear() {
+	d.mx.Lock()
+	defer d.mx.Unlock()
+
+	d.active = false
+	d.suggestions = nil
+	d.selected = -1
+	d.text = ""
+}
+
+// IsActive returns true when the dropdown has suggestions to render.
+func (d *SuggestionDropdown) IsActive() bool {
+	d.mx.RLock()
+	defer d.mx.RUnlock()
+
+	return d.active
+}
+
+// Items returns the rendered suggestion values.
+func (d *SuggestionDropdown) Items() []string {
+	d.mx.RLock()
+	defer d.mx.RUnlock()
+
+	if len(d.suggestions) == 0 {
+		return nil
+	}
+
+	items := make([]string, len(d.suggestions))
+	for i, s := range d.suggestions {
+		items[i] = d.text + s
+	}
+	return items
+}
+
+// SelectedIndex returns the active suggestion index.
+func (d *SuggestionDropdown) SelectedIndex() int {
+	d.mx.RLock()
+	defer d.mx.RUnlock()
+
+	return d.selected
+}
+
+// Draw renders the dropdown below the prompt.
+func (d *SuggestionDropdown) Draw(screen tcell.Screen) {
+	text, suggestions, selected, ok := d.snapshot()
+	if !ok || d.prompt == nil {
+		return
+	}
+
+	px, py, pw, ph := d.prompt.GetRect()
+	sw, sh := screen.Size()
+	x, y := px+d.prompt.spacer, py+ph
+	if x >= sw || y >= sh {
+		return
+	}
+
+	start, rows := suggestionWindow(len(suggestions), selected)
+	if y+rows+2 > sh {
+		rows = sh - y - 2
+	}
+	if rows <= 0 {
+		return
+	}
+
+	width := d.suggestionWidth(text, suggestions[start:start+rows]) + 4
+	if maxWidth := pw - d.prompt.spacer - 1; maxWidth > 0 && width > maxWidth {
+		width = maxWidth
+	}
+	if x+width > sw {
+		width = sw - x
+	}
+	if width <= 2 {
+		return
+	}
+
+	d.SetRect(x, y, width, rows+2)
+	d.SetBorderColor(d.styles.Prompt().Border.CommandColor.Color())
+	d.SetBorderFocusColor(d.styles.Prompt().Border.CommandColor.Color())
+	d.SetBackgroundColor(d.styles.BgColor())
+	d.Box.DrawForSubclass(screen, d)
+
+	ix, iy, iw, _ := d.GetInnerRect()
+	for row := range rows {
+		idx := start + row
+		d.drawRow(screen, ix, iy+row, iw, text+suggestions[idx], idx == selected)
+	}
+}
+
+func (d *SuggestionDropdown) snapshot() (string, []string, int, bool) {
+	d.mx.RLock()
+	defer d.mx.RUnlock()
+
+	if !d.active || len(d.suggestions) == 0 {
+		return "", nil, -1, false
+	}
+
+	ss := make([]string, len(d.suggestions))
+	copy(ss, d.suggestions)
+	return d.text, ss, d.selected, true
+}
+
+func (d *SuggestionDropdown) suggestionWidth(text string, suggestions []string) int {
+	width := 0
+	for _, s := range suggestions {
+		if w := tview.TaggedStringWidth(text + s); w > width {
+			width = w
+		}
+	}
+	return width
+}
+
+func (d *SuggestionDropdown) drawRow(screen tcell.Screen, x, y, width int, text string, selected bool) {
+	fg, bg := d.styles.Prompt().FgColor.Color(), d.styles.BgColor()
+	if selected {
+		fg = d.styles.Table().CursorFgColor.Color()
+		bg = d.styles.Table().CursorBgColor.Color()
+	}
+
+	style := tcell.StyleDefault.Foreground(fg).Background(bg)
+	for col := range width {
+		screen.SetContent(x+col, y, ' ', nil, style)
+	}
+	if width > 2 {
+		x++
+		width -= 2
+	}
+	tview.Print(screen, text, x, y, width, tview.AlignLeft, fg)
+}
+
+func suggestionWindow(count, selected int) (int, int) {
+	if count <= maxPromptSuggestions {
+		return 0, count
+	}
+	if selected < maxPromptSuggestions {
+		return 0, maxPromptSuggestions
+	}
+	return selected - maxPromptSuggestions + 1, maxPromptSuggestions
+}

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -176,6 +176,7 @@ func (a *App) layout(ctx context.Context) {
 	main.AddItem(flash, 1, 1, false)
 
 	a.Main.AddPage("main", main, true, false)
+	a.Main.AddPage("commandSuggestions", a.CommandSuggestions(), false, true)
 	a.toggleHeader(!a.Config.K9s.IsHeadless(), !a.Config.K9s.IsLogoless())
 	if !a.Config.K9s.IsSplashless() {
 		a.Main.AddPage("splash", ui.NewSplash(a.Styles, a.version), true, true)
@@ -553,6 +554,7 @@ func (a *App) Run() error {
 		}
 		a.QueueUpdateDraw(func() {
 			a.Main.SwitchToPage("main")
+			a.Main.ShowPage("commandSuggestions")
 			// if command bar is already active, focus it
 			if a.CmdBuff().IsActive() {
 				a.SetFocus(a.Prompt())
@@ -660,7 +662,11 @@ func (a *App) toggleCrumbsCmd(evt *tcell.EventKey) *tcell.EventKey {
 
 func (a *App) gotoCmd(evt *tcell.EventKey) *tcell.EventKey {
 	if a.CmdBuff().IsActive() && !a.CmdBuff().Empty() {
-		a.gotoResource(a.GetCmd(), "", true, true)
+		cmd := a.GetCmd()
+		if s, ok := a.CmdBuff().CurrentSuggestion(); ok {
+			cmd += s
+		}
+		a.gotoResource(cmd, "", true, true)
 		a.ResetCmd()
 		return nil
 	}


### PR DESCRIPTION
<img width="804" height="350" alt="Screenshot 2026-04-26 at 19 19 17" src="https://github.com/user-attachments/assets/0b510fef-dc28-45d9-9b22-7df2520fce57" />

This is a fix with minimal code changes to tell apart multiple similar crds. 
It behaves equivalently to kubectl.

Potential problems:
- slight ui inconcistency (we don't have this dropdown when filtering a CR). But if you decide you like it, i'm more than happy implementing it there as well
- the same resource is suggested multiple times under different names. This is consistent with the previous behavior, so it's not introducing a regression. I'm happy to fix it too, if requested. Maybe I can use aliases <ctrl+a> as a data source instead?