### PR TITLE
perf: skip Clone and view notification when table data unchanged

### DIFF
--- a/internal/model/table.go
+++ b/internal/model/table.go
@@ -65,7 +65,7 @@ func (t *Table) SetViewSetting(ctx context.Context, vs *config.ViewSetting) {
 	t.mx.Unlock()
 
 	if ctx != context.Background() {
-		if err := t.reconcile(ctx); err != nil {
+		if _, err := t.reconcile(ctx); err != nil {
 			slog.Error("Refresh failed", slogs.GVR, t.gvr)
 		}
 	}
@@ -233,8 +233,12 @@ func (t *Table) refresh(ctx context.Context) error {
 	}
 	defer atomic.StoreInt32(&t.inUpdate, 0)
 
-	if err := t.reconcile(ctx); err != nil {
+	changed, err := t.reconcile(ctx)
+	if err != nil {
 		return err
+	}
+	if !changed && !t.data.Empty() {
+		return nil
 	}
 	data := t.Peek()
 	if data.RowCount() == 0 {
@@ -265,7 +269,7 @@ func (t *Table) list(ctx context.Context, a dao.Accessor) ([]runtime.Object, err
 	return a.List(ctx, ns)
 }
 
-func (t *Table) reconcile(ctx context.Context) error {
+func (t *Table) reconcile(ctx context.Context) (bool, error) {
 	var (
 		oo  []runtime.Object
 		err error
@@ -282,7 +286,7 @@ func (t *Table) reconcile(ctx context.Context) error {
 		oo, err = []runtime.Object{o}, e
 	}
 	if err != nil {
-		return err
+		return false, err
 	}
 	r := meta.Renderer
 	r.SetViewSetting(t.vs)

--- a/internal/model/table_int_test.go
+++ b/internal/model/table_int_test.go
@@ -33,7 +33,7 @@ func TestTableReconcile(t *testing.T) {
 	ctx := context.WithValue(context.Background(), internal.KeyFactory, f)
 	ctx = context.WithValue(ctx, internal.KeyFields, "")
 	ctx = context.WithValue(ctx, internal.KeyWithMetrics, false)
-	err := ta.reconcile(ctx)
+	_, err := ta.reconcile(ctx)
 	require.NoError(t, err)
 	data := ta.Peek()
 	assert.Equal(t, 26, data.HeaderCount())

--- a/internal/model1/table_data.go
+++ b/internal/model1/table_data.go
@@ -249,33 +249,34 @@ func (t *TableData) Reset(ns string) {
 	t.Clear()
 }
 
-func (t *TableData) Render(_ context.Context, r Renderer, oo []runtime.Object) error {
+// Render hydrates rows and returns true if data changed.
+func (t *TableData) Render(_ context.Context, r Renderer, oo []runtime.Object) (bool, error) {
 	var rows Rows
 	if len(oo) > 0 {
 		if r.IsGeneric() {
 			table, ok := oo[0].(*metav1.Table)
 			if !ok {
-				return fmt.Errorf("expecting a meta table but got %T", oo[0])
+				return false, fmt.Errorf("expecting a meta table but got %T", oo[0])
 			}
 			rows = make(Rows, len(table.Rows))
 			if err := GenericHydrate(t.namespace, table, rows, r); err != nil {
-				return err
+				return false, err
 			}
 		} else {
 			rows = make(Rows, len(oo))
 			if err := Hydrate(t.namespace, oo, rows, r); err != nil {
-				return err
+				return false, err
 			}
 		}
 	}
 
-	t.Update(rows)
+	changed := t.Update(rows)
 	t.SetHeader(t.namespace, r.Header(t.namespace))
 	if t.HeaderCount() == 0 {
-		return fmt.Errorf("no data found for resource %s", t.gvr)
+		return false, fmt.Errorf("no data found for resource %s", t.gvr)
 	}
 
-	return nil
+	return changed, nil
 }
 
 // Empty checks if there are no entries.
@@ -421,11 +422,12 @@ func (t *TableData) SetHeader(ns string, h Header) {
 	t.namespace, t.header = ns, h
 }
 
-// Update computes row deltas and update the table data.
-func (t *TableData) Update(rows Rows) {
+// Update computes row deltas and returns true if any rows changed.
+func (t *TableData) Update(rows Rows) bool {
 	empty := t.Empty()
 	kk := sets.New[string]()
 	var blankDelta DeltaRow
+	changed := empty && len(rows) > 0
 	t.mx.Lock()
 	for _, row := range rows {
 		kk.Insert(row.ID)
@@ -444,20 +446,26 @@ func (t *TableData) Update(rows Rows) {
 				t.rowEvents.Set(index, ev)
 			} else {
 				t.rowEvents.Set(index, NewRowEventWithDeltas(row, delta))
+				changed = true
 			}
 			continue
 		}
 		t.rowEvents.Add(NewRowEvent(EventAdd, row))
+		changed = true
 	}
 	t.mx.Unlock()
 
 	if !empty {
-		t.Delete(kk)
+		if t.Delete(kk) {
+			changed = true
+		}
 	}
+
+	return changed
 }
 
-// Delete removes items in cache that are no longer valid.
-func (t *TableData) Delete(newKeys sets.Set[string]) {
+// Delete removes stale entries and returns true if any were deleted.
+func (t *TableData) Delete(newKeys sets.Set[string]) bool {
 	t.mx.Lock()
 	defer t.mx.Unlock()
 
@@ -479,6 +487,8 @@ func (t *TableData) Delete(newKeys sets.Set[string]) {
 			)
 		}
 	}
+
+	return victims.Len() > 0
 }
 
 // Diff checks if two tables are equal.


### PR DESCRIPTION
Belt-and-suspenders with #3989 — even after reconcile runs, if `Update()` found zero actual diffs (no adds, changes, or deletes), skip the `Clone()` + `fireTableChanged()` path. Saves the deep copy and avoids a tview re-render when nothing visually changed.

`Update()` and `Delete()` now return `bool` indicating whether they actually modified anything, threaded through `Render()` → `reconcile()` → `refresh()`.

Ref: #1462