### PR TITLE
fix(view): correct bracket escaping regex and sanitize save output

### DIFF
--- a/internal/view/helpers.go
+++ b/internal/view/helpers.go
@@ -45,7 +45,7 @@ func aliases(m *v1.APIResource, aa sets.Set[string]) sets.Set[string] {
 	return ss
 }
 
-var bracketRX = regexp.MustCompile(`\[(.+)\[\]`)
+var bracketRX = regexp.MustCompile(`\[([^\[]*)\[\]`)
 
 func sanitizeEsc(s string) string {
 	return bracketRX.ReplaceAllString(s, `[$1]`)

--- a/internal/view/helpers_test.go
+++ b/internal/view/helpers_test.go
@@ -342,6 +342,26 @@ func Test_sanitizeEsc(t *testing.T) {
 			s: "[fred[]",
 			e: "[fred]",
 		},
+		"multi-bracket": {
+			s: "[INFO[] some [DEBUG[] msg",
+			e: "[INFO] some [DEBUG] msg",
+		},
+		"json-array": {
+			s: `[["a","b"[]`,
+			e: `[["a","b"]`,
+		},
+		"nested-tags": {
+			s: "[red::b[]text[-::-[]",
+			e: "[red::b]text[-::-]",
+		},
+		"no-escape-needed": {
+			s: "plain text without brackets",
+			e: "plain text without brackets",
+		},
+		"real-log-line": {
+			s: "2024-01-01T00:00:00Z [INFO[] Application started on port [8080[]",
+			e: "2024-01-01T00:00:00Z [INFO] Application started on port [8080]",
+		},
 	}
 
 	for k, u := range uu {

--- a/internal/view/log.go
+++ b/internal/view/log.go
@@ -420,7 +420,7 @@ func (l *Log) filterCmd(evt *tcell.EventKey) *tcell.EventKey {
 
 // SaveCmd dumps the logs to file.
 func (l *Log) SaveCmd(*tcell.EventKey) *tcell.EventKey {
-	path, err := saveData(l.app.Config.K9s.ContextScreenDumpDir(), l.model.GetPath(), l.logs.GetText(true))
+	path, err := saveData(l.app.Config.K9s.ContextScreenDumpDir(), l.model.GetPath(), sanitizeEsc(l.logs.GetText(true)))
 	if err != nil {
 		l.app.Flash().Err(err)
 		return nil

--- a/internal/view/logger.go
+++ b/internal/view/logger.go
@@ -155,7 +155,7 @@ func (l *Logger) resetCmd(evt *tcell.EventKey) *tcell.EventKey {
 }
 
 func (l *Logger) saveCmd(*tcell.EventKey) *tcell.EventKey {
-	if path, err := saveYAML(l.app.Config.K9s.ContextScreenDumpDir(), l.title, l.GetText(true)); err != nil {
+	if path, err := saveYAML(l.app.Config.K9s.ContextScreenDumpDir(), l.title, sanitizeEsc(l.GetText(true))); err != nil {
 		l.app.Flash().Err(err)
 	} else {
 		l.app.Flash().Infof("Log %s saved successfully!", path)


### PR DESCRIPTION
## Summary

Fix the bracket escaping regex that corrupts multi-bracket log lines, and add `sanitizeEsc()` to both save-to-file paths so saved logs contain the original bracket characters.

## Changes

### Regex fix (`internal/view/helpers.go`)
- Change `bracketRX` from `\[(.+)\[\]` (greedy — spans across multiple bracket pairs) to `\[([^\[]*)\[\]` (stops at each bracket pair independently)
- Before: `[INFO[] some [DEBUG[] msg` → corrupted output
- After: `[INFO[] some [DEBUG[] msg` → `[INFO] some [DEBUG] msg` ✓

### Save path sanitization (`internal/view/log.go`, `internal/view/logger.go`)
- Apply `sanitizeEsc()` to `Log.SaveCmd` and `Logger.saveCmd` so saved files get bracket escaping stripped
- The clipboard copy path (`cpCmd`) already had this — the save paths were overlooked

### Tests (`internal/view/helpers_test.go`)
- Add test cases for multi-bracket lines, JSON arrays, nested tview tags, real log lines, and plain text passthrough

## Root Cause

tview interprets `[text]` as color/style markup. k9s escapes literal brackets in log output by converting `[text]` to `[text[]` (the `[]` suffix tells tview to treat it as literal). The `sanitizeEsc` function reverses this for copy/save. However:

1. The regex used `(.+)` which is greedy and matches across multiple bracket pairs on the same line, corrupting output like `[INFO] foo [DEBUG] bar`
2. The two save-to-file paths never called `sanitizeEsc`, so saved files contained the tview escape sequences instead of the original brackets

## References

- Fixes #3051 — brackets disappear or corrupt multi-bracket lines
- Fixes #3099 — bracket rendering breaks with text wrap
- Fixes #1398 — square brackets removed from log output
- Fixes #1164 — copied log text loses bracket content
- Ref #809 — original bracket escaping discussion
- Supersedes PR #3945 (unmerged bracket fix with different approach)