### PR TITLE
test(view): add SimulationScreen visual test harness

### DIFF
--- a/internal/view/simscreen_test.go
+++ b/internal/view/simscreen_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/derailed/tcell/v2"
+	"github.com/derailed/tview"
+)
+
+// SimScreen wraps a tcell.SimulationScreen and a tview.Application for
+// rendering TUI components in tests without a real terminal.
+//
+// Usage:
+//
+//	sim := NewSimScreen(t, 80, 25)
+//	defer sim.Fini()
+//	tv := tview.NewTextView()
+//	tv.SetText("hello")
+//	sim.Render(tv)
+//	text := sim.ScreenText()
+//	assert.Contains(t, text, "hello")
+type SimScreen struct {
+	t      testing.TB
+	Screen tcell.SimulationScreen
+	App    *tview.Application
+	width  int
+	height int
+}
+
+// NewSimScreen creates a SimulationScreen of the given dimensions
+// and attaches it to a new tview.Application. The screen is initialized
+// and ready for rendering.
+func NewSimScreen(t testing.TB, width, height int) *SimScreen {
+	t.Helper()
+	scr := tcell.NewSimulationScreen("UTF-8")
+	if err := scr.Init(); err != nil {
+		t.Fatalf("SimulationScreen.Init: %v", err)
+	}
+	scr.SetSize(width, height)
+
+	app := tview.NewApplication()
+	app.SetScreen(scr)
+
+	return &SimScreen{
+		t:      t,
+		Screen: scr,
+		App:    app,
+		width:  width,
+		height: height,
+	}
+}
+
+// Render draws the given Primitive into the simulation screen.
+// It sets the primitive as root, forces a full-screen layout, and
+// calls Draw() to flush the cell buffer.
+func (s *SimScreen) Render(p tview.Primitive) {
+	s.t.Helper()
+	s.App.SetRoot(p, true)
+	p.SetRect(0, 0, s.width, s.height)
+	s.App.ForceDraw()
+}
+
+// ScreenText reads every cell from the simulation screen and returns
+// the visible text as a single string with embedded newlines.
+// Trailing whitespace on each row is trimmed.
+func (s *SimScreen) ScreenText() string {
+	s.t.Helper()
+	cells, w, h := s.Screen.GetContents()
+	var sb strings.Builder
+	for row := 0; row < h; row++ {
+		for col := 0; col < w; col++ {
+			cell := cells[row*w+col]
+			if len(cell.Runes) > 0 {
+				sb.WriteRune(cell.Runes[0])
+			} else {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+// ScreenLines returns each row of the screen as a trimmed string.
+func (s *SimScreen) ScreenLines() []string {
+	raw := s.ScreenText()
+	rows := strings.Split(raw, "\n")
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, strings.TrimRight(r, " "))
+	}
+	return out
+}
+
+// CellStyle returns the style applied to the cell at (col, row).
+func (s *SimScreen) CellStyle(col, row int) tcell.Style {
+	s.t.Helper()
+	cells, w, _ := s.Screen.GetContents()
+	return cells[row*w+col].Style
+}
+
+// Fini tears down the simulation screen.
+func (s *SimScreen) Fini() {
+	s.Screen.Fini()
+}

--- a/internal/view/simscreen_test.go
+++ b/internal/view/simscreen_test.go
@@ -71,8 +71,8 @@ func (s *SimScreen) ScreenText() string {
 	s.t.Helper()
 	cells, w, h := s.Screen.GetContents()
 	var sb strings.Builder
-	for row := 0; row < h; row++ {
-		for col := 0; col < w; col++ {
+	for row := range h {
+		for col := range w {
 			cell := cells[row*w+col]
 			if len(cell.Runes) > 0 {
 				sb.WriteRune(cell.Runes[0])

--- a/internal/view/simscreen_visual_test.go
+++ b/internal/view/simscreen_visual_test.go
@@ -35,7 +35,7 @@ func TestSimScreen_BracketLiteralRendering(t *testing.T) {
 	sim.Render(tv)
 
 	lines := sim.ScreenLines()
-	require.Positive(t, len(lines))
+	require.NotEmpty(t, lines)
 	assert.Contains(t, lines[0], "[INFO]", "literal brackets should render on screen")
 	assert.Contains(t, lines[0], "[8080]", "literal brackets should render on screen")
 }
@@ -86,7 +86,7 @@ func TestSimScreen_EscapedBracketsInLogLine(t *testing.T) {
 	sim.Render(tv)
 
 	lines := sim.ScreenLines()
-	require.Positive(t, len(lines))
+	require.NotEmpty(t, lines)
 	assert.Contains(t, lines[0], "[INFO]")
 	assert.Contains(t, lines[0], "Application started")
 }

--- a/internal/view/simscreen_visual_test.go
+++ b/internal/view/simscreen_visual_test.go
@@ -35,7 +35,7 @@ func TestSimScreen_BracketLiteralRendering(t *testing.T) {
 	sim.Render(tv)
 
 	lines := sim.ScreenLines()
-	require.True(t, len(lines) > 0)
+	require.Positive(t, len(lines))
 	assert.Contains(t, lines[0], "[INFO]", "literal brackets should render on screen")
 	assert.Contains(t, lines[0], "[8080]", "literal brackets should render on screen")
 }
@@ -86,7 +86,7 @@ func TestSimScreen_EscapedBracketsInLogLine(t *testing.T) {
 	sim.Render(tv)
 
 	lines := sim.ScreenLines()
-	require.True(t, len(lines) > 0)
+	require.Positive(t, len(lines))
 	assert.Contains(t, lines[0], "[INFO]")
 	assert.Contains(t, lines[0], "Application started")
 }

--- a/internal/view/simscreen_visual_test.go
+++ b/internal/view/simscreen_visual_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/derailed/tview"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimScreen_BasicText(t *testing.T) {
+	sim := NewSimScreen(t, 40, 5)
+	defer sim.Fini()
+
+	tv := tview.NewTextView()
+	tv.SetText("hello world")
+	sim.Render(tv)
+
+	text := sim.ScreenText()
+	assert.Contains(t, text, "hello world")
+}
+
+func TestSimScreen_BracketLiteralRendering(t *testing.T) {
+	sim := NewSimScreen(t, 80, 10)
+	defer sim.Fini()
+
+	tv := tview.NewTextView()
+	tv.SetDynamicColors(true)
+	// tview escaping: [[ produces a literal [ on screen
+	tv.SetText("[[INFO]] server started on [[8080]]")
+	sim.Render(tv)
+
+	lines := sim.ScreenLines()
+	require.True(t, len(lines) > 0)
+	assert.Contains(t, lines[0], "[INFO]", "literal brackets should render on screen")
+	assert.Contains(t, lines[0], "[8080]", "literal brackets should render on screen")
+}
+
+func TestSimScreen_MultipleLinesRendering(t *testing.T) {
+	sim := NewSimScreen(t, 60, 10)
+	defer sim.Fini()
+
+	tv := tview.NewTextView()
+	tv.SetDynamicColors(true)
+	tv.SetText("line one\nline two\nline three")
+	sim.Render(tv)
+
+	lines := sim.ScreenLines()
+	found := 0
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		switch trimmed {
+		case "line one", "line two", "line three":
+			found++
+		}
+	}
+	assert.Equal(t, 3, found, "all three lines should be visible")
+}
+
+func TestSimScreen_PlainTextNoBrackets(t *testing.T) {
+	sim := NewSimScreen(t, 80, 5)
+	defer sim.Fini()
+
+	tv := tview.NewTextView()
+	tv.SetText("error message without any special markup")
+	sim.Render(tv)
+
+	text := sim.ScreenText()
+	assert.Contains(t, text, "error message without any special markup")
+}
+
+func TestSimScreen_EscapedBracketsInLogLine(t *testing.T) {
+	sim := NewSimScreen(t, 100, 5)
+	defer sim.Fini()
+
+	// Simulate what sanitizeEsc produces: [INFO[] becomes [INFO] on screen
+	// But tview renders [INFO[] by stripping the first bracket pair as a tag.
+	// The correct way to show literal [INFO] is [[INFO]]
+	tv := tview.NewTextView()
+	tv.SetDynamicColors(true)
+	tv.SetText("2024-01-01 [[INFO]] Application started")
+	sim.Render(tv)
+
+	lines := sim.ScreenLines()
+	require.True(t, len(lines) > 0)
+	assert.Contains(t, lines[0], "[INFO]")
+	assert.Contains(t, lines[0], "Application started")
+}
+
+func TestSimScreen_ScreenLines(t *testing.T) {
+	sim := NewSimScreen(t, 20, 3)
+	defer sim.Fini()
+
+	tv := tview.NewTextView()
+	tv.SetText("abc\nxyz")
+	sim.Render(tv)
+
+	lines := sim.ScreenLines()
+	assert.Equal(t, "abc", lines[0])
+	assert.Equal(t, "xyz", lines[1])
+}


### PR DESCRIPTION
## Summary

Introduce a `SimScreen` test helper that wraps `tcell.SimulationScreen` and `tview.Application` to enable pixel-level visual testing of TUI components without a real terminal. k9s previously had **zero visual terminal tests** — all existing view tests use `GetText(true)` which returns the raw text buffer and cannot detect rendering issues.

## Changes

### Test harness (`internal/view/simscreen_test.go`)
- `NewSimScreen(t, width, height)` — creates an initialized simulation screen
- `Render(primitive)` — draws a tview `Primitive` into the screen buffer
- `ScreenText()` — reads all cells as a single string with embedded newlines
- `ScreenLines()` — returns per-row trimmed strings for line-by-line assertions
- `CellStyle(col, row)` — returns the `tcell.Style` at a given position
- `Fini()` — tears down the screen

### Visual tests (`internal/view/simscreen_visual_test.go`)
- `TestSimScreen_BasicText` — plain text renders correctly
- `TestSimScreen_BracketLiteralRendering` — escaped brackets (`[[INFO]]`) render as literal `[INFO]` on screen
- `TestSimScreen_MultipleLinesRendering` — multi-line content lays out correctly
- `TestSimScreen_PlainTextNoBrackets` — text without special markup renders unchanged
- `TestSimScreen_EscapedBracketsInLogLine` — full log line with timestamp and escaped brackets
- `TestSimScreen_ScreenLines` — per-row extraction works correctly

## Why

`GetText(true)` cannot detect rendering bugs like bracket corruption, color tag leakage, or wrapping issues because it returns the internal buffer, not what the user sees. `SimulationScreen` provides the actual rendered cell grid, enabling tests that verify visual output. This is directly relevant to the bracket escaping fixes (#3051, #3099).

## References

- Ref #3051 — bracket rendering bugs that motivated this harness
- Ref #3099 — bracket rendering breaks with text wrap