### PR TITLE
fix(config): raise default tail to 1000 and max threshold to 10000

### DIFF
--- a/internal/config/json/testdata/k9s/cool.yaml
+++ b/internal/config/json/testdata/k9s/cool.yaml
@@ -26,8 +26,8 @@ k9s:
       namespaces: []
       labels: {}
   logger:
-    tail: 100
-    buffer: 5000
+    tail: 1000
+    buffer: 10000
     sinceSeconds: -1
     textWrap: false
     disableAutoscroll: false

--- a/internal/config/json/testdata/k9s/toast.yaml
+++ b/internal/config/json/testdata/k9s/toast.yaml
@@ -19,8 +19,8 @@ k9s:
       namespaces: []
       labels: {}
   logger:
-    tail: 100
-    buffer: 5000
+    tail: 1000
+    buffer: 10000
     sinceSeconds: -1
     textWrap: false
     disableAutoscroll: false

--- a/internal/config/logger.go
+++ b/internal/config/logger.go
@@ -5,10 +5,10 @@ package config
 
 const (
 	// DefaultLoggerTailCount tracks default log tail size.
-	DefaultLoggerTailCount = 100
+	DefaultLoggerTailCount = 1000
 
 	// MaxLogThreshold sets the max value for log size.
-	MaxLogThreshold = 5_000
+	MaxLogThreshold = 10_000
 
 	// DefaultSinceSeconds tracks default log age.
 	DefaultSinceSeconds = -1 // tail logs by default

--- a/internal/config/logger_test.go
+++ b/internal/config/logger_test.go
@@ -14,8 +14,8 @@ func TestNewLogger(t *testing.T) {
 	l := config.NewLogger()
 	l = l.Validate()
 
-	assert.Equal(t, int64(100), l.TailCount)
-	assert.Equal(t, 5000, l.BufferSize)
+	assert.Equal(t, int64(config.DefaultLoggerTailCount), l.TailCount)
+	assert.Equal(t, config.MaxLogThreshold, l.BufferSize)
 	assert.Equal(t, 50, l.LogBufferSize)
 }
 
@@ -23,7 +23,29 @@ func TestLoggerValidate(t *testing.T) {
 	var l config.Logger
 	l = l.Validate()
 
-	assert.Equal(t, int64(100), l.TailCount)
-	assert.Equal(t, 5000, l.BufferSize)
+	assert.Equal(t, int64(config.DefaultLoggerTailCount), l.TailCount)
+	assert.Equal(t, config.MaxLogThreshold, l.BufferSize)
 	assert.Equal(t, 50, l.LogBufferSize)
+}
+
+func TestLoggerValidateOverMax(t *testing.T) {
+	l := config.Logger{
+		TailCount:  20_000,
+		BufferSize: 20_000,
+	}
+	l = l.Validate()
+
+	assert.Equal(t, int64(config.MaxLogThreshold), l.TailCount)
+	assert.Equal(t, config.MaxLogThreshold, l.BufferSize)
+}
+
+func TestLoggerValidateCustom(t *testing.T) {
+	l := config.Logger{
+		TailCount:  500,
+		BufferSize: 8000,
+	}
+	l = l.Validate()
+
+	assert.Equal(t, int64(500), l.TailCount)
+	assert.Equal(t, 8000, l.BufferSize)
 }

--- a/internal/config/testdata/configs/default.yaml
+++ b/internal/config/testdata/configs/default.yaml
@@ -33,8 +33,8 @@ k9s:
       namespaces: []
       labels: {}
   logger:
-    tail: 100
-    buffer: 5000
+    tail: 1000
+    buffer: 10000
     sinceSeconds: -1
     textWrap: false
     disableAutoscroll: false


### PR DESCRIPTION
## Summary

The default `TailCount` of 100 lines is too small for most real-world debugging workflows. Users consistently report that by the time they open the log viewer, the relevant lines have already scrolled past the 100-line window.

## Changes

### Config defaults (`internal/config/logger.go`)
- Raise `DefaultLoggerTailCount` from 100 to 1000
- Raise `MaxLogThreshold` from 5,000 to 10,000 (caps both `TailCount` and `BufferSize` in `Validate`)
- Both values remain fully configurable via the k9s config file

### Tests (`internal/config/logger_test.go`)
- Update existing tests to use named constants (`config.DefaultLoggerTailCount`, `config.MaxLogThreshold`) instead of magic numbers
- Add `TestLoggerValidateOverMax` — verifies values above the threshold are clamped
- Add `TestLoggerValidateCustom` — verifies user-specified values within range are preserved

## Rationale

- 100 lines is ~3 seconds of output for a moderately busy service — not enough context for debugging
- 1000 lines provides a much more useful initial window while remaining lightweight
- Raising the max to 10,000 gives power users more headroom without unbounded memory growth
- The values are still configurable, so users who prefer smaller buffers can set them

## References

- Fixes #1483 — users miss log context with small default window
- Ref #1846 — related to insufficient log history
- Ref #3051 — part of broader log reliability improvements