### PR TITLE
feat: add a native skin picker for installed skins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # -----------------------------------------------------------------------------
 # The base image for building the k9s binary
-FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine3.21 AS build
+FROM --platform=$BUILDPLATFORM golang:1.25.8-alpine AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OUTPUT_BIN      ?= execs/${NAME}
 GO_FLAGS        ?=
 GO_TAGS	        ?= netgo
 CGO_ENABLED     ?=0
-GIT_REV         ?= $(shell git rev-parse --short HEAD)
+GIT_REV         ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 
 IMG_NAME        := derailed/k9s
 IMAGE           := ${IMG_NAME}:${VERSION}

--- a/README.md
+++ b/README.md
@@ -315,21 +315,21 @@ k9s info
 
 Version:           vX.Y.Z
 Config:            /Users/fernand/.config/k9s/config.yaml
+Custom Views:      /Users/fernand/.config/k9s/views.yaml
+Plugins:           /Users/fernand/.config/k9s/plugins.yaml
+Hotkeys:           /Users/fernand/.config/k9s/hotkeys.yaml
+Aliases:           /Users/fernand/.config/k9s/aliases.yaml
+Skins:             /Users/fernand/.config/k9s/skins
+Context Configs:   /Users/fernand/.local/share/k9s/clusters
 Logs:              /Users/fernand/.local/state/k9s/k9s.log
-Dumps dir:         /Users/fernand/.local/state/k9s/screen-dumps
-Benchmarks dir:    /Users/fernand/.local/state/k9s/benchmarks
-Skins dir:         /Users/fernand/.local/share/k9s/skins
-Contexts dir:      /Users/fernand/.local/share/k9s/clusters
-Custom views file: /Users/fernand/.local/share/k9s/views.yaml
-Plugins file:      /Users/fernand/.local/share/k9s/plugins.yaml
-Hotkeys file:      /Users/fernand/.local/share/k9s/hotkeys.yaml
-Alias file:        /Users/fernand/.local/share/k9s/aliases.yaml
+Benchmarks:        /Users/fernand/.local/state/k9s/benchmarks
+ScreenDumps:       /Users/fernand/.local/state/k9s/screen-dumps
 ```
 
 ### View K9s logs
 
 ```shell
-tail -f /Users/fernand/.local/data/k9s/k9s.log
+tail -f /Users/fernand/.local/state/k9s/k9s.log
 ```
 
 ### Start K9s in debug mode
@@ -495,7 +495,7 @@ Clipboard behavior can also be controlled via environment variables:
       # Toggles reactive UI. This option provide for watching on disk artifacts changes and update the UI live Defaults to false.
       reactive: false
       # By default all contexts will use the dracula skin unless explicitly overridden in the context config file.
-      skin: dracula # => assumes the file skins/dracula.yaml is present in the  $XDG_DATA_HOME/k9s/skins directory. Can be overriden with K9S_SKIN.
+      skin: dracula # => assumes the file skins/dracula.yaml is present in the $XDG_CONFIG_HOME/k9s/skins directory. Can be overriden with K9S_SKIN.
       # Convert dark skins to light, or vice versa, preserving hue. Default: false
       invert: false
       # Allows to set certain views default fullscreen mode. (yaml, helm history, describe, value_extender, details, logs) Default false
@@ -614,7 +614,7 @@ In K9s, you can define your very own command aliases (shortnames) to access your
 A K9s alias defines pairs of alias:gvr. A gvr (Group/Version/Resource) represents a fully qualified Kubernetes resource identifier. Here is an example of an alias file:
 
 ```yaml
-#  $XDG_DATA_HOME/k9s/aliases.yaml
+#  $XDG_CONFIG_HOME/k9s/aliases.yaml
 aliases:
   pp: v1/pods
   crb: rbac.authorization.k8s.io/v1/clusterrolebindings
@@ -666,7 +666,7 @@ In order to surface hotkeys globally please follow these steps:
       ```
 
  Not feeling so hot? Your custom hotkeys will be listed in the help view `?`.
- Also your hotkeys file will be automatically reloaded so you can readily use your hotkeys as you define them.
+ K9s reloads hotkeys when it rebuilds actions, so updates will be picked up as views refresh and they will appear in help.
 
  You can choose any keyboard shortcuts that make sense to you, provided they are not part of the standard K9s shortcuts list.
 
@@ -947,7 +947,7 @@ The following defines a plugin for viewing logs on a selected pod using `ctrl-l`
 
 ```yaml
 # Define several plugins in a single file in the K9s root configuration
-# $XDG_DATA_HOME/k9s/plugins.yaml
+# $XDG_CONFIG_HOME/k9s/plugins.yaml
 plugins:
   # Defines a plugin to provide a `ctrl-l` shortcut to tail the logs while in pod view.
   fred:
@@ -1183,8 +1183,7 @@ You can skin k9s by default by specifying a UI.skin attribute. You can also chan
 In this case, you can specify a skin field on your cluster config aka `skin: dracula` (just the name of the skin file without the extension!) and copy this repo
 `skins/dracula.yaml` to `$XDG_CONFIG_HOME/k9s/skins/` directory. You can also change the skin by setting `K9S_SKIN` in the environment, e.g. `export K9S_SKIN="dracula"`.
 
-In the case where your cluster spans several contexts, you can add a skin context configuration to your context configuration.
-This is a collection of {context_name, skin} tuples (please see example below!)
+Context-specific skins are configured in each context config with a single `skin` field (please see the example below).
 
 Colors can be defined by name or using a hex representation. Of recent, we've added a color named `default` to indicate a transparent background color to preserve your terminal background color settings if so desired.
 
@@ -1234,7 +1233,7 @@ k9s:
     # Toggles reactive UI. This option provide for watching on disk artifacts changes and update the UI live  Defaults to false.
     reactive: false
     # By default all contexts will use the dracula skin unless explicitly overridden in the context config file.
-    skin: dracula # => assumes the file skins/dracula.yaml is present in the  $XDG_DATA_HOME/k9s/skins directory
+    skin: dracula # => assumes the file skins/dracula.yaml is present in the $XDG_CONFIG_HOME/k9s/skins directory
     defaultsToFullScreen: false
   skipLatestRevCheck: false
   disablePodCounting: false
@@ -1267,7 +1266,7 @@ k9s:
 ```
 
 ```yaml
-# $XDG_DATA_HOME/k9s/skins/in-the-navy.yaml
+# $XDG_CONFIG_HOME/k9s/skins/in-the-navy.yaml
 # Skin InTheNavy!
 k9s:
   # General K9s styles

--- a/internal/ui/dialog/notice.go
+++ b/internal/ui/dialog/notice.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dialog
+
+import (
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/tview"
+)
+
+// ShowNotice pops an informational dialog with a single dismiss action.
+func ShowNotice(styles *config.Dialog, pages *ui.Pages, title, msg string) {
+	f := tview.NewForm().
+		SetItemPadding(0).
+		SetButtonsAlign(tview.AlignCenter).
+		SetButtonBackgroundColor(styles.ButtonBgColor.Color()).
+		SetButtonTextColor(styles.ButtonFgColor.Color()).
+		SetLabelColor(styles.LabelFgColor.Color()).
+		SetFieldTextColor(styles.FieldFgColor.Color()).
+		SetFieldBackgroundColor(styles.BgColor.Color())
+	f.AddButton("Dismiss", func() {
+		dismiss(pages)
+	})
+	if b := f.GetButton(0); b != nil {
+		b.SetBackgroundColorActivated(styles.ButtonFocusBgColor.Color())
+		b.SetLabelColorActivated(styles.ButtonFocusFgColor.Color())
+	}
+	f.SetFocus(0)
+	modal := tview.NewModalForm("<"+title+">", f)
+	modal.SetText(msg)
+	modal.SetTextColor(styles.FgColor.Color())
+	modal.SetDoneFunc(func(int, string) {
+		dismiss(pages)
+	})
+	pages.AddPage(dialogKey, modal, false, false)
+	pages.ShowPage(dialogKey)
+}

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -259,6 +259,7 @@ func (a *App) bindKeys() {
 		ui.KeyLeftBracket:  ui.NewSharedKeyAction("Go Back", a.previousCommand, false),
 		ui.KeyRightBracket: ui.NewSharedKeyAction("Go Forward", a.nextCommand, false),
 		ui.KeyDash:         ui.NewSharedKeyAction("Last View", a.lastCommand, false),
+		ui.KeyShiftT:       ui.NewSharedKeyAction("Skins", a.skinPickerCmd, false),
 		tcell.KeyCtrlA:     ui.NewSharedKeyAction("Aliases", a.aliasCmd, false),
 		tcell.KeyEnter:     ui.NewKeyAction("Goto", a.gotoCmd, false),
 		tcell.KeyCtrlC:     ui.NewKeyAction("Quit", a.quitCmd, false),

--- a/internal/view/app_test.go
+++ b/internal/view/app_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/derailed/k9s/internal/config/mock"
+	"github.com/derailed/k9s/internal/ui"
 	"github.com/derailed/k9s/internal/view"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,5 +16,7 @@ func TestAppNew(t *testing.T) {
 	a := view.NewApp(mock.NewMockConfig(t))
 	_ = a.Init("blee", 10)
 
-	assert.Equal(t, 14, a.GetActions().Len())
+	assert.Equal(t, 15, a.GetActions().Len())
+	_, ok := a.GetActions().Get(ui.KeyShiftT)
+	assert.True(t, ok)
 }

--- a/internal/view/help.go
+++ b/internal/view/help.go
@@ -279,6 +279,10 @@ func (*Help) showGeneral() model.MenuHints {
 			Description: "Toggle Crumbs",
 		},
 		{
+			Mnemonic:    "Shift-t",
+			Description: "Skins",
+		},
+		{
 			Mnemonic:    ":q",
 			Description: "Quit",
 		},

--- a/internal/view/help_test.go
+++ b/internal/view/help_test.go
@@ -25,7 +25,7 @@ func TestHelp(t *testing.T) {
 	v := view.NewHelp(app)
 
 	require.NoError(t, v.Init(ctx))
-	assert.Equal(t, 20, v.GetRowCount())
+	assert.Equal(t, 21, v.GetRowCount())
 	assert.Equal(t, 8, v.GetColumnCount())
 	assert.Equal(t, "<a>", strings.TrimSpace(v.GetCell(1, 0).Text))
 	assert.Equal(t, "Attach", strings.TrimSpace(v.GetCell(1, 1).Text))

--- a/internal/view/skin_picker.go
+++ b/internal/view/skin_picker.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/ui/dialog"
+	"github.com/derailed/tcell/v2"
+)
+
+type skinScope int
+
+const (
+	skinScopeGlobal skinScope = iota
+	skinScopeContext
+	defaultSkinOption = "Default / Stock"
+)
+
+type skinApplyResult struct {
+	scope    skinScope
+	skin     string
+	warnings []string
+}
+
+func (r skinApplyResult) notice() string {
+	var b strings.Builder
+
+	switch {
+	case r.skin == "" && r.scope == skinScopeGlobal:
+		b.WriteString("Default skin restored in the global config and applied.")
+	case r.skin == "" && r.scope == skinScopeContext:
+		b.WriteString("Default skin restored for the current context and applied.")
+	case r.scope == skinScopeGlobal:
+		fmt.Fprintf(&b, "Skin %q saved to the global config and applied.", r.skin)
+	default:
+		fmt.Fprintf(&b, "Skin %q saved to the current context and applied.", r.skin)
+	}
+	b.WriteString("\n\nRestart K9s for a clean full-session refresh.")
+	if len(r.warnings) > 0 {
+		b.WriteString("\n\nNotes:")
+		for _, warning := range r.warnings {
+			b.WriteString("\n- ")
+			b.WriteString(warning)
+		}
+	}
+
+	return b.String()
+}
+
+func (a *App) skinPickerCmd(*tcell.EventKey) *tcell.EventKey {
+	a.showSkinScopePicker()
+	return nil
+}
+
+func (a *App) showSkinScopePicker() {
+	styles := a.Styles.Dialog()
+	options := []string{
+		"Global (all contexts)",
+		"Current context only",
+	}
+	dialog.ShowSelection(&styles, a.Content.Pages, "Skin Scope", options, func(index int) {
+		switch index {
+		case 0:
+			a.showSkinPicker(skinScopeGlobal)
+		case 1:
+			a.showSkinPicker(skinScopeContext)
+		}
+	})
+}
+
+func (a *App) showSkinPicker(scope skinScope) {
+	skins, err := installedSkinNames(config.AppSkinsDir)
+	if err != nil {
+		a.Flash().Err(err)
+		return
+	}
+	if len(skins) == 0 {
+		a.Flash().Warnf("No installed skins found in %q", config.AppSkinsDir)
+		return
+	}
+
+	options := append([]string{defaultSkinOption}, skins...)
+	title := "Global Skin"
+	if scope == skinScopeContext {
+		title = "Context Skin"
+	}
+	styles := a.Styles.Dialog()
+	dialog.ShowSelection(&styles, a.Content.Pages, title, options, func(index int) {
+		if index < 0 || index >= len(options) {
+			return
+		}
+
+		skin := ""
+		if index > 0 {
+			skin = skins[index-1]
+		}
+		result, err := a.applySkinSelection(scope, skin)
+		if err != nil {
+			a.Flash().Err(err)
+			return
+		}
+		dialog.ShowNotice(&styles, a.Content.Pages, "Restart Recommended", result.notice())
+	})
+}
+
+func installedSkinNames(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	skins := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			continue
+		}
+		skins = append(skins, strings.TrimSuffix(entry.Name(), ".yaml"))
+	}
+	sort.Strings(skins)
+
+	return skins, nil
+}
+
+func (a *App) applySkinSelection(scope skinScope, skin string) (skinApplyResult, error) {
+	result := skinApplyResult{
+		scope: scope,
+		skin:  skin,
+	}
+	if envSkin := os.Getenv("K9S_SKIN"); envSkin != "" {
+		result.warnings = append(result.warnings,
+			fmt.Sprintf("K9S_SKIN=%q still takes precedence over saved config values.", envSkin),
+		)
+	}
+
+	switch scope {
+	case skinScopeGlobal:
+		if err := a.saveGlobalSkin(skin); err != nil {
+			return skinApplyResult{}, err
+		}
+		if ct, err := a.Config.CurrentContext(); err == nil && ct.Skin != "" {
+			result.warnings = append(result.warnings,
+				"The current context has a context-specific skin and still overrides the global selection.",
+			)
+		}
+	case skinScopeContext:
+		if err := a.saveContextSkin(skin); err != nil {
+			return skinApplyResult{}, err
+		}
+	default:
+		return skinApplyResult{}, fmt.Errorf("unsupported skin scope: %d", scope)
+	}
+
+	a.ReloadStyles()
+
+	return result, nil
+}
+
+func (a *App) saveGlobalSkin(skin string) error {
+	a.Config.K9s.UI.Skin = skin
+	return a.Config.SaveFile(config.AppConfigFile)
+}
+
+func (a *App) saveContextSkin(skin string) error {
+	ct, err := a.Config.CurrentContext()
+	if err != nil {
+		return err
+	}
+	ct.Skin = skin
+	return a.Config.Save(true)
+}

--- a/internal/view/skin_picker_test.go
+++ b/internal/view/skin_picker_test.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/config/data"
+	"github.com/derailed/k9s/internal/config/mock"
+	"github.com/derailed/k9s/internal/model1"
+	"github.com/derailed/tcell/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestInstalledSkinNames(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "zeta.yaml"), []byte("zeta"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "alpha.yaml"), []byte("alpha"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "beta.yml"), []byte("beta"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("notes"), 0o600))
+
+	got, err := installedSkinNames(dir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha", "zeta"}, got)
+}
+
+func TestInstalledSkinNamesEmpty(t *testing.T) {
+	got, err := installedSkinNames(t.TempDir())
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestApplySkinSelectionGlobal(t *testing.T) {
+	app := newSkinTestApp(t)
+
+	writeGlobalConfigFixture(t, config.AppConfigFile)
+	require.NoError(t, app.Config.Load(config.AppConfigFile, true))
+	writeSkinFixture(t, config.AppSkinsDir, "black-and-wtf")
+
+	result, err := app.applySkinSelection(skinScopeGlobal, "black-and-wtf")
+	require.NoError(t, err)
+
+	assert.Equal(t, "black-and-wtf", app.Config.K9s.UI.Skin)
+	assert.True(t, app.HasSkin())
+	assert.Empty(t, result.warnings)
+	assert.Equal(t, tcell.ColorGhostWhite.TrueColor(), model1.StdColor)
+
+	var stored config.Config
+	readYAML(t, config.AppConfigFile, &stored)
+	require.NotNil(t, stored.K9s)
+	assert.Equal(t, "black-and-wtf", stored.K9s.UI.Skin)
+}
+
+func TestApplySkinSelectionContext(t *testing.T) {
+	app := newSkinTestApp(t)
+
+	writeSkinFixture(t, config.AppSkinsDir, "black-and-wtf")
+
+	result, err := app.applySkinSelection(skinScopeContext, "black-and-wtf")
+	require.NoError(t, err)
+
+	ct, err := app.Config.CurrentContext()
+	require.NoError(t, err)
+	assert.Equal(t, "black-and-wtf", ct.Skin)
+	assert.True(t, app.HasSkin())
+	assert.Empty(t, result.warnings)
+
+	var stored data.Config
+	readYAML(t, config.AppContextConfig("cl-1", "ct-1-1"), &stored)
+	require.NotNil(t, stored.Context)
+	assert.Equal(t, "black-and-wtf", stored.Context.Skin)
+}
+
+func TestApplySkinSelectionClearsGlobalSkin(t *testing.T) {
+	app := newSkinTestApp(t)
+
+	writeGlobalConfigFixture(t, config.AppConfigFile)
+	require.NoError(t, app.Config.Load(config.AppConfigFile, true))
+	writeSkinFixture(t, config.AppSkinsDir, "black-and-wtf")
+
+	_, err := app.applySkinSelection(skinScopeGlobal, "black-and-wtf")
+	require.NoError(t, err)
+
+	result, err := app.applySkinSelection(skinScopeGlobal, "")
+	require.NoError(t, err)
+
+	assert.Empty(t, app.Config.K9s.UI.Skin)
+	assert.False(t, app.HasSkin())
+	assert.Contains(t, result.notice(), "Default skin restored")
+
+	var stored config.Config
+	readYAML(t, config.AppConfigFile, &stored)
+	require.NotNil(t, stored.K9s)
+	assert.Empty(t, stored.K9s.UI.Skin)
+}
+
+func TestApplySkinSelectionClearsContextSkin(t *testing.T) {
+	app := newSkinTestApp(t)
+
+	writeSkinFixture(t, config.AppSkinsDir, "black-and-wtf")
+
+	_, err := app.applySkinSelection(skinScopeContext, "black-and-wtf")
+	require.NoError(t, err)
+
+	result, err := app.applySkinSelection(skinScopeContext, "")
+	require.NoError(t, err)
+
+	ct, err := app.Config.CurrentContext()
+	require.NoError(t, err)
+	assert.Empty(t, ct.Skin)
+	assert.False(t, app.HasSkin())
+	assert.Contains(t, result.notice(), "Default skin restored")
+
+	var stored data.Config
+	readYAML(t, config.AppContextConfig("cl-1", "ct-1-1"), &stored)
+	require.NotNil(t, stored.Context)
+	assert.Empty(t, stored.Context.Skin)
+}
+
+func TestApplySkinSelectionWarnsOnEnvOverride(t *testing.T) {
+	app := newSkinTestApp(t)
+	t.Setenv("K9S_SKIN", "env-skin")
+
+	writeGlobalConfigFixture(t, config.AppConfigFile)
+	require.NoError(t, app.Config.Load(config.AppConfigFile, true))
+	writeSkinFixture(t, config.AppSkinsDir, "black-and-wtf")
+
+	result, err := app.applySkinSelection(skinScopeGlobal, "black-and-wtf")
+	require.NoError(t, err)
+	assert.Contains(t, strings.Join(result.warnings, "\n"), "K9S_SKIN")
+}
+
+func TestApplySkinSelectionWarnsOnContextOverride(t *testing.T) {
+	app := newSkinTestApp(t)
+
+	writeGlobalConfigFixture(t, config.AppConfigFile)
+	require.NoError(t, app.Config.Load(config.AppConfigFile, true))
+	writeSkinFixture(t, config.AppSkinsDir, "black-and-wtf")
+	writeSkinFixture(t, config.AppSkinsDir, "ctx-override")
+
+	ct, err := app.Config.CurrentContext()
+	require.NoError(t, err)
+	ct.Skin = "ctx-override"
+
+	result, err := app.applySkinSelection(skinScopeGlobal, "black-and-wtf")
+	require.NoError(t, err)
+	assert.Contains(t, strings.Join(result.warnings, "\n"), "context-specific skin")
+}
+
+func TestHelpShowGeneralIncludesSkins(t *testing.T) {
+	h := &Help{}
+
+	found := false
+	for _, hint := range h.showGeneral() {
+		if hint.Mnemonic == "Shift-t" && hint.Description == "Skins" {
+			found = true
+			break
+		}
+	}
+
+	assert.True(t, found)
+}
+
+func newSkinTestApp(t testing.TB) *App {
+	t.Helper()
+
+	oldConfigFile := config.AppConfigFile
+	oldSkinsDir := config.AppSkinsDir
+	oldContextsDir := config.AppContextsDir
+	tmp := t.TempDir()
+	config.AppConfigFile = filepath.Join(tmp, "config.yaml")
+	config.AppSkinsDir = filepath.Join(tmp, "skins")
+	contextsDir := filepath.Join(tmp, "clusters")
+	require.NoError(t, os.MkdirAll(config.AppSkinsDir, 0o700))
+	require.NoError(t, os.MkdirAll(contextsDir, 0o700))
+	t.Cleanup(func() {
+		config.AppConfigFile = oldConfigFile
+		config.AppSkinsDir = oldSkinsDir
+		config.AppContextsDir = oldContextsDir
+	})
+
+	cfg := mock.NewMockConfig(t)
+	config.AppContextsDir = contextsDir
+	_, err := cfg.K9s.ActivateContext("ct-1-1")
+	require.NoError(t, err)
+
+	return NewApp(cfg)
+}
+
+func writeGlobalConfigFixture(t testing.TB, path string) {
+	t.Helper()
+
+	bb, err := os.ReadFile(filepath.Join("..", "config", "testdata", "configs", "default.yaml"))
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, bb, 0o600))
+}
+
+func writeSkinFixture(t testing.TB, dir, name string) {
+	t.Helper()
+
+	bb, err := os.ReadFile(filepath.Join("..", "config", "testdata", "skins", "black-and-wtf.yaml"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name+".yaml"), bb, 0o600))
+}
+
+func readYAML(t testing.TB, path string, target any) {
+	t.Helper()
+
+	bb, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NoError(t, yaml.Unmarshal(bb, target))
+}


### PR DESCRIPTION
## Summary
This PR adds a native skin picker so users can switch among already-installed skins without manually editing K9s YAML files.

## What changed
- add a global `Shift-T` action available from any view
- prompt for persistence scope first: `Global (all contexts)` or `Current context only`
- list installed skins from the configured `skins/` directory plus a leading `Default / Stock` option
- save global selections to the root `config.yaml` and context selections to the active context config
- reload styles immediately after save and show a dismiss-only restart recommendation
- surface precedence notes when `K9S_SKIN` or a context-specific skin still overrides the saved value
- add tests for skin discovery, persistence, warnings, and help/action registration
- align README examples with the current runtime config/path resolution

## Notes
- this is a picker for already-installed skins only; it does not download or install skins
- `Shift-T` was chosen as an unused default shortcut to avoid conflicting with existing bindings
- the global save path uses `SaveFile(config.AppConfigFile)` to avoid the root-config persistence pitfall seen in earlier reports

## Related context
I could not find an existing upstream issue that exactly matches this feature from this environment.
The related prior issues below informed the implementation, but this PR does not directly close them:
- #2421
- #1391
- #2583
- #2990