### PR TITLE
feat(config): add fieldManager configuration option

### DIFF
--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -25,6 +25,7 @@
         "maxConnRetry": { "type": "integer" },
         "readOnly": { "type": "boolean" },
         "noExitOnCtrlC": { "type": "boolean" },
+        "fieldManager": { "type": "string" },
         "skipLatestRevCheck": { "type": "boolean" },
         "disablePodCounting": { "type": "boolean" },
         "defaultView": { "type": "string" },

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -42,6 +42,7 @@ type K9s struct {
 	MaxConnRetry        int32      `json:"maxConnRetry" yaml:"maxConnRetry"`
 	ReadOnly            bool       `json:"readOnly" yaml:"readOnly"`
 	NoExitOnCtrlC       bool       `json:"noExitOnCtrlC" yaml:"noExitOnCtrlC"`
+	FieldManager        string     `json:"fieldManager" yaml:"fieldManager"`
 	PortForwardAddress  string     `yaml:"portForwardAddress"`
 	UI                  UI         `json:"ui" yaml:"ui"`
 	SkipLatestRevCheck  bool       `json:"skipLatestRevCheck" yaml:"skipLatestRevCheck"`
@@ -73,6 +74,7 @@ func NewK9s(conn client.Connection, ks data.KubeSettings) *K9s {
 		MaxConnRetry:       defaultMaxConnRetry,
 		APIServerTimeout:   client.DefaultCallTimeoutDuration.String(),
 		ScreenDumpDir:      AppDumpsDir,
+		FieldManager:       defaultFieldManager,
 		Logger:             NewLogger(),
 		Thresholds:         NewThreshold(),
 		PortForwardAddress: defaultPFAddress(),
@@ -143,6 +145,7 @@ func (k *K9s) Merge(k1 *K9s) {
 	k.MaxConnRetry = k1.MaxConnRetry
 	k.ReadOnly = k1.ReadOnly
 	k.NoExitOnCtrlC = k1.NoExitOnCtrlC
+	k.FieldManager = k1.FieldManager
 	k.PortForwardAddress = k1.PortForwardAddress
 	k.UI = k1.UI
 	k.SkipLatestRevCheck = k1.SkipLatestRevCheck
@@ -427,6 +430,9 @@ func (k *K9s) Validate(c client.Connection, contextName, clusterName string) {
 	}
 	if k.MaxConnRetry <= 0 {
 		k.MaxConnRetry = defaultMaxConnRetry
+	}
+	if k.FieldManager == "" {
+		k.FieldManager = defaultFieldManager
 	}
 
 	if a := os.Getenv(envPFAddress); a != "" {

--- a/internal/config/testdata/configs/default.yaml
+++ b/internal/config/testdata/configs/default.yaml
@@ -7,6 +7,7 @@ k9s:
   maxConnRetry: 5
   readOnly: false
   noExitOnCtrlC: false
+  fieldManager: kubectl-rollout
   portForwardAddress: localhost
   ui:
     enableMouse: false

--- a/internal/config/testdata/configs/expected.yaml
+++ b/internal/config/testdata/configs/expected.yaml
@@ -8,6 +8,7 @@ k9s:
   maxConnRetry: 5
   readOnly: true
   noExitOnCtrlC: false
+  fieldManager: my-field-manager
   portForwardAddress: localhost
   ui:
     enableMouse: false

--- a/internal/config/testdata/configs/k9s.yaml
+++ b/internal/config/testdata/configs/k9s.yaml
@@ -7,6 +7,7 @@ k9s:
   maxConnRetry: 5
   readOnly: false
   noExitOnCtrlC: false
+  fieldManager: my-field-manager
   portForwardAddress: localhost
   ui:
     enableMouse: false

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -6,6 +6,7 @@ package config
 const (
 	defaultRefreshRate  = 2
 	defaultMaxConnRetry = 5
+	defaultFieldManager = "kubectl-rollout"
 
 	// CPU tracks cpu usage.
 	CPU = "cpu"

--- a/internal/view/restart_extender.go
+++ b/internal/view/restart_extender.go
@@ -59,7 +59,7 @@ func (r *RestartExtender) restartCmd(*tcell.EventKey) *tcell.EventKey {
 	opts := dialog.RestartDialogOpts{
 		Title:        "Confirm Restart",
 		Message:      msg,
-		FieldManager: "kubectl-rollout",
+		FieldManager: r.App().Config.K9s.FieldManager,
 		Ack: func(opts *metav1.PatchOptions) bool {
 			ctx, cancel := context.WithTimeout(context.Background(), r.App().Conn().Config().CallTimeout())
 			defer cancel()


### PR DESCRIPTION
## Summary

Add a configurable FieldManager field to k9s config to help operators in certain situations not create conflicts in their clusters.

## How It Works

Configuration option is added called `k9s.fieldManager`, example `config.yaml` snippet:

```yaml
k9s:
  fieldManager: flux-client-side-apply
```

default is kept as `kubectl-rollout`

fixes #3983
refs #3398
refs #3285