### PR TITLE
perf: raise default client QPS from 5 to 50

### DIFF
--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -24,6 +24,9 @@ const (
 
 	// UsePersistentConfig caches client config to avoid reloads.
 	UsePersistentConfig = true
+
+	defaultQPS   float32 = 50
+	defaultBurst         = 100
 )
 
 // Config tracks a kubernetes configuration.
@@ -60,6 +63,10 @@ func (c *Config) RESTConfig() (*restclient.Config, error) {
 	}
 	if c.proxy != nil {
 		cfg.Proxy = c.proxy
+	}
+	if cfg.QPS == 0 {
+		cfg.QPS = defaultQPS
+		cfg.Burst = defaultBurst
 	}
 
 	return cfg, nil


### PR DESCRIPTION
The default client-go rate limiter (QPS=5, Burst=10) causes `CanI` checks to queue up and timeout during startup on clusters with many resource types. `kubectl` itself defaults to QPS=50/Burst=300.

Sets QPS=50, Burst=100 when no explicit value is configured. Only kicks in when `cfg.QPS == 0`, so user-specified values are preserved.

Ref: #1462