### PR TITLE
fix(browser): show syncing status instead of spurious no-resources warning

### DIFF
--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -310,6 +310,15 @@ func (b *Browser) TableNoData(mdata *model1.TableData) {
 		return
 	}
 
+	// While the informer cache hasn't synced yet, show a neutral status
+	// instead of a misleading "no resources found" warning.
+	if synced, _ := b.app.factory.HasSynced(b.GVR(), b.GetNamespace()); !synced {
+		b.app.QueueUpdateDraw(func() {
+			b.app.Flash().Infof("Synchronizing %s in %q namespace...", b.GVR(), client.PrintNamespace(b.GetNamespace()))
+		})
+		return
+	}
+
 	cdata := b.Update(mdata, b.app.Conn().HasMetrics())
 	b.app.QueueUpdateDraw(func() {
 		if b.getUpdating() {


### PR DESCRIPTION
When using a slow connection, it takes a while to populate the cold informer cache, and a misleading "No resources found" warning shows on an empty table, just to disappear a second later.

This adds a check on an empty table view to replace that warning with an info message saying that we're still synchronizing the data.