### PR TITLE
Adjust namespace handling for RBAC checks in CanForResource and CanForInstance

### DIFF
--- a/internal/watch/factory.go
+++ b/internal/watch/factory.go
@@ -213,6 +213,11 @@ func (f *Factory) CanForResource(ns string, gvr *client.GVR, verbs []string) (in
 		return nil, fmt.Errorf("%v access denied on resource %q:%q", verbs, ns, gvr)
 	}
 
+	// Namespaces are cluster-scoped; always use cluster scope for the informer
+	if gvr == client.NsGVR {
+		ns = client.ClusterScope
+	}
+
 	return f.ForResource(ns, gvr)
 }
 
@@ -223,18 +228,20 @@ func (f *Factory) CanForInstance(fqn string, gvr *client.GVR, verbs []string) (i
 		ns = client.BlankNamespace
 	}
 
-	// For namespace resources, set namespace to the resource name to allow
-	// RoleBindings within that namespace to grant permissions
+	// For namespace resources, use the resource name as the namespace for RBAC
+	// (RoleBindings within that namespace can grant permissions),
+	// but keep the original ns for the informer since namespaces are cluster-scoped.
+	authNs := ns
 	if gvr == client.NsGVR {
-		ns = n
+		authNs = n
 	}
 
-	auth, err := f.Client().CanI(ns, gvr, n, verbs)
+	auth, err := f.Client().CanI(authNs, gvr, n, verbs)
 	if err != nil {
 		return nil, err
 	}
 	if !auth {
-		return nil, fmt.Errorf("%v access denied on resource %q:%q", verbs, ns, gvr)
+		return nil, fmt.Errorf("%v access denied on resource %q:%q", verbs, authNs, gvr)
 	}
 
 	return f.ForResource(ns, gvr)


### PR DESCRIPTION
follow-up to #3792.

#3792 restored the `ns = n` override for namespace RBAC in `CanForInstance`, but the modified `ns` also gets passed to `ForResource`, which creates a namespace-scoped informer for a cluster-scoped resource. This causes `namespaces "default" not found` when pressing `y` on a namespace, and for some users, reflector errors like `failed to list /v1, Resource=namespaces: the server could not find the requested resource`.

The same problem exists in `CanForResource` -- when called from `browser.Init()` with the active namespace (e.g. "cattle-fleet-system"), it passes that namespace to `ForResource`, creating a scoped informer that tries to list namespaces within that namespace.

Fix: separate the namespace used for RBAC from the one used for the informer.

- `CanForInstance`: introduce `authNs` for the `CanI` call; keep original `ns` (cluster scope) for `ForResource`
- `CanForResource`: reset `ns` to `ClusterScope` before calling `ForResource` when dealing with namespace GVR

Discussion: https://github.com/derailed/k9s/pull/3792/changes/BASE..fd81a05c104a7f095796b76a2257907802432587?notification_referrer_id=NT_kwHOA0ajiNoAJVJlcG9zaXRvcnk7MTY3NTk2MzkzO0lzc3VlOzM4NDYzNTI0MTE