### PR TITLE
feat(plugins): add lnav log viewer plugin

### DIFF
--- a/plugins/log-lnav.yaml
+++ b/plugins/log-lnav.yaml
@@ -1,0 +1,38 @@
+plugins:
+  # Leverage lnav (https://lnav.org) for powerful log viewing with
+  # filtering, searching, SQL queries, and timeline support.
+  # Requires lnav to be installed: https://lnav.org/downloads
+  lnav-pod:
+    shortCut: Ctrl-L
+    confirm: false
+    description: "Logs (lnav)"
+    scopes:
+      - pods
+    command: bash
+    background: false
+    args:
+      - -c
+      - >-
+        kubectl logs --follow --all-containers --tail=5000
+        $NAME
+        -n $NAMESPACE
+        --context $CONTEXT
+        --kubeconfig $KUBECONFIG
+        2>&1 | lnav
+  lnav-container:
+    shortCut: Ctrl-L
+    confirm: false
+    description: "Logs (lnav)"
+    scopes:
+      - containers
+    command: bash
+    background: false
+    args:
+      - -c
+      - >-
+        kubectl logs --follow --tail=5000
+        -c $NAME $POD
+        -n $NAMESPACE
+        --context $CONTEXT
+        --kubeconfig $KUBECONFIG
+        2>&1 | lnav


### PR DESCRIPTION
## Summary

Add a plugin that pipes pod/container logs through [lnav](https://lnav.org), a powerful terminal log viewer with filtering, searching, SQL queries, syntax highlighting, and timeline support. This provides users with a reliable alternative to the built-in log viewer that bypasses all tview rendering issues.

## Changes

- Add `plugins/log-lnav.yaml` with two scopes:
  - **pods**: streams all containers with `--all-containers` and `--tail=5000`
  - **containers**: streams a specific container with `--tail=5000`
- Shortcut: `Ctrl-L`
- Follows existing plugin patterns from `plugins/log-stern.yaml` and `plugins/log-full.yaml`

## Why

The built-in log viewer uses tview for rendering, which has inherent limitations with bracket interpretation, ANSI color handling, and text wrapping. An external viewer like lnav sidesteps all of these by receiving raw log output directly from kubectl.

## Requirements

- [lnav](https://lnav.org/downloads) must be installed

## Issues Addressed

This plugin provides a workaround for the following open log viewer issues by letting users view raw logs in a dedicated tool:

- #3051 — bracket interpretation corrupts log lines
- #3099 — bracket rendering breaks with text wrap
- #1398 — square brackets removed from log output
- #1164 — copied log text loses bracket content
- #1483 — log entries silently dropped
- #1846 — partial lines not shown
- #2998, #2148 — JSON log readability
- #2212 — ANSI color corruption

Closes #1187