### PR TITLE
fix: paginate metrics API calls to prevent timeout on large clusters

### DIFF
--- a/internal/client/metrics.go
+++ b/internal/client/metrics.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	mxCacheSize   = 100
-	mxCacheExpiry = 1 * time.Minute
+	mxCacheSize    = 100
+	mxCacheExpiry  = 1 * time.Minute
+	metricsPageSize int64 = 500
 )
 
 // MetricsDial tracks global metric server handle.
@@ -168,9 +169,20 @@ func (m *MetricsServer) FetchNodesMetrics(ctx context.Context) (*mv1beta1.NodeMe
 	if err != nil {
 		return mx, err
 	}
-	mxList, err := client.MetricsV1beta1().NodeMetricses().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return mx, err
+	mxList := &mv1beta1.NodeMetricsList{
+		Items: make([]mv1beta1.NodeMetrics, 0, metricsPageSize),
+	}
+	opts := metav1.ListOptions{Limit: metricsPageSize}
+	for {
+		page, err := client.MetricsV1beta1().NodeMetricses().List(ctx, opts)
+		if err != nil {
+			return mx, err
+		}
+		mxList.Items = append(mxList.Items, page.Items...)
+		if page.Continue == "" {
+			break
+		}
+		opts.Continue = page.Continue
 	}
 	m.cache.Add(key, mxList, mxCacheExpiry)
 
@@ -239,13 +251,24 @@ func (m *MetricsServer) FetchPodsMetrics(ctx context.Context, ns string) (*mv1be
 	if err != nil {
 		return mx, err
 	}
-	mxList, err := client.MetricsV1beta1().PodMetricses(ns).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return mx, err
+	mxList := &mv1beta1.PodMetricsList{
+		Items: make([]mv1beta1.PodMetrics, 0, metricsPageSize),
+	}
+	opts := metav1.ListOptions{Limit: metricsPageSize}
+	for {
+		page, err := client.MetricsV1beta1().PodMetricses(ns).List(ctx, opts)
+		if err != nil {
+			return mx, err
+		}
+		mxList.Items = append(mxList.Items, page.Items...)
+		if page.Continue == "" {
+			break
+		}
+		opts.Continue = page.Continue
 	}
 	m.cache.Add(key, mxList, mxCacheExpiry)
 
-	return mxList, err
+	return mxList, nil
 }
 
 // FetchContainersMetrics returns a pod's containers metrics.


### PR DESCRIPTION
`FetchPodsMetrics` and `FetchNodesMetrics` use `metav1.ListOptions{}` — no limit, everything in one shot. On our 70k-pod clusters this hits the API server's max-request-bytes wall and times out.

Switches both to a `Limit: 500` / `Continue` pagination loop. Same data, same cache, just bounded API calls. Standard pattern from client-go's `pager` package.

Ref: #1462