### PR TITLE
fix(render): apply views.yaml column specs to container header

### DIFF
--- a/internal/render/container.go
+++ b/internal/render/container.go
@@ -106,7 +106,19 @@ func (c Container) Render(o any, _ string, row *model1.Row) error {
 		return fmt.Errorf("expected ContainerRes, but got %T", o)
 	}
 
-	return c.defaultRow(cr, row)
+	if err := c.defaultRow(cr, row); err != nil {
+		return err
+	}
+	if c.specs.isEmpty() {
+		return nil
+	}
+	cols, err := c.specs.realize(&cr, defaultCOHeader, row)
+	if err != nil {
+		return err
+	}
+	cols.hydrateRow(row)
+
+	return nil
 }
 
 func (c Container) defaultRow(cr ContainerRes, r *model1.Row) error {

--- a/internal/render/container.go
+++ b/internal/render/container.go
@@ -72,11 +72,10 @@ func (Container) ColorerFunc() model1.ColorerFunc {
 }
 
 // Header returns a header row.
-func (Container) Header(_ string) model1.Header {
-	return defaultCOHeader
+func (c *Container) Header(_ string) model1.Header {
+	return c.doHeader(defaultCOHeader)
 }
 
-// Header returns a header row.
 var defaultCOHeader = model1.Header{
 	model1.HeaderColumn{Name: "IDX"},
 	model1.HeaderColumn{Name: "NAME"},

--- a/internal/render/container_test.go
+++ b/internal/render/container_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	cfg "github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/model1"
 	"github.com/derailed/k9s/internal/render"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,36 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	mv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
+
+func TestContainerHeader(t *testing.T) {
+	uu := map[string]struct {
+		vs        *cfg.ViewSetting
+		firstCols []string
+	}{
+		"default": {
+			firstCols: []string{"IDX", "NAME", "PF"},
+		},
+		"custom-columns": {
+			vs:        &cfg.ViewSetting{Columns: []string{"NAME", "IMAGE"}},
+			firstCols: []string{"NAME", "IMAGE", "IDX"},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			c := new(render.Container)
+			if u.vs != nil {
+				c.SetViewSetting(u.vs)
+			}
+			h := c.Header("")
+			names := make([]string, len(u.firstCols))
+			for i, col := range h[:len(u.firstCols)] {
+				names[i] = col.Name
+			}
+			assert.Equal(t, u.firstCols, names)
+		})
+	}
+}
 
 func TestContainer(t *testing.T) {
 	var c render.Container

--- a/internal/render/container_test.go
+++ b/internal/render/container_test.go
@@ -86,6 +86,43 @@ func TestContainer(t *testing.T) {
 	)
 }
 
+func TestContainerRenderCustomColumns(t *testing.T) {
+	uu := map[string]struct {
+		vs          *cfg.ViewSetting
+		firstFields model1.Fields
+	}{
+		"no-custom-cols": {
+			firstFields: model1.Fields{"", "fred", "●", "img"},
+		},
+		"custom-cols-reordered": {
+			vs:          &cfg.ViewSetting{Columns: []string{"NAME", "IMAGE"}},
+			firstFields: model1.Fields{"fred", "img"},
+		},
+		"custom-cols-subset": {
+			vs:          &cfg.ViewSetting{Columns: []string{"STATE", "NAME"}},
+			firstFields: model1.Fields{"Running", "fred"},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			c := new(render.Container)
+			if u.vs != nil {
+				c.SetViewSetting(u.vs)
+			}
+			cres := render.ContainerRes{
+				Container: makeContainer(),
+				Status:    makeContainerStatus(),
+				MX:        makeContainerMetrics(),
+				Age:       makeAge(),
+			}
+			var r model1.Row
+			require.NoError(t, c.Render(cres, "", &r))
+			assert.Equal(t, u.firstFields, r.Fields[:len(u.firstFields)])
+		})
+	}
+}
+
 func BenchmarkContainerRender(b *testing.B) {
 	var (
 		c    render.Container


### PR DESCRIPTION
Fixes #3995

## Problem

`Container.Header()` used a value receiver and returned `defaultCOHeader` directly, bypassing `Base.doHeader()` which applies custom column specs from `views.yaml`. As a result, container view always rendered the full default column set, ignoring any user-defined column customizations.

## Fix

Change `Container.Header()` to a pointer receiver and delegate to `c.doHeader(defaultCOHeader)`, consistent with how other renderers (e.g. Pod) handle `ViewSetting` column specs.

  ## Testing

Added `TestContainerHeader` covering:
- default: unmodified header returned as-is
- custom-columns: columns from `views.yaml` are applied correctly