### PR TITLE
feat: add tab support

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,22 @@ K9S_LOGS_DIR=/var/log k9s
 less /var/log/k9s.log
 ```
 
+## Tabs
+
+K9s supports multiple tabs to allow you to quickly switch between different views and resources!
+You can open up to 9 tabs simultaneously. Each tab maintains its own isolated view stack, command interpreter, and navigation/filter histories, while sharing the same underlying cluster connection.
+
+A tab bar appears at the top of the content area whenever more than one tab is open, displaying the tab index and the active resource label.
+
+You can manage tabs using the following key bindings:
+
+| Action                     | Command  | Comment                                                          |
+|----------------------------|----------|------------------------------------------------------------------|
+| Open a new tab             | `ctrl-t` | Opens a new tab pre-loaded with the resource currently on screen |
+| Close the active tab       | `ctrl-x` | Closing the last tab is a no-op                                  |
+| Switch to the next tab     | `ctrl-n` | Wraps around to the first tab                                    |
+| Switch to the previous tab | `ctrl-b` | Wraps around to the last tab                                     |
+
 ## Key Bindings
 
 K9s uses aliases to navigate most K8s resources.

--- a/internal/model/stack.go
+++ b/internal/model/stack.go
@@ -182,6 +182,16 @@ func (s *Stack) notify(a StackAction, c Component) {
 	}
 }
 
+// Repopulate replaces the stack contents with the given components without
+// triggering any lifecycle (Stop/Start) callbacks or notifying listeners.
+// Use this to mirror an external stack snapshot (e.g. when switching tabs).
+func (s *Stack) Repopulate(components []Component) {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+	s.components = make([]Component, len(components))
+	copy(s.components, components)
+}
+
 // ----------------------------------------------------------------------------
 // Helpers...
 

--- a/internal/ui/crumbs.go
+++ b/internal/ui/crumbs.go
@@ -58,6 +58,13 @@ func (c *Crumbs) StackPopped(_, _ model.Component) {
 // StackTop indicates the top of the stack.
 func (*Crumbs) StackTop(model.Component) {}
 
+// Reset rebuilds the crumbs display from a snapshot of the component stack.
+// Call this when switching tabs to replace the previous tab's breadcrumb trail.
+func (c *Crumbs) Reset(components []model.Component) {
+	c.stack.Repopulate(components)
+	c.refresh(c.stack.Flatten())
+}
+
 // Refresh updates view with new crumbs.
 func (c *Crumbs) refresh(crumbs []string) {
 	c.Clear()

--- a/internal/ui/tab_bar.go
+++ b/internal/ui/tab_bar.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/tview"
+)
+
+// TabBar renders the one-line horizontal strip of tab labels shown above the
+// content area whenever more than one tab is open.
+type TabBar struct {
+	*tview.TextView
+	styles *config.Styles
+}
+
+// NewTabBar returns an initialised TabBar attached to the given style set.
+func NewTabBar(styles *config.Styles) *TabBar {
+	t := &TabBar{
+		styles:   styles,
+		TextView: tview.NewTextView(),
+	}
+	t.SetDynamicColors(true)
+	t.SetBorderPadding(0, 0, 1, 1)
+	t.SetBackgroundColor(styles.BgColor())
+	styles.AddListener(t)
+	return t
+}
+
+// StylesChanged implements config.StyleListener.
+func (t *TabBar) StylesChanged(s *config.Styles) {
+	t.styles = s
+	t.SetBackgroundColor(s.BgColor())
+}
+
+// Render redraws the tab strip. activeIdx is the zero-based index of the
+// currently active tab; labels contains one entry per open tab.
+func (t *TabBar) Render(labels []string, activeIdx int) {
+	t.Clear()
+	var sb strings.Builder
+	for i, label := range labels {
+		if i == activeIdx {
+			fmt.Fprintf(&sb, "[black:white:b] %d:%s [-:-:-]  ", i+1, label)
+		} else {
+			fmt.Fprintf(&sb, "[gray:-:-] %d:%s [-:-:-]  ", i+1, label)
+		}
+	}
+	fmt.Fprint(t, sb.String())
+}

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -52,6 +52,7 @@ type App struct {
 	clusterModel  *model.ClusterInfo
 	cmdHistory    *model.History
 	filterHistory *model.History
+	tabManager    *TabManager
 	conRetry      int32
 	showHeader    bool
 	showLogo      bool
@@ -132,6 +133,18 @@ func (a *App) Init(version string, _ int) error {
 	}
 	a.CmdBuff().SetSuggestionFn(a.suggestCommand())
 
+	// Wrap the initial page stack, command and histories into the first
+	// TabSession, then hand control to the TabManager.  From here on layout()
+	// must reference tabManager.contentArea instead of a.Content directly.
+	initialSess := &TabSession{
+		Content:       a.Content,
+		command:       a.command,
+		cmdHistory:    a.cmdHistory,
+		filterHistory: a.filterHistory,
+	}
+	a.tabManager = newTabManager(a)
+	a.tabManager.initWithSession(initialSess)
+
 	a.layout(ctx)
 	a.initSignals()
 
@@ -169,7 +182,7 @@ func (a *App) layout(ctx context.Context) {
 
 	main := tview.NewFlex().SetDirection(tview.FlexRow)
 	main.AddItem(a.statusIndicator(), 1, 1, false)
-	main.AddItem(a.Content, 0, 10, true)
+	main.AddItem(a.tabManager.contentArea, 0, 10, true)
 	if !a.Config.K9s.IsCrumbsless() {
 		main.AddItem(a.Crumbs(), 1, 1, false)
 	}
@@ -262,6 +275,10 @@ func (a *App) bindKeys() {
 		tcell.KeyCtrlA:     ui.NewSharedKeyAction("Aliases", a.aliasCmd, false),
 		tcell.KeyEnter:     ui.NewKeyAction("Goto", a.gotoCmd, false),
 		tcell.KeyCtrlC:     ui.NewKeyAction("Quit", a.quitCmd, false),
+		tcell.KeyCtrlT:     ui.NewSharedKeyAction("NewTab", a.newTabCmd, false),
+		tcell.KeyCtrlX:     ui.NewSharedKeyAction("CloseTab", a.closeTabCmd, false),
+		tcell.KeyCtrlN:     ui.NewSharedKeyAction("NextTab", a.nextTabCmd, false),
+		tcell.KeyCtrlB:     ui.NewSharedKeyAction("PrevTab", a.prevTabCmd, false),
 	}))
 }
 
@@ -807,6 +824,55 @@ func (a *App) inject(c model.Component, clearStack bool) error {
 	}
 	a.Content.Push(c)
 
+	// Keep the tab label in sync with the top-level resource being browsed.
+	if clearStack && a.tabManager != nil {
+		a.tabManager.updateActiveLabel(c.Name())
+	}
+
+	return nil
+}
+
+// newTabCmd opens a new tab pre-loaded with the resource currently on screen.
+func (a *App) newTabCmd(evt *tcell.EventKey) *tcell.EventKey {
+	if a.InCmdMode() {
+		return evt
+	}
+	ctx := context.WithValue(context.Background(), internal.KeyApp, a)
+	if err := a.tabManager.newTab(ctx); err != nil {
+		a.Flash().Err(err)
+		return nil
+	}
+	// Navigate the new tab to the resource that was active in the source tab.
+	a.gotoResource(a.Config.ActiveView(), "", true, false)
+	return nil
+}
+
+// closeTabCmd closes the active tab.  Closing the last tab is a no-op.
+func (a *App) closeTabCmd(evt *tcell.EventKey) *tcell.EventKey {
+	if a.InCmdMode() {
+		return evt
+	}
+	if err := a.tabManager.closeActive(); err != nil {
+		a.Flash().Warn(err.Error())
+	}
+	return nil
+}
+
+// nextTabCmd switches focus to the next tab (wraps around).
+func (a *App) nextTabCmd(evt *tcell.EventKey) *tcell.EventKey {
+	if a.InCmdMode() {
+		return evt
+	}
+	a.tabManager.NextTab()
+	return nil
+}
+
+// prevTabCmd switches focus to the previous tab (wraps around).
+func (a *App) prevTabCmd(evt *tcell.EventKey) *tcell.EventKey {
+	if a.InCmdMode() {
+		return evt
+	}
+	a.tabManager.PrevTab()
 	return nil
 }
 

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -470,6 +470,8 @@ func (a *App) switchNS(ns string) error {
 		return err
 	}
 
+	a.tabManager.switchNS(ns)
+
 	return a.factory.SetActiveNS(ns)
 }
 

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -528,6 +528,9 @@ func (a *App) switchContext(ci *cmd.Interpreter, force bool) error {
 			slogs.View, a.Config.ActiveView(),
 		)
 		a.Flash().Infof("Switching context to %q::%q", contextName, ns)
+		if a.tabManager != nil {
+			a.tabManager.CloseOtherTabs()
+		}
 		a.ReloadStyles()
 		a.gotoResource(a.Config.ActiveView(), "", true, true)
 		if a.clusterModel != nil {

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -807,12 +807,13 @@ func (a *App) aliasCmd(*tcell.EventKey) *tcell.EventKey {
 	return nil
 }
 
-func (a *App) gotoResource(c, path string, clearStack, pushCmd bool) {
+func (a *App) gotoResource(c, path string, clearStack, pushCmd bool) error {
 	err := a.command.run(cmd.NewInterpreter(c), path, clearStack, pushCmd)
 	if err != nil {
 		d := a.Styles.Dialog()
 		dialog.ShowError(&d, a.Content.Pages, err.Error())
 	}
+	return err
 }
 
 func (a *App) inject(c model.Component, clearStack bool) error {
@@ -848,7 +849,16 @@ func (a *App) newTabCmd(evt *tcell.EventKey) *tcell.EventKey {
 		return nil
 	}
 	// Navigate the new tab to the resource that was active in the source tab.
-	a.gotoResource(a.Config.ActiveView(), "", true, false)
+	// gotoResource shows its own error dialog; if navigation fails we still
+	// have to unwind the empty tab we just created so the user isn't left
+	// staring at a blank page after dismissing the dialog.
+	if err := a.gotoResource(a.Config.ActiveView(), "", true, false); err != nil {
+		if closeErr := a.tabManager.closeActive(); closeErr != nil {
+			slog.Warn("Failed to close new tab after navigation error",
+				slogs.Error, closeErr,
+			)
+		}
+	}
 	return nil
 }
 

--- a/internal/view/app_test.go
+++ b/internal/view/app_test.go
@@ -15,5 +15,5 @@ func TestAppNew(t *testing.T) {
 	a := view.NewApp(mock.NewMockConfig(t))
 	_ = a.Init("blee", 10)
 
-	assert.Equal(t, 14, a.GetActions().Len())
+	assert.Equal(t, 18, a.GetActions().Len())
 }

--- a/internal/view/cronjob.go
+++ b/internal/view/cronjob.go
@@ -61,8 +61,8 @@ func (*CronJob) showJobs(app *App, _ ui.Tabular, gvr *client.GVR, fqn string) {
 	}
 
 	ns, _ := client.Namespaced(fqn)
-	if err := app.Config.SetActiveNamespace(ns); err != nil {
-		slog.Error("Unable to set active namespace during show pods", slogs.Error, err)
+	if err := app.switchNS(ns); err != nil {
+		slog.Error("Unable to switch namespace during show pods", slogs.Error, err)
 	}
 	v := NewJob(client.JobGVR)
 	v.SetContextFn(jobCtx(fqn, string(cj.UID)))

--- a/internal/view/helpers.go
+++ b/internal/view/helpers.go
@@ -139,8 +139,8 @@ func showReplicasets(app *App, path string, labelSel labels.Selector, fieldSel s
 	v.SetLabelSelector(labelSel, true)
 
 	ns, _ := client.Namespaced(path)
-	if err := app.Config.SetActiveNamespace(ns); err != nil {
-		slog.Error("Unable to set active namespace during show replicasets", slogs.Error, err)
+	if err := app.switchNS(ns); err != nil {
+		slog.Error("Unable to switch namespace during show replicasets", slogs.Error, err)
 	}
 	if err := app.inject(v, false); err != nil {
 		app.Flash().Err(err)
@@ -153,8 +153,8 @@ func showPods(app *App, path string, labelSel labels.Selector, fieldSel string) 
 	v.SetLabelSelector(labelSel, true)
 
 	ns, _ := client.Namespaced(path)
-	if err := app.Config.SetActiveNamespace(ns); err != nil {
-		slog.Error("Unable to set active namespace during show pods", slogs.Error, err)
+	if err := app.switchNS(ns); err != nil {
+		slog.Error("Unable to switch namespace during show pods", slogs.Error, err)
 	}
 	if err := app.inject(v, false); err != nil {
 		app.Flash().Err(err)

--- a/internal/view/scale_extender.go
+++ b/internal/view/scale_extender.go
@@ -109,20 +109,13 @@ func (s *ScaleExtender) replicasFromReady(_ string) (string, error) {
 }
 
 func (s *ScaleExtender) replicasFromScaleSubresource(sel string) (string, error) {
-	res, err := dao.AccessorFor(s.App().factory, s.GVR())
-	if err != nil {
-		return "", err
-	}
-
-	replicasGetter, ok := res.(dao.ReplicasGetter)
-	if !ok {
-		return "", fmt.Errorf("expecting a replicasGetter resource for %q", s.GVR())
-	}
-
+	var scaler dao.Scaler
+	scaler.Init(s.App().factory, s.GVR())
+	
 	ctx, cancel := context.WithTimeout(context.Background(), s.App().Conn().Config().CallTimeout())
 	defer cancel()
 
-	replicas, err := replicasGetter.Replicas(ctx, sel)
+	replicas, err := scaler.Replicas(ctx, sel)
 	if err != nil {
 		return "", err
 	}
@@ -145,12 +138,11 @@ func (s *ScaleExtender) makeScaleForm(fqns []string) (*tview.Form, error) {
 		// For built-in resources or cases where we can't get the replicas from the CRD, we can
 		// only try to get the number of copies from the READY field.
 		if factor == "0" {
-			replicas, err := s.replicasFromReady(fqns[0])
-			if err != nil {
-				return nil, err
+			if replicas, err := s.replicasFromReady(fqns[0]); err == nil {
+				factor = replicas
+			} else {
+				slog.Warn("Unable to read replicas from ready column", slogs.Error, err)
 			}
-
-			factor = replicas
 		}
 	}
 
@@ -222,7 +214,9 @@ func (s *ScaleExtender) scale(ctx context.Context, path string, replicas int32) 
 	}
 	scaler, ok := res.(dao.Scalable)
 	if !ok {
-		return fmt.Errorf("expecting a scalable resource for %q", s.GVR())
+		var genericScaler dao.Scaler
+		genericScaler.Init(s.App().factory, s.GVR())
+		return genericScaler.Scale(ctx, path, replicas)
 	}
 
 	return scaler.Scale(ctx, path, replicas)

--- a/internal/view/scale_extender.go
+++ b/internal/view/scale_extender.go
@@ -109,13 +109,20 @@ func (s *ScaleExtender) replicasFromReady(_ string) (string, error) {
 }
 
 func (s *ScaleExtender) replicasFromScaleSubresource(sel string) (string, error) {
-	var scaler dao.Scaler
-	scaler.Init(s.App().factory, s.GVR())
-	
+	res, err := dao.AccessorFor(s.App().factory, s.GVR())
+	if err != nil {
+		return "", err
+	}
+
+	replicasGetter, ok := res.(dao.ReplicasGetter)
+	if !ok {
+		return "", fmt.Errorf("expecting a replicasGetter resource for %q", s.GVR())
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), s.App().Conn().Config().CallTimeout())
 	defer cancel()
 
-	replicas, err := scaler.Replicas(ctx, sel)
+	replicas, err := replicasGetter.Replicas(ctx, sel)
 	if err != nil {
 		return "", err
 	}
@@ -138,11 +145,12 @@ func (s *ScaleExtender) makeScaleForm(fqns []string) (*tview.Form, error) {
 		// For built-in resources or cases where we can't get the replicas from the CRD, we can
 		// only try to get the number of copies from the READY field.
 		if factor == "0" {
-			if replicas, err := s.replicasFromReady(fqns[0]); err == nil {
-				factor = replicas
-			} else {
-				slog.Warn("Unable to read replicas from ready column", slogs.Error, err)
+			replicas, err := s.replicasFromReady(fqns[0])
+			if err != nil {
+				return nil, err
 			}
+
+			factor = replicas
 		}
 	}
 
@@ -214,9 +222,7 @@ func (s *ScaleExtender) scale(ctx context.Context, path string, replicas int32) 
 	}
 	scaler, ok := res.(dao.Scalable)
 	if !ok {
-		var genericScaler dao.Scaler
-		genericScaler.Init(s.App().factory, s.GVR())
-		return genericScaler.Scale(ctx, path, replicas)
+		return fmt.Errorf("expecting a scalable resource for %q", s.GVR())
 	}
 
 	return scaler.Scale(ctx, path, replicas)

--- a/internal/view/scale_extender.go
+++ b/internal/view/scale_extender.go
@@ -124,7 +124,9 @@ func (s *ScaleExtender) replicasFromScaleSubresource(sel string) (string, error)
 }
 
 func (s *ScaleExtender) makeScaleForm(fqns []string) (*tview.Form, error) {
-	factor := "0"
+	// Use empty string as the "unknown" sentinel so a legitimate current
+	// replica count of 0 (e.g., paused workload) is not treated as failure.
+	factor := ""
 	if len(fqns) == 1 {
 		// If the CRD resource supports scaling, then first try to
 		// read the replicas directly from the CRD.
@@ -137,13 +139,30 @@ func (s *ScaleExtender) makeScaleForm(fqns []string) (*tview.Form, error) {
 
 		// For built-in resources or cases where we can't get the replicas from the CRD, we can
 		// only try to get the number of copies from the READY field.
-		if factor == "0" {
-			if replicas, err := s.replicasFromReady(fqns[0]); err == nil {
+		var readyErr error
+		if factor == "" {
+			replicas, err := s.replicasFromReady(fqns[0])
+			if err == nil {
 				factor = replicas
 			} else {
+				readyErr = err
 				slog.Warn("Unable to read replicas from ready column", slogs.Error, err)
 			}
 		}
+
+		// Refuse to open the dialog when we cannot determine the current
+		// replica count — otherwise a user hitting OK without editing would
+		// silently scale the workload to zero.
+		if factor == "" {
+			if readyErr != nil {
+				return nil, fmt.Errorf("unable to determine current replica count: %w", readyErr)
+			}
+			return nil, fmt.Errorf("unable to determine current replica count for %s", fqns[0])
+		}
+	} else {
+		// Bulk-scale: there is no single "current" value to pre-fill, so the
+		// user must explicitly enter a target.  Keep the documented default.
+		factor = "0"
 	}
 
 	styles := s.App().Styles.Dialog()

--- a/internal/view/scale_extender.go
+++ b/internal/view/scale_extender.go
@@ -124,9 +124,7 @@ func (s *ScaleExtender) replicasFromScaleSubresource(sel string) (string, error)
 }
 
 func (s *ScaleExtender) makeScaleForm(fqns []string) (*tview.Form, error) {
-	// Use empty string as the "unknown" sentinel so a legitimate current
-	// replica count of 0 (e.g., paused workload) is not treated as failure.
-	factor := ""
+	factor := "0"
 	if len(fqns) == 1 {
 		// If the CRD resource supports scaling, then first try to
 		// read the replicas directly from the CRD.
@@ -139,30 +137,13 @@ func (s *ScaleExtender) makeScaleForm(fqns []string) (*tview.Form, error) {
 
 		// For built-in resources or cases where we can't get the replicas from the CRD, we can
 		// only try to get the number of copies from the READY field.
-		var readyErr error
-		if factor == "" {
-			replicas, err := s.replicasFromReady(fqns[0])
-			if err == nil {
+		if factor == "0" {
+			if replicas, err := s.replicasFromReady(fqns[0]); err == nil {
 				factor = replicas
 			} else {
-				readyErr = err
 				slog.Warn("Unable to read replicas from ready column", slogs.Error, err)
 			}
 		}
-
-		// Refuse to open the dialog when we cannot determine the current
-		// replica count — otherwise a user hitting OK without editing would
-		// silently scale the workload to zero.
-		if factor == "" {
-			if readyErr != nil {
-				return nil, fmt.Errorf("unable to determine current replica count: %w", readyErr)
-			}
-			return nil, fmt.Errorf("unable to determine current replica count for %s", fqns[0])
-		}
-	} else {
-		// Bulk-scale: there is no single "current" value to pre-fill, so the
-		// user must explicitly enter a target.  Keep the documented default.
-		factor = "0"
 	}
 
 	styles := s.App().Styles.Dialog()

--- a/internal/view/tab_manager.go
+++ b/internal/view/tab_manager.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/derailed/k9s/internal/model"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/tview"
+)
+
+const maxTabs = 9
+
+// TabManager orchestrates multiple tab sessions within a shared tview layout.
+//
+// Layout hierarchy (replaces the bare Content slot in the main Flex):
+//
+//	contentArea  *tview.Flex  (FlexRow)
+//	  ├── tabBar  *ui.TabBar    (1 line, visible only when len(sessions) > 1)
+//	  └── container *tview.Pages (one page per TabSession)
+//
+// The K8s factory, cluster model, and application styles are shared across all
+// sessions.  Each session owns its view stack, command interpreter and
+// navigation histories.
+type TabManager struct {
+	sessions      []*TabSession
+	activeIdx     int
+	nextID        int
+	container     *tview.Pages
+	tabBar        *ui.TabBar
+	contentArea   *tview.Flex
+	tabBarVisible bool
+	app           *App
+	mu            sync.RWMutex
+}
+
+// newTabManager constructs a TabManager without any sessions.
+// Call initWithSession to seed the first session.
+func newTabManager(app *App) *TabManager {
+	tm := &TabManager{
+		app:       app,
+		container: tview.NewPages(),
+		tabBar:    ui.NewTabBar(app.Styles),
+	}
+	tm.contentArea = tview.NewFlex().SetDirection(tview.FlexRow)
+	tm.contentArea.AddItem(tm.container, 0, 1, true)
+	return tm
+}
+
+// initWithSession registers sess as the first tab.  The session's Content,
+// command and histories must already be initialised by the caller (app.Init
+// does this before calling initWithSession).  Crumbs and Menu listeners have
+// already been attached to sess.Content by app.Init as well.
+func (tm *TabManager) initWithSession(sess *TabSession) {
+	sess.id = tm.nextID
+	tm.nextID++
+	tm.sessions = []*TabSession{sess}
+	tm.activeIdx = 0
+	tm.container.AddPage(tm.pageKey(sess.id), sess.Content, true, true)
+}
+
+// Active returns the currently active session.
+func (tm *TabManager) Active() *TabSession {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	return tm.sessions[tm.activeIdx]
+}
+
+// Count returns the number of open tabs.
+func (tm *TabManager) Count() int {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	return len(tm.sessions)
+}
+
+// newTab creates a new session, activates it, and registers its page in the
+// container.  The caller is responsible for navigating the new session to the
+// desired resource after newTab returns.
+// Must be called on the tview main goroutine.
+func (tm *TabManager) newTab(ctx context.Context) error {
+	tm.mu.Lock()
+	if len(tm.sessions) >= maxTabs {
+		tm.mu.Unlock()
+		return fmt.Errorf("maximum %d tabs allowed", maxTabs)
+	}
+	id := tm.nextID
+	tm.nextID++
+	tm.mu.Unlock()
+
+	sess := &TabSession{
+		id:            id,
+		Content:       NewPageStack(),
+		cmdHistory:    model.NewHistory(model.MaxHistory),
+		filterHistory: model.NewHistory(model.MaxHistory),
+		label:         "",
+	}
+
+	if err := sess.Content.Init(ctx); err != nil {
+		return fmt.Errorf("init tab content: %w", err)
+	}
+
+	cmd := NewCommand(tm.app)
+	if err := cmd.Init(tm.app.Config.ContextAliasesPath()); err != nil {
+		return fmt.Errorf("init tab command: %w", err)
+	}
+	sess.command = cmd
+
+	tm.mu.Lock()
+	tm.sessions = append(tm.sessions, sess)
+	newIdx := len(tm.sessions) - 1
+	tm.mu.Unlock()
+
+	tm.container.AddPage(tm.pageKey(sess.id), sess.Content, true, false)
+	tm.activateSession(newIdx)
+	tm.refreshTabBar()
+
+	return nil
+}
+
+// closeActive closes the active tab, switches to an adjacent one, and stops
+// all components belonging to the closed session.
+// Returns an error when the last tab is requested to be closed.
+// Must be called on the tview main goroutine.
+func (tm *TabManager) closeActive() error {
+	tm.mu.Lock()
+	if len(tm.sessions) <= 1 {
+		tm.mu.Unlock()
+		return fmt.Errorf("cannot close the last tab")
+	}
+
+	idx := tm.activeIdx
+	sess := tm.sessions[idx]
+
+	// Prefer the right neighbour; fall back to the left one.
+	nextIdx := idx
+	if idx >= len(tm.sessions)-1 {
+		nextIdx = idx - 1
+	}
+	// After removal, an element originally to the right of idx shifts left by
+	// one, landing at idx — so nextIdx stays correct when nextIdx == idx.
+
+	tm.sessions = append(tm.sessions[:idx], tm.sessions[idx+1:]...)
+	tm.mu.Unlock()
+
+	// Switch app state to the target session (rewires listeners).
+	tm.activateSession(nextIdx)
+
+	// Stop all view components belonging to the closed session.
+	// Clear() internally calls StackTop() which may redirect focus to
+	// intermediate components of the now-closed session.  Restore focus
+	// explicitly afterwards.
+	sess.Content.Clear()
+	tm.container.RemovePage(tm.pageKey(sess.id))
+
+	// Re-establish focus on the new session's top component, which may have
+	// been overwritten by the PageStack.StackTop callbacks fired during Clear().
+	if top := tm.app.Content.Top(); top != nil {
+		tm.app.SetFocus(top)
+	}
+
+	tm.refreshTabBar()
+	return nil
+}
+
+// SwitchTo activates the tab at the given zero-based slice index.
+// Must be called on the tview main goroutine.
+func (tm *TabManager) SwitchTo(idx int) {
+	tm.mu.RLock()
+	count := len(tm.sessions)
+	tm.mu.RUnlock()
+
+	if idx < 0 || idx >= count {
+		return
+	}
+	tm.activateSession(idx)
+	tm.refreshTabBar()
+}
+
+// NextTab activates the tab to the right, wrapping around.
+func (tm *TabManager) NextTab() {
+	tm.mu.RLock()
+	count := len(tm.sessions)
+	cur := tm.activeIdx
+	tm.mu.RUnlock()
+
+	if count <= 1 {
+		return
+	}
+	tm.SwitchTo((cur + 1) % count)
+}
+
+// PrevTab activates the tab to the left, wrapping around.
+func (tm *TabManager) PrevTab() {
+	tm.mu.RLock()
+	count := len(tm.sessions)
+	cur := tm.activeIdx
+	tm.mu.RUnlock()
+
+	if count <= 1 {
+		return
+	}
+	tm.SwitchTo((cur - 1 + count) % count)
+}
+
+// updateActiveLabel updates the label shown for the active tab.
+// Must be called on the tview main goroutine.
+func (tm *TabManager) updateActiveLabel(label string) {
+	tm.mu.Lock()
+	tm.sessions[tm.activeIdx].label = label
+	tm.mu.Unlock()
+	tm.refreshTabBar()
+}
+
+// activateSession rewires the app's mutable state pointers (Content, command,
+// histories) to the session at idx and brings its page to the front.
+// Must be called on the tview main goroutine.
+func (tm *TabManager) activateSession(idx int) {
+	app := tm.app
+
+	tm.mu.Lock()
+	if idx < 0 || idx >= len(tm.sessions) {
+		tm.mu.Unlock()
+		return
+	}
+	newSess := tm.sessions[idx]
+	oldContent := app.Content
+	// Guard: if the target session is already active there is nothing to do.
+	if oldContent == newSess.Content {
+		tm.activeIdx = idx
+		tm.mu.Unlock()
+		return
+	}
+	tm.activeIdx = idx
+	tm.mu.Unlock()
+
+	// Detach breadcrumbs and menu from the outgoing content so they no longer
+	// receive push/pop events from the tab we are leaving.
+	if oldContent != nil {
+		oldContent.RemoveListener(app.Crumbs())
+		oldContent.RemoveListener(app.Menu())
+	}
+
+	// Swap the active-session pointers in App.  All existing code paths that
+	// reference app.Content / app.command / app.cmdHistory / app.filterHistory
+	// automatically operate on the new tab from this point on.
+	app.Content = newSess.Content
+	app.command = newSess.command
+	app.cmdHistory = newSess.cmdHistory
+	app.filterHistory = newSess.filterHistory
+
+	// Rebuild breadcrumbs to reflect the incoming tab's navigation history.
+	app.Crumbs().Reset(newSess.Content.Peek())
+
+	// Attach breadcrumbs and menu to the incoming content.
+	newSess.Content.AddListener(app.Crumbs())
+	newSess.Content.AddListener(app.Menu())
+
+	// Bring the new session's page to the front of the container.
+	tm.container.SwitchToPage(tm.pageKey(newSess.id))
+
+	// Restart and focus the top-most component of the incoming session.
+	if top := newSess.Content.Top(); top != nil {
+		top.Start()
+		app.SetFocus(top)
+	}
+}
+
+// refreshTabBar shows or hides the tab bar strip and re-renders its labels.
+// Must be called on the tview main goroutine.
+func (tm *TabManager) refreshTabBar() {
+	tm.mu.RLock()
+	count := len(tm.sessions)
+	active := tm.activeIdx
+	labels := make([]string, count)
+	for i, s := range tm.sessions {
+		labels[i] = s.label
+	}
+	tm.mu.RUnlock()
+
+	showBar := count > 1
+	switch {
+	case showBar && !tm.tabBarVisible:
+		tm.contentArea.AddItemAtIndex(0, tm.tabBar, 1, 1, false)
+		tm.tabBarVisible = true
+	case !showBar && tm.tabBarVisible:
+		tm.contentArea.RemoveItemAtIndex(0)
+		tm.tabBarVisible = false
+	}
+	if showBar {
+		tm.tabBar.Render(labels, active)
+	}
+}
+
+func (tm *TabManager) pageKey(id int) string {
+	return fmt.Sprintf("tab-%d", id)
+}

--- a/internal/view/tab_manager.go
+++ b/internal/view/tab_manager.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/derailed/k9s/internal/dao"
 	"github.com/derailed/k9s/internal/model"
 	"github.com/derailed/k9s/internal/ui"
 	"github.com/derailed/tview"
@@ -332,4 +333,26 @@ func (tm *TabManager) refreshTabBar() {
 
 func (tm *TabManager) pageKey(id int) string {
 	return fmt.Sprintf("tab-%d", id)
+}
+
+// switchNS switches the namespace for all open sessions.
+func (tm *TabManager) switchNS(ns string) {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+
+	for _, sess := range tm.sessions {
+		sess.cmdHistory.SwitchNS(ns)
+		for _, c := range sess.Content.Peek() {
+			if rv, ok := c.(ResourceViewer); ok {
+				if namespaced, err := dao.MetaAccess.IsNamespaced(rv.GVR()); err == nil && !namespaced {
+					continue
+				}
+				if b, ok := rv.(*Browser); ok {
+					b.setNamespace(ns)
+				} else {
+					rv.GetTable().GetModel().SetNamespace(ns)
+				}
+			}
+		}
+	}
 }

--- a/internal/view/tab_manager.go
+++ b/internal/view/tab_manager.go
@@ -166,6 +166,41 @@ func (tm *TabManager) closeActive() error {
 	return nil
 }
 
+// CloseOtherTabs closes all tabs except the currently active one.
+// Must be called on the tview main goroutine.
+func (tm *TabManager) CloseOtherTabs() {
+	tm.mu.Lock()
+	if len(tm.sessions) <= 1 {
+		tm.mu.Unlock()
+		return
+	}
+
+	activeSess := tm.sessions[tm.activeIdx]
+	var toClose []*TabSession
+	for i, sess := range tm.sessions {
+		if i != tm.activeIdx {
+			toClose = append(toClose, sess)
+		}
+	}
+
+	tm.sessions = []*TabSession{activeSess}
+	tm.activeIdx = 0
+	tm.mu.Unlock()
+
+	for _, sess := range toClose {
+		sess.Content.Clear()
+		tm.container.RemovePage(tm.pageKey(sess.id))
+	}
+
+	// Re-establish focus on the new session's top component, which may have
+	// been overwritten by the PageStack.StackTop callbacks fired during Clear().
+	if top := tm.app.Content.Top(); top != nil {
+		tm.app.SetFocus(top)
+	}
+
+	tm.refreshTabBar()
+}
+
 // SwitchTo activates the tab at the given zero-based slice index.
 // Must be called on the tview main goroutine.
 func (tm *TabManager) SwitchTo(idx int) {

--- a/internal/view/tab_manager.go
+++ b/internal/view/tab_manager.go
@@ -6,7 +6,6 @@ package view
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/derailed/k9s/internal/dao"
 	"github.com/derailed/k9s/internal/model"
@@ -27,6 +26,11 @@ const maxTabs = 9
 // The K8s factory, cluster model, and application styles are shared across all
 // sessions.  Each session owns its view stack, command interpreter and
 // navigation histories.
+//
+// Concurrency: every method on TabManager must be called from the tview main
+// goroutine.  Call sites running on other goroutines must wrap invocations in
+// app.QueueUpdateDraw.  This single-writer contract is what allows the type
+// to omit explicit synchronization.
 type TabManager struct {
 	sessions      []*TabSession
 	activeIdx     int
@@ -36,7 +40,6 @@ type TabManager struct {
 	contentArea   *tview.Flex
 	tabBarVisible bool
 	app           *App
-	mu            sync.RWMutex
 }
 
 // newTabManager constructs a TabManager without any sessions.
@@ -66,15 +69,11 @@ func (tm *TabManager) initWithSession(sess *TabSession) {
 
 // Active returns the currently active session.
 func (tm *TabManager) Active() *TabSession {
-	tm.mu.RLock()
-	defer tm.mu.RUnlock()
 	return tm.sessions[tm.activeIdx]
 }
 
 // Count returns the number of open tabs.
 func (tm *TabManager) Count() int {
-	tm.mu.RLock()
-	defer tm.mu.RUnlock()
 	return len(tm.sessions)
 }
 
@@ -83,17 +82,12 @@ func (tm *TabManager) Count() int {
 // desired resource after newTab returns.
 // Must be called on the tview main goroutine.
 func (tm *TabManager) newTab(ctx context.Context) error {
-	tm.mu.Lock()
 	if len(tm.sessions) >= maxTabs {
-		tm.mu.Unlock()
 		return fmt.Errorf("maximum %d tabs allowed", maxTabs)
 	}
-	id := tm.nextID
-	tm.nextID++
-	tm.mu.Unlock()
 
 	sess := &TabSession{
-		id:            id,
+		id:            tm.nextID,
 		Content:       NewPageStack(),
 		cmdHistory:    model.NewHistory(model.MaxHistory),
 		filterHistory: model.NewHistory(model.MaxHistory),
@@ -106,14 +100,16 @@ func (tm *TabManager) newTab(ctx context.Context) error {
 
 	cmd := NewCommand(tm.app)
 	if err := cmd.Init(tm.app.Config.ContextAliasesPath()); err != nil {
+		// Roll back the already-initialised PageStack so it doesn't outlive
+		// this failed newTab call as an orphaned, listener-attached primitive.
+		sess.Content.Clear()
 		return fmt.Errorf("init tab command: %w", err)
 	}
 	sess.command = cmd
 
-	tm.mu.Lock()
+	tm.nextID++
 	tm.sessions = append(tm.sessions, sess)
 	newIdx := len(tm.sessions) - 1
-	tm.mu.Unlock()
 
 	tm.container.AddPage(tm.pageKey(sess.id), sess.Content, true, false)
 	tm.activateSession(newIdx)
@@ -127,9 +123,7 @@ func (tm *TabManager) newTab(ctx context.Context) error {
 // Returns an error when the last tab is requested to be closed.
 // Must be called on the tview main goroutine.
 func (tm *TabManager) closeActive() error {
-	tm.mu.Lock()
 	if len(tm.sessions) <= 1 {
-		tm.mu.Unlock()
 		return fmt.Errorf("cannot close the last tab")
 	}
 
@@ -145,7 +139,6 @@ func (tm *TabManager) closeActive() error {
 	// one, landing at idx — so nextIdx stays correct when nextIdx == idx.
 
 	tm.sessions = append(tm.sessions[:idx], tm.sessions[idx+1:]...)
-	tm.mu.Unlock()
 
 	// Switch app state to the target session (rewires listeners).
 	tm.activateSession(nextIdx)
@@ -170,14 +163,12 @@ func (tm *TabManager) closeActive() error {
 // CloseOtherTabs closes all tabs except the currently active one.
 // Must be called on the tview main goroutine.
 func (tm *TabManager) CloseOtherTabs() {
-	tm.mu.Lock()
 	if len(tm.sessions) <= 1 {
-		tm.mu.Unlock()
 		return
 	}
 
 	activeSess := tm.sessions[tm.activeIdx]
-	var toClose []*TabSession
+	toClose := make([]*TabSession, 0, len(tm.sessions)-1)
 	for i, sess := range tm.sessions {
 		if i != tm.activeIdx {
 			toClose = append(toClose, sess)
@@ -186,9 +177,16 @@ func (tm *TabManager) CloseOtherTabs() {
 
 	tm.sessions = []*TabSession{activeSess}
 	tm.activeIdx = 0
-	tm.mu.Unlock()
 
 	for _, sess := range toClose {
+		// Defensively detach app-wide listeners before Clear(), since Clear
+		// fires StackPopped → StackTop callbacks on every remaining listener.
+		// The invariant today is that only the active tab carries Crumbs/Menu
+		// listeners (activateSession hands them over on every switch), so
+		// these RemoveListener calls are normally no-ops, but they protect us
+		// from regressions if that invariant ever loosens.
+		sess.Content.RemoveListener(tm.app.Crumbs())
+		sess.Content.RemoveListener(tm.app.Menu())
 		sess.Content.Clear()
 		tm.container.RemovePage(tm.pageKey(sess.id))
 	}
@@ -205,11 +203,7 @@ func (tm *TabManager) CloseOtherTabs() {
 // SwitchTo activates the tab at the given zero-based slice index.
 // Must be called on the tview main goroutine.
 func (tm *TabManager) SwitchTo(idx int) {
-	tm.mu.RLock()
-	count := len(tm.sessions)
-	tm.mu.RUnlock()
-
-	if idx < 0 || idx >= count {
+	if idx < 0 || idx >= len(tm.sessions) {
 		return
 	}
 	tm.activateSession(idx)
@@ -218,36 +212,26 @@ func (tm *TabManager) SwitchTo(idx int) {
 
 // NextTab activates the tab to the right, wrapping around.
 func (tm *TabManager) NextTab() {
-	tm.mu.RLock()
 	count := len(tm.sessions)
-	cur := tm.activeIdx
-	tm.mu.RUnlock()
-
 	if count <= 1 {
 		return
 	}
-	tm.SwitchTo((cur + 1) % count)
+	tm.SwitchTo((tm.activeIdx + 1) % count)
 }
 
 // PrevTab activates the tab to the left, wrapping around.
 func (tm *TabManager) PrevTab() {
-	tm.mu.RLock()
 	count := len(tm.sessions)
-	cur := tm.activeIdx
-	tm.mu.RUnlock()
-
 	if count <= 1 {
 		return
 	}
-	tm.SwitchTo((cur - 1 + count) % count)
+	tm.SwitchTo((tm.activeIdx - 1 + count) % count)
 }
 
 // updateActiveLabel updates the label shown for the active tab.
 // Must be called on the tview main goroutine.
 func (tm *TabManager) updateActiveLabel(label string) {
-	tm.mu.Lock()
 	tm.sessions[tm.activeIdx].label = label
-	tm.mu.Unlock()
 	tm.refreshTabBar()
 }
 
@@ -255,23 +239,29 @@ func (tm *TabManager) updateActiveLabel(label string) {
 // histories) to the session at idx and brings its page to the front.
 // Must be called on the tview main goroutine.
 func (tm *TabManager) activateSession(idx int) {
-	app := tm.app
-
-	tm.mu.Lock()
 	if idx < 0 || idx >= len(tm.sessions) {
-		tm.mu.Unlock()
 		return
 	}
+
+	app := tm.app
 	newSess := tm.sessions[idx]
 	oldContent := app.Content
+
 	// Guard: if the target session is already active there is nothing to do.
 	if oldContent == newSess.Content {
 		tm.activeIdx = idx
-		tm.mu.Unlock()
 		return
 	}
 	tm.activeIdx = idx
-	tm.mu.Unlock()
+
+	// Stop the outgoing tab's top component so its data-watch goroutines,
+	// informers and tickers terminate.  Without this every tab switch would
+	// leak goroutines and stack watchers on the API server.
+	if oldContent != nil {
+		if top := oldContent.Top(); top != nil {
+			top.Stop()
+		}
+	}
 
 	// Detach breadcrumbs and menu from the outgoing content so they no longer
 	// receive push/pop events from the tab we are leaving.
@@ -308,14 +298,11 @@ func (tm *TabManager) activateSession(idx int) {
 // refreshTabBar shows or hides the tab bar strip and re-renders its labels.
 // Must be called on the tview main goroutine.
 func (tm *TabManager) refreshTabBar() {
-	tm.mu.RLock()
 	count := len(tm.sessions)
-	active := tm.activeIdx
 	labels := make([]string, count)
 	for i, s := range tm.sessions {
 		labels[i] = s.label
 	}
-	tm.mu.RUnlock()
 
 	showBar := count > 1
 	switch {
@@ -327,7 +314,7 @@ func (tm *TabManager) refreshTabBar() {
 		tm.tabBarVisible = false
 	}
 	if showBar {
-		tm.tabBar.Render(labels, active)
+		tm.tabBar.Render(labels, tm.activeIdx)
 	}
 }
 
@@ -336,23 +323,31 @@ func (tm *TabManager) pageKey(id int) string {
 }
 
 // switchNS switches the namespace for all open sessions.
+// Must be called on the tview main goroutine.
 func (tm *TabManager) switchNS(ns string) {
-	tm.mu.RLock()
-	defer tm.mu.RUnlock()
-
 	for _, sess := range tm.sessions {
 		sess.cmdHistory.SwitchNS(ns)
 		for _, c := range sess.Content.Peek() {
-			if rv, ok := c.(ResourceViewer); ok {
-				if namespaced, err := dao.MetaAccess.IsNamespaced(rv.GVR()); err == nil && !namespaced {
-					continue
-				}
-				if b, ok := rv.(*Browser); ok {
-					b.setNamespace(ns)
-				} else {
-					rv.GetTable().GetModel().SetNamespace(ns)
-				}
+			rv, ok := c.(ResourceViewer)
+			if !ok {
+				continue
 			}
+			if namespaced, err := dao.MetaAccess.IsNamespaced(rv.GVR()); err == nil && !namespaced {
+				continue
+			}
+			if b, ok := rv.(*Browser); ok {
+				b.setNamespace(ns)
+				continue
+			}
+			tbl := rv.GetTable()
+			if tbl == nil {
+				continue
+			}
+			m := tbl.GetModel()
+			if m == nil {
+				continue
+			}
+			m.SetNamespace(ns)
 		}
 	}
 }

--- a/internal/view/tab_manager_int_test.go
+++ b/internal/view/tab_manager_int_test.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/derailed/k9s/internal"
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/config/mock"
+	"github.com/derailed/k9s/internal/model"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/k9s/internal/view/cmd"
+	"github.com/derailed/tcell/v2"
+	"github.com/derailed/tview"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// ---------------------------------------------------------------------------
+// Test fix #1 — outgoing top is Stop()'d on tab switch (no goroutine leak).
+// ---------------------------------------------------------------------------
+
+func TestActivateSession_StopsOutgoingTop(t *testing.T) {
+	app := view_newAppForTest(t)
+	require.NotNil(t, app.tabManager)
+	require.Equal(t, 1, app.tabManager.Count())
+
+	// Open a second tab so we have something to switch between.
+	ctx := context.WithValue(context.Background(), internal.KeyApp, app)
+	require.NoError(t, app.tabManager.newTab(ctx))
+	require.Equal(t, 2, app.tabManager.Count())
+
+	// Push a counting component onto each tab's PageStack.  Pushing notifies
+	// the PageStack listener which calls Start() — that's expected setup
+	// noise; we reset counters before the actual assertions.
+	c0 := newCountingComp("tab-0-top")
+	c1 := newCountingComp("tab-1-top")
+	app.tabManager.sessions[0].Content.Push(c0)
+	app.tabManager.sessions[1].Content.Push(c1)
+
+	// After both pushes, the active tab is sessions[1] (set by newTab above).
+	// Force a known starting point and reset the counters.
+	app.tabManager.SwitchTo(1)
+	c0.reset()
+	c1.reset()
+
+	// Switching to tab 0 must Stop() c1 (outgoing) and Start() c0 (incoming).
+	app.tabManager.SwitchTo(0)
+	assert.Equal(t, int32(1), c1.stops.Load(), "outgoing top should be Stop()'d on switch")
+	assert.Equal(t, int32(1), c0.starts.Load(), "incoming top should be Start()'d on switch")
+
+	// Switching back must Stop() c0 and Start() c1.
+	app.tabManager.SwitchTo(1)
+	assert.Equal(t, int32(1), c0.stops.Load(), "outgoing top should be Stop()'d on switch back")
+	assert.Equal(t, int32(1), c1.starts.Load(), "incoming top should be Start()'d on switch back")
+
+	// Round-trip again — counters increment by exactly one per side.
+	app.tabManager.SwitchTo(0)
+	assert.Equal(t, int32(2), c1.stops.Load())
+	assert.Equal(t, int32(2), c0.starts.Load())
+}
+
+// ---------------------------------------------------------------------------
+// Test fix #2 — switchNS does not panic when ResourceViewer returns nil from
+// GetTable() or from GetTable().GetModel().
+// ---------------------------------------------------------------------------
+
+func TestSwitchNS_NoPanicOnNilTableOrModel(t *testing.T) {
+	app := view_newAppForTest(t)
+
+	// Stub viewer with nil Table.
+	nilTableViewer := &stubResourceViewer{
+		name:  "nil-table",
+		gvr:   client.PodGVR,
+		table: nil,
+	}
+
+	// Stub viewer with non-nil Table but uninitialised (nil) embedded model.
+	bareTable := &Table{Table: ui.NewTable(client.PodGVR)}
+	nilModelViewer := &stubResourceViewer{
+		name:  "nil-model",
+		gvr:   client.PodGVR,
+		table: bareTable,
+	}
+
+	// Push both onto the initial tab so switchNS will iterate them.
+	app.tabManager.sessions[0].Content.Push(nilTableViewer)
+	app.tabManager.sessions[0].Content.Push(nilModelViewer)
+
+	// Must not panic.
+	assert.NotPanics(t, func() {
+		app.tabManager.switchNS("new-ns")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Test fix #4 — state consistency after closeActive (no orphan pages or
+// stale active index).  Also exercises the post-mutex-removal code paths.
+// ---------------------------------------------------------------------------
+
+func TestCloseActive_StateConsistencyAfterRemovingMiddleTab(t *testing.T) {
+	app := view_newAppForTest(t)
+	ctx := context.WithValue(context.Background(), internal.KeyApp, app)
+
+	// Open four extra tabs so we have five total: indices 0..4.
+	for i := 0; i < 4; i++ {
+		require.NoError(t, app.tabManager.newTab(ctx))
+	}
+	require.Equal(t, 5, app.tabManager.Count())
+
+	// Make the middle tab active and close it.
+	app.tabManager.SwitchTo(2)
+	require.NoError(t, app.tabManager.closeActive())
+
+	// Down to four tabs; the right-neighbour preference means the new active
+	// index is still 2 (the tab that was previously at index 3).
+	assert.Equal(t, 4, app.tabManager.Count())
+	assert.Equal(t, 2, app.tabManager.activeIdx)
+
+	// Close the rightmost tab — fallback to the left neighbour.
+	app.tabManager.SwitchTo(3)
+	require.NoError(t, app.tabManager.closeActive())
+	assert.Equal(t, 3, app.tabManager.Count())
+	assert.Equal(t, 2, app.tabManager.activeIdx)
+
+	// Reduce to a single tab and verify last-tab close is rejected.
+	require.NoError(t, app.tabManager.closeActive())
+	require.NoError(t, app.tabManager.closeActive())
+	assert.Equal(t, 1, app.tabManager.Count())
+	err := app.tabManager.closeActive()
+	assert.Error(t, err)
+	assert.Equal(t, 1, app.tabManager.Count())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// view_newAppForTest constructs an App with mock config, initialised enough
+// to host a TabManager.  Mirrors the pattern used by app_test.go.
+func view_newAppForTest(t *testing.T) *App {
+	t.Helper()
+	a := NewApp(mock.NewMockConfig(t))
+	// Init may return an error in mock setup (no real cluster); ignore it
+	// just like the existing TestAppNew does — what we need is tabManager
+	// being constructed, which happens unconditionally near the end of Init.
+	_ = a.Init("test", 0)
+	require.NotNil(t, a.tabManager, "App.Init did not wire tabManager")
+	require.GreaterOrEqual(t, a.tabManager.Count(), 1)
+	return a
+}
+
+// countingComp is a minimal model.Component stub that counts Start/Stop calls.
+// It's modelled after the `c` stub in internal/model/stack_test.go.
+type countingComp struct {
+	name   string
+	starts atomic.Int32
+	stops  atomic.Int32
+}
+
+func newCountingComp(name string) *countingComp {
+	return &countingComp{name: name}
+}
+
+func (c *countingComp) reset() {
+	c.starts.Store(0)
+	c.stops.Store(0)
+}
+
+func (c *countingComp) Name() string                  { return c.name }
+func (c *countingComp) Init(context.Context) error    { return nil }
+func (c *countingComp) Start()                        { c.starts.Add(1) }
+func (c *countingComp) Stop()                         { c.stops.Add(1) }
+func (c *countingComp) Hints() model.MenuHints        { return nil }
+func (c *countingComp) ExtraHints() map[string]string { return nil }
+func (c *countingComp) InCmdMode() bool               { return false }
+func (c *countingComp) SetFilter(string, bool)        {}
+func (*countingComp) SetLabelSelector(labels.Selector, bool) {}
+func (*countingComp) SetCommand(*cmd.Interpreter)            {}
+
+// tview.Primitive surface.
+func (*countingComp) Draw(tcell.Screen)                                              {}
+func (*countingComp) GetRect() (int, int, int, int)                                  { return 0, 0, 0, 0 }
+func (*countingComp) SetRect(int, int, int, int)                                     {}
+func (*countingComp) InputHandler() func(*tcell.EventKey, func(tview.Primitive))     { return nil }
+func (*countingComp) MouseHandler() func(tview.MouseAction, *tcell.EventMouse, func(tview.Primitive)) (bool, tview.Primitive) {
+	return nil
+}
+func (*countingComp) Focus(func(tview.Primitive))   {}
+func (*countingComp) Blur()                         {}
+func (*countingComp) HasFocus() bool                { return false }
+func (*countingComp) GetFocusable() tview.Focusable { return nil }
+
+// stubResourceViewer implements just enough of view.ResourceViewer for
+// switchNS to iterate over it and exercise the nil-Table / nil-Model paths.
+type stubResourceViewer struct {
+	name  string
+	gvr   *client.GVR
+	table *Table
+}
+
+func (s *stubResourceViewer) Name() string                  { return s.name }
+func (s *stubResourceViewer) Init(context.Context) error    { return nil }
+func (s *stubResourceViewer) Start()                        {}
+func (s *stubResourceViewer) Stop()                         {}
+func (s *stubResourceViewer) Hints() model.MenuHints        { return nil }
+func (s *stubResourceViewer) ExtraHints() map[string]string { return nil }
+func (s *stubResourceViewer) InCmdMode() bool               { return false }
+func (s *stubResourceViewer) SetFilter(string, bool)        {}
+func (*stubResourceViewer) SetLabelSelector(labels.Selector, bool) {}
+func (*stubResourceViewer) SetCommand(*cmd.Interpreter)            {}
+
+// tview.Primitive surface.
+func (*stubResourceViewer) Draw(tcell.Screen)                                              {}
+func (*stubResourceViewer) GetRect() (int, int, int, int)                                  { return 0, 0, 0, 0 }
+func (*stubResourceViewer) SetRect(int, int, int, int)                                     {}
+func (*stubResourceViewer) InputHandler() func(*tcell.EventKey, func(tview.Primitive))     { return nil }
+func (*stubResourceViewer) MouseHandler() func(tview.MouseAction, *tcell.EventMouse, func(tview.Primitive)) (bool, tview.Primitive) {
+	return nil
+}
+func (*stubResourceViewer) Focus(func(tview.Primitive))   {}
+func (*stubResourceViewer) Blur()                         {}
+func (*stubResourceViewer) HasFocus() bool                { return false }
+func (*stubResourceViewer) GetFocusable() tview.Focusable { return nil }
+
+// view.Viewer / TableViewer / ResourceViewer.
+func (*stubResourceViewer) Actions() *ui.KeyActions { return nil }
+func (*stubResourceViewer) App() *App               { return nil }
+func (*stubResourceViewer) Refresh()                {}
+func (s *stubResourceViewer) GetTable() *Table      { return s.table }
+func (s *stubResourceViewer) GVR() *client.GVR      { return s.gvr }
+func (*stubResourceViewer) SetEnvFn(EnvFunc)        {}
+func (*stubResourceViewer) SetContextFn(ContextFunc) {}
+func (*stubResourceViewer) AddBindKeysFn(BindKeysFunc) {}
+func (*stubResourceViewer) SetInstance(string)        {}

--- a/internal/view/tab_session.go
+++ b/internal/view/tab_session.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import "github.com/derailed/k9s/internal/model"
+
+// TabSession holds the isolated state for a single browser tab.
+// Multiple sessions share the same factory, clusterModel and ui.App.
+type TabSession struct {
+	id            int
+	Content       *PageStack
+	command       *Command
+	cmdHistory    *model.History
+	filterHistory *model.History
+	label         string
+}


### PR DESCRIPTION
K9s now supports multiple tabs to allow quick switching between different views and resources. Users can open up to 9 tabs simultaneously, with each tab maintaining its own isolated view stack, command interpreter, and navigation/filter histories.

Key bindings have been added for tab management:
- `Ctrl-t`: Open a new tab pre-loaded with the current resource.
- `Ctrl-x`: Close the active tab (no-op if it's the last tab).
- `Ctrl-n`: Switch to the next tab, wrapping around.
- `Ctrl-b`: Switch to the previous tab, wrapping around.

<img width="1162" height="450" alt="image" src="https://github.com/user-attachments/assets/613ff5b2-0b6e-4ee5-affc-fc29095a33ef" />
