### PR TITLE
client: hint at stale kubeconfig endpoint on connect timeout

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -136,6 +136,9 @@ func loadConfiguration() (*config.Config, error) {
 
 	conn, err := client.InitConnection(k8sCfg, slog.Default())
 	if err != nil {
+		if hint := client.ConnectivityHint(err); hint != "" {
+			err = fmt.Errorf("%w (%s)", err, hint)
+		}
 		errs = errors.Join(errs, err)
 	}
 	k9sCfg.SetConnection(conn)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -326,11 +326,26 @@ func (a *APIClient) CheckConnectivity() bool {
 			a.reset()
 		}
 	} else {
-		slog.Error("Unable to fetch server version", slogs.Error, err)
+		if hint := ConnectivityHint(err); hint != "" {
+			slog.Error("Unable to fetch server version", slogs.Error, err, "hint", hint)
+		} else {
+			slog.Error("Unable to fetch server version", slogs.Error, err)
+		}
 		a.setConnOK(false)
 	}
 
 	return a.getConnOK()
+}
+
+func ConnectivityHint(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "i/o timeout") || strings.Contains(msg, "no such host") || strings.Contains(msg, "connection refused") {
+		return "API server endpoint may be stale — verify kubeconfig 'server:' field is current (e.g. re-run your cloud provider's get-credentials command)"
+	}
+	return ""
 }
 
 // Config return a kubernetes configuration.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,12 +4,38 @@
 package client
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	authorizationv1 "k8s.io/api/authorization/v1"
 )
+
+func TestConnectivityHint(t *testing.T) {
+	uu := map[string]struct {
+		err  error
+		want string
+	}{
+		"nil":               {err: nil, want: ""},
+		"io-timeout":        {err: errors.New(`Get "https://1.2.3.4/api?timeout=32s": dial tcp 1.2.3.4:443: i/o timeout`), want: "stale"},
+		"no-such-host":      {err: errors.New(`dial tcp: lookup foo.example.com: no such host`), want: "stale"},
+		"connection-refused": {err: errors.New(`dial tcp 1.2.3.4:443: connect: connection refused`), want: "stale"},
+		"unauthorized":      {err: errors.New(`Unauthorized`), want: ""},
+		"other":             {err: errors.New(`something else`), want: ""},
+	}
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			got := ConnectivityHint(u.err)
+			if u.want == "" {
+				assert.Empty(t, got)
+				return
+			}
+			assert.Contains(t, got, u.want)
+		})
+	}
+}
 
 func TestMakeSAR(t *testing.T) {
 	uu := map[string]struct {


### PR DESCRIPTION
When k9s can't reach the API server because of a network timeout, DNS failure, or refused connection, it now adds a short hint telling the user their kubeconfig server address may be stale and to re-run their cloud provider's get-credentials command. This catches the common case of cloud providers (like GKE) rotating the control-plane IP.
