### PR TITLE
internal/config: load per-context views.yaml

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,16 @@ func (c *Config) ContextAliasesPath() string {
 	return AppContextAliasesFile(ct.GetClusterName(), c.K9s.activeContextName)
 }
 
+// ContextViewsPath returns a context specific views file spec.
+func (c *Config) ContextViewsPath() string {
+	ct, err := c.K9s.ActiveContext()
+	if err != nil {
+		return ""
+	}
+
+	return AppContextViewsFile(ct.GetClusterName(), c.K9s.activeContextName)
+}
+
 // ContextPluginsPath returns a context specific plugins file spec.
 func (c *Config) ContextPluginsPath() (string, error) {
 	ct, err := c.K9s.ActiveContext()

--- a/internal/config/files.go
+++ b/internal/config/files.go
@@ -230,6 +230,11 @@ func AppContextHotkeysFile(cluster, context string) string {
 	return filepath.Join(AppContextsDir, data.SanitizeContextSubpath(cluster, context), "hotkeys.yaml")
 }
 
+// AppContextViewsFile generates a valid context specific views file path.
+func AppContextViewsFile(cluster, context string) string {
+	return filepath.Join(AppContextsDir, data.SanitizeContextSubpath(cluster, context), "views.yaml")
+}
+
 // AppContextConfig generates a valid context config file path.
 func AppContextConfig(cluster, context string) string {
 	return filepath.Join(AppContextDir(cluster, context), data.MainConfigFile)

--- a/internal/config/views.go
+++ b/internal/config/views.go
@@ -113,7 +113,12 @@ func (v *CustomView) Load(path string) error {
 	if err := yaml.Unmarshal(bb, &in); err != nil {
 		return err
 	}
-	v.Views = in.Views
+	if v.Views == nil {
+		v.Views = make(map[string]ViewSetting)
+	}
+	for k, vs := range in.Views {
+		v.Views[k] = vs
+	}
 	v.fireConfigChanged()
 
 	return nil

--- a/internal/config/views_test.go
+++ b/internal/config/views_test.go
@@ -5,6 +5,8 @@ package config_test
 
 import (
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/derailed/k9s/internal/client"
@@ -47,6 +49,56 @@ func TestCustomViewLoad(t *testing.T) {
 			assert.Equal(t, u.e, cfg.Views[u.key].Columns)
 		})
 	}
+}
+
+func TestCustomViewLoadMerge(t *testing.T) {
+	dir := t.TempDir()
+	globalPath := filepath.Join(dir, "global.yaml")
+	ctxPath := filepath.Join(dir, "ctx.yaml")
+
+	globalYAML := []byte(`views:
+  v1/pods:
+    columns:
+      - NAMESPACE
+      - NAME
+      - AGE
+  v1/services:
+    columns:
+      - NAMESPACE
+      - NAME
+`)
+	ctxYAML := []byte(`views:
+  v1/pods:
+    columns:
+      - NAME
+      - IP
+      - NODE
+  v1/configmaps:
+    columns:
+      - NAME
+      - DATA
+`)
+	require.NoError(t, os.WriteFile(globalPath, globalYAML, 0o600))
+	require.NoError(t, os.WriteFile(ctxPath, ctxYAML, 0o600))
+
+	cv := config.NewCustomView()
+	require.NoError(t, cv.Load(globalPath))
+	require.NoError(t, cv.Load(ctxPath))
+
+	// Per-context overrides global on key collision.
+	assert.Equal(t, []string{"NAME", "IP", "NODE"}, cv.Views[client.PodGVR.String()].Columns)
+	// Global-only entries survive.
+	assert.Equal(t, []string{"NAMESPACE", "NAME"}, cv.Views["v1/services"].Columns)
+	// Per-context-only entries are added.
+	assert.Equal(t, []string{"NAME", "DATA"}, cv.Views["v1/configmaps"].Columns)
+
+	// Reset clears prior content before next reload.
+	cv.Reset()
+	assert.Empty(t, cv.Views)
+	require.NoError(t, cv.Load(globalPath))
+	assert.Equal(t, []string{"NAMESPACE", "NAME", "AGE"}, cv.Views[client.PodGVR.String()].Columns)
+	_, hasCtxOnly := cv.Views["v1/configmaps"]
+	assert.False(t, hasCtxOnly)
 }
 
 func TestViewSettingEquals(t *testing.T) {

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -56,11 +56,12 @@ func (c *Configurator) CustomViewsWatcher(ctx context.Context, s synchronizer) e
 		return err
 	}
 
+	ctxViewsFile := c.contextViewsFile()
 	go func() {
 		for {
 			select {
 			case evt := <-w.Events:
-				if evt.Name == config.AppViewsFile && evt.Op != fsnotify.Chmod {
+				if evt.Op != fsnotify.Chmod && (evt.Name == config.AppViewsFile || (ctxViewsFile != "" && evt.Name == ctxViewsFile)) {
 					s.QueueUpdateDraw(func() {
 						if err := c.RefreshCustomViews(); err != nil {
 							slog.Warn("Custom views refresh failed", slogs.Error, err)
@@ -85,6 +86,19 @@ func (c *Configurator) CustomViewsWatcher(ctx context.Context, s synchronizer) e
 	}
 	slog.Debug("Loading custom views", slogs.FileName, config.AppViewsFile)
 
+	if ctxViewsFile != "" {
+		if _, err := os.Stat(ctxViewsFile); err == nil {
+			if err := w.Add(ctxViewsFile); err != nil {
+				slog.Warn("Unable to watch context views file",
+					slogs.FileName, ctxViewsFile,
+					slogs.Error, err,
+				)
+			} else {
+				slog.Debug("Loading context custom views", slogs.FileName, ctxViewsFile)
+			}
+		}
+	}
+
 	return c.RefreshCustomViews()
 }
 
@@ -92,7 +106,21 @@ func (c *Configurator) CustomViewsWatcher(ctx context.Context, s synchronizer) e
 func (c *Configurator) RefreshCustomViews() error {
 	c.CustomView().Reset()
 
-	return c.CustomView().Load(config.AppViewsFile)
+	if err := c.CustomView().Load(config.AppViewsFile); err != nil {
+		return err
+	}
+	if p := c.contextViewsFile(); p != "" {
+		return c.CustomView().Load(p)
+	}
+
+	return nil
+}
+
+func (c *Configurator) contextViewsFile() string {
+	if c.Config == nil {
+		return ""
+	}
+	return c.Config.ContextViewsPath()
 }
 
 // SkinsDirWatcher watches for skin directory file changes.


### PR DESCRIPTION
## Summary
Per-cluster/context `views.yaml` files documented at `$XDG_DATA_HOME/k9s/clusters/<cluster>/<context>/views.yaml` were silently ignored — only the global `$XDG_CONFIG_HOME/k9s/views.yaml` was loaded. Aliases, plugins, and hotkeys all had path builders, `Config` accessors, and loader/watcher hookups for their per-context variants; views had none.

This PR adds the missing wiring:
- New `AppContextViewsFile(cluster, context)` path builder and `Config.ContextViewsPath()` accessor, mirroring the existing pattern.
- `CustomView.Load` merges entries into the existing map instead of replacing it.
- `RefreshCustomViews` loads the global file then overlays the per-context one (per-context keys win on collision).
- The fsnotify watcher tracks both paths when present and is rebuilt on context switch via the existing `Halt`/`Resume` cycle.

## Test plan
- [x] New `TestCustomViewLoadMerge` covers merge, per-context override, and reset.
- [x] `go test ./...` — full suite green.
- [x] `go build ./...` — clean.
- [ ] Manual: drop a `views.yaml` under `$XDG_DATA_HOME/k9s/clusters/<cluster>/<context>/` with different columns from the global file, run k9s, confirm per-context columns are shown; switch to a context without a per-context file and confirm fallback to global; live-edit the per-context file and confirm watcher-triggered reload.