### PR TITLE
Make kanagawa dialogs readable

### DIFF
--- a/skins/kanagawa.yaml
+++ b/skins/kanagawa.yaml
@@ -35,7 +35,7 @@ k9s:
     numKeyColor: *blue
     sectionColor: *purple
   dialog:
-    fgColor: *black
+    fgColor: *orange
     bgColor: *background
     buttonFgColor: *foreground
     buttonBgColor: *green


### PR DESCRIPTION
Before:
<img width="1010" height="521" alt="grafik" src="https://github.com/user-attachments/assets/e8a254e8-bf12-4907-9bc8-617e61834482" />

After:
<img width="1010" height="521" alt="grafik" src="https://github.com/user-attachments/assets/31d0160e-40f7-40ef-a231-cabedcf20d4c" />
