### PR TITLE
perf: skip reconcile cycle when informer data is unchanged

### DIFF
--- a/internal/dao/types.go
+++ b/internal/dao/types.go
@@ -45,6 +45,12 @@ type Factory interface {
 	Forwarders() watch.Forwarders
 }
 
+// EventSequencer tracks per-GVR change events from informers.
+type EventSequencer interface {
+	HasChanged(gvr *client.GVR) bool
+	ResetChanged(gvr *client.GVR)
+}
+
 // ImageLister tracks resources with container images.
 type ImageLister interface {
 	// ListImages lists container images.

--- a/internal/model/table.go
+++ b/internal/model/table.go
@@ -233,6 +233,15 @@ func (t *Table) refresh(ctx context.Context) error {
 	}
 	defer atomic.StoreInt32(&t.inUpdate, 0)
 
+	if t.instance == "" && !t.data.Empty() {
+		if seq, ok := ctx.Value(internal.KeyFactory).(dao.EventSequencer); ok {
+			if !seq.HasChanged(t.gvr) {
+				return nil
+			}
+			defer seq.ResetChanged(t.gvr)
+		}
+	}
+
 	if err := t.reconcile(ctx); err != nil {
 		return err
 	}

--- a/internal/watch/factory.go
+++ b/internal/watch/factory.go
@@ -8,22 +8,37 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/slogs"
+	lru "github.com/hashicorp/golang-lru/v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	di "k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
 )
 
 const (
 	defaultResync   = 10 * time.Minute
 	defaultWaitTime = 500 * time.Millisecond
+	maxWatchedGVRs  = 100
 )
+
+type handlerEntry struct {
+	reg cache.ResourceEventHandlerRegistration
+	inf cache.SharedInformer
+}
+
+// gvrWatcher tracks per-GVR event state and handler registrations.
+type gvrWatcher struct {
+	seq     atomic.Int64
+	handles map[string]handlerEntry
+}
 
 // Factory tracks various resource informers.
 type Factory struct {
@@ -32,15 +47,26 @@ type Factory struct {
 	stopChan   chan struct{}
 	forwarders Forwarders
 	mx         sync.RWMutex
+
+	watchers *lru.Cache[string, *gvrWatcher]
 }
 
 // NewFactory returns a new informers factory.
 func NewFactory(clt client.Connection) *Factory {
-	return &Factory{
+	f := Factory{
 		client:     clt,
 		factories:  make(map[string]di.DynamicSharedInformerFactory),
 		forwarders: NewForwarders(),
 	}
+	f.watchers, _ = lru.NewWithEvict[string, *gvrWatcher](maxWatchedGVRs, func(gvr string, w *gvrWatcher) {
+		for _, h := range w.handles {
+			if err := h.inf.RemoveEventHandler(h.reg); err != nil {
+				slog.Debug("Failed to remove event handler", slogs.GVR, gvr)
+			}
+		}
+	})
+
+	return &f
 }
 
 // Start initializes the informers until caller cancels the context.
@@ -68,6 +94,7 @@ func (f *Factory) Terminate() {
 	for k := range f.factories {
 		delete(f.factories, k)
 	}
+	f.watchers.Purge()
 	f.forwarders.DeleteAll()
 }
 
@@ -255,11 +282,65 @@ func (f *Factory) ForResource(ns string, gvr *client.GVR) (informers.GenericInfo
 		return inf, nil
 	}
 
+	f.registerEventHandler(ns, gvr, inf)
+
 	f.mx.RLock()
 	defer f.mx.RUnlock()
 	fact.Start(f.stopChan)
 
 	return inf, nil
+}
+
+func (f *Factory) registerEventHandler(ns string, gvr *client.GVR, inf informers.GenericInformer) {
+	gvrKey := gvr.String()
+	f.mx.Lock()
+	defer f.mx.Unlock()
+
+	w, ok := f.watchers.Get(gvrKey)
+	if !ok {
+		w = &gvrWatcher{handles: make(map[string]handlerEntry)}
+		f.watchers.Add(gvrKey, w)
+	}
+	if _, ok := w.handles[ns]; ok {
+		return
+	}
+	bump := func() { w.seq.Add(1) }
+	reg, err := inf.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(_ any) { bump() },
+		UpdateFunc: func(_, _ any) { bump() },
+		DeleteFunc: func(_ any) { bump() },
+	})
+	if err != nil {
+		slog.Error("Failed to register event handler",
+			slogs.GVR, gvr,
+			slogs.Namespace, ns,
+			slogs.Error, err,
+		)
+		return
+	}
+	w.handles[ns] = handlerEntry{reg: reg, inf: inf.Informer()}
+}
+
+// HasChanged checks if a GVR received informer events since last reset.
+func (f *Factory) HasChanged(gvr *client.GVR) bool {
+	f.mx.RLock()
+	defer f.mx.RUnlock()
+
+	w, ok := f.watchers.Get(gvr.String())
+	if !ok {
+		return true
+	}
+	return w.seq.Load() > 0
+}
+
+// ResetChanged zeros the event counter for a given GVR.
+func (f *Factory) ResetChanged(gvr *client.GVR) {
+	f.mx.RLock()
+	defer f.mx.RUnlock()
+
+	if w, ok := f.watchers.Peek(gvr.String()); ok {
+		w.seq.Store(0)
+	}
 }
 
 func (f *Factory) ensureFactory(ns string) (di.DynamicSharedInformerFactory, error) {

--- a/internal/watch/factory_test.go
+++ b/internal/watch/factory_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package watch
+
+import (
+	"testing"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestGVRWatcherSeq(t *testing.T) {
+	f := NewFactory(nil)
+
+	gvr := client.NewGVR("v1/pods")
+
+	assert.True(t, f.HasChanged(gvr), "unknown GVR should report changed")
+
+	w := &gvrWatcher{handles: make(map[string]handlerEntry)}
+	f.watchers.Add(gvr.String(), w)
+
+	assert.False(t, f.HasChanged(gvr), "fresh watcher with seq=0 should not be changed")
+
+	w.seq.Add(1)
+	assert.True(t, f.HasChanged(gvr), "seq>0 should report changed")
+
+	f.ResetChanged(gvr)
+	assert.False(t, f.HasChanged(gvr), "after reset should not be changed")
+}
+
+func TestGVRWatcherIsolation(t *testing.T) {
+	f := NewFactory(nil)
+
+	pods := client.NewGVR("v1/pods")
+	nodes := client.NewGVR("v1/nodes")
+
+	pw := &gvrWatcher{handles: make(map[string]handlerEntry)}
+	nw := &gvrWatcher{handles: make(map[string]handlerEntry)}
+	f.watchers.Add(pods.String(), pw)
+	f.watchers.Add(nodes.String(), nw)
+
+	pw.seq.Add(1)
+
+	assert.True(t, f.HasChanged(pods))
+	assert.False(t, f.HasChanged(nodes), "node watcher should be unaffected by pod events")
+}
+
+type fakeRegistration struct{}
+
+func (fakeRegistration) HasSynced() bool { return true }
+
+type fakeInformer struct {
+	cache.SharedInformer
+	removed int
+}
+
+func (f *fakeInformer) RemoveEventHandler(_ cache.ResourceEventHandlerRegistration) error {
+	f.removed++
+	return nil
+}
+
+func TestTerminateCleansUpHandlers(t *testing.T) {
+	f := NewFactory(nil)
+	f.stopChan = make(chan struct{})
+
+	inf := &fakeInformer{}
+	w := &gvrWatcher{
+		handles: map[string]handlerEntry{
+			"default":     {reg: fakeRegistration{}, inf: inf},
+			"kube-system": {reg: fakeRegistration{}, inf: inf},
+		},
+	}
+	f.watchers.Add("v1/pods", w)
+
+	f.Terminate()
+
+	assert.Equal(t, 2, inf.removed, "should have removed both handlers")
+	assert.Equal(t, 0, f.watchers.Len(), "watchers should be purged")
+}
+
+func TestLRUEvictsOldWatchers(t *testing.T) {
+	f := NewFactory(nil)
+
+	inf := &fakeInformer{}
+	for i := range maxWatchedGVRs + 5 {
+		gvr := client.NewGVR("v1/fake" + string(rune('a'+i)))
+		w := &gvrWatcher{
+			handles: map[string]handlerEntry{
+				"default": {reg: fakeRegistration{}, inf: inf},
+			},
+		}
+		f.watchers.Add(gvr.String(), w)
+	}
+
+	assert.Equal(t, maxWatchedGVRs, f.watchers.Len(), "LRU should cap at maxWatchedGVRs")
+	assert.Equal(t, 5, inf.removed, "evicted watchers should have handlers removed")
+}


### PR DESCRIPTION
Right now k9s runs the full list→hydrate→diff→clone pipeline every 2 seconds regardless of whether anything changed in the cluster. On a 50k-pod cluster that's ~13ms of CPU burned per idle cycle for no reason.

This registers informer event handlers that bump a monotonic counter on add/update/delete. The table model checks the counter before each refresh — if nothing changed, it skips entirely.

Uses a separate `EventSequencer` interface with a type assertion so existing `Factory` implementations don't break. Falls through gracefully if the factory doesn't support it.

Ref: #1462