### PR TITLE
fix(secret): sort keys to prevent jumping when coding/decoding

### DIFF
--- a/internal/dao/secret.go
+++ b/internal/dao/secret.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/derailed/k9s/internal/slogs"
@@ -110,8 +112,8 @@ func (s *Secret) Decode(encodedDescription, path string) (string, error) {
 		return "", err
 	}
 	decodedSecrets := make([]string, 0, len(data))
-	for k, v := range data {
-		line := fmt.Sprintf("%s: %s", k, v)
+	for _, k := range slices.Sorted(maps.Keys(data)) {
+		line := fmt.Sprintf("%s: %s", k, data[k])
 		decodedSecrets = append(decodedSecrets, strings.TrimSpace(line))
 	}
 

--- a/internal/dao/secret_test.go
+++ b/internal/dao/secret_test.go
@@ -26,7 +26,14 @@ Type:  generic
 
 Data
 ====
-token-secret:  24 bytes`
+token-secret-a:  16 bytes
+token-secret-b:  16 bytes
+token-secret-c:  16 bytes
+token-secret-d:  16 bytes
+token-secret-e:  16 bytes
+token-secret-f:  16 bytes
+token-secret-g:  16 bytes
+token-secret-h:  16 bytes`
 
 	expected := "\nName: bootstrap-token-abcdef\n" +
 		"Namespace:    kube-system\n" +
@@ -37,7 +44,14 @@ token-secret:  24 bytes`
 		"\n" +
 		"Data\n" +
 		"====\n" +
-		"token-secret: 0123456789abcdef"
+		"token-secret-a: 0123456789abcdea\n" +
+		"token-secret-b: 0123456789abcdeb\n" +
+		"token-secret-c: 0123456789abcdec\n" +
+		"token-secret-d: 0123456789abcded\n" +
+		"token-secret-e: 0123456789abcdee\n" +
+		"token-secret-f: 0123456789abcdef\n" +
+		"token-secret-g: 0123456789abcdeg\n" +
+		"token-secret-h: 0123456789abcdeh"
 
 	decodedDescription, err := s.Decode(encodedString, "kube-system/bootstrap-token-abcdef")
 	require.NoError(t, err)

--- a/internal/dao/testdata/secret.json
+++ b/internal/dao/testdata/secret.json
@@ -1,7 +1,14 @@
 {
     "apiVersion": "v1",
     "data": {
-        "token-secret": "MDEyMzQ1Njc4OWFiY2RlZg=="
+        "token-secret-a": "MDEyMzQ1Njc4OWFiY2RlYQ==",
+        "token-secret-b": "MDEyMzQ1Njc4OWFiY2RlYg==",
+        "token-secret-c": "MDEyMzQ1Njc4OWFiY2RlYw==",
+        "token-secret-d": "MDEyMzQ1Njc4OWFiY2RlZA==",
+        "token-secret-e": "MDEyMzQ1Njc4OWFiY2RlZQ==",
+        "token-secret-f": "MDEyMzQ1Njc4OWFiY2RlZg==",
+        "token-secret-g": "MDEyMzQ1Njc4OWFiY2RlZw==",
+        "token-secret-h": "MDEyMzQ1Njc4OWFiY2RlaA=="
     },
     "kind": "Secret",
     "metadata": {


### PR DESCRIPTION
Secrets are jumping around when coding/decoding, sort them to avoid that.

I implemented this on k8s to fix this, but seems the client still doesn't order the output. Attempting a simpler sort instead: https://github.com/kubernetes/kubernetes/pull/130309