### PR TITLE
feat: add a native plugins catalog view

### DIFF
--- a/internal/client/gvrs.go
+++ b/internal/client/gvrs.go
@@ -63,6 +63,7 @@ var (
 	SdGVR  = NewGVR("screendumps")
 	BeGVR  = NewGVR("benchmarks")
 	AliGVR = NewGVR("aliases")
+	PlgGVR = NewGVR("plugins")
 	XGVR   = NewGVR("xrays")
 	HlpGVR = NewGVR("help")
 	QGVR   = NewGVR("quit")
@@ -96,6 +97,7 @@ var reservedGVRs = sets.New(
 	SdGVR,
 	BeGVR,
 	AliGVR,
+	PlgGVR,
 	XGVR,
 	HlpGVR,
 	QGVR,

--- a/internal/config/alias.go
+++ b/internal/config/alias.go
@@ -193,6 +193,7 @@ func (a *Aliases) loadDefaultAliases() {
 	a.declare(client.PfGVR, "portforward", "pf")
 	a.declare(client.BeGVR, "benchmark", "bench")
 	a.declare(client.SdGVR, "screendump", "sd")
+	a.declare(client.PlgGVR, "plugin", "plugins", "plg")
 	a.declare(client.PuGVR, "pulse", "pu", "hz")
 	a.declare(client.XGVR, "xray", "x")
 	a.declare(client.WkGVR, "workload", "wk")

--- a/internal/config/alias_test.go
+++ b/internal/config/alias_test.go
@@ -113,7 +113,7 @@ func TestAliasesLoad(t *testing.T) {
 	a := config.NewAliases()
 	require.NoError(t, a.Load(path.Join(config.AppConfigDir, "plain.yaml")))
 
-	assert.Len(t, a.Alias, 55)
+	assert.Len(t, a.Alias, 58)
 }
 
 func TestAliasesSave(t *testing.T) {

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -30,6 +30,30 @@ type Plugins struct {
 	Plugins plugins `yaml:"plugins"`
 }
 
+// PluginSource identifies where a plugin was loaded from.
+type PluginSource string
+
+const (
+	PluginSourceGlobal      PluginSource = "global"
+	PluginSourceContext     PluginSource = "context"
+	PluginSourceXDGConfig   PluginSource = "xdg-config"
+	PluginSourceXDGDataHome PluginSource = "xdg-data-home"
+	PluginSourceXDGDataDir  PluginSource = "xdg-data-dir"
+)
+
+// PluginEntry tracks the effective plugin plus the file it came from.
+type PluginEntry struct {
+	Name   string
+	Path   string
+	Source PluginSource
+	Plugin Plugin
+}
+
+// PluginCatalog represents all effective plugins keyed by name.
+type PluginCatalog struct {
+	Entries map[string]PluginEntry
+}
+
 // PluginInputType represents the type of input field.
 type PluginInputType string
 
@@ -118,28 +142,57 @@ func NewPlugins() Plugins {
 	}
 }
 
+// NewPluginCatalog returns a new plugin catalog.
+func NewPluginCatalog() PluginCatalog {
+	return PluginCatalog{
+		Entries: make(map[string]PluginEntry),
+	}
+}
+
 // Load K9s plugins.
 func (p Plugins) Load(path string, loadExtra bool) error {
+	return loadPlugins(path, loadExtra, func(name string, plugin Plugin, _ string, _ PluginSource) {
+		p.Plugins[name] = plugin
+	})
+}
+
+// Load loads the effective plugin catalog including source metadata.
+func (p PluginCatalog) Load(path string, loadExtra bool) error {
+	return loadPlugins(path, loadExtra, func(name string, plugin Plugin, path string, source PluginSource) {
+		p.Entries[name] = PluginEntry{
+			Name:   name,
+			Path:   path,
+			Source: source,
+			Plugin: plugin,
+		}
+	})
+}
+
+type pluginSink func(name string, plugin Plugin, path string, source PluginSource)
+
+type pluginRoot struct {
+	path   string
+	source PluginSource
+}
+
+func loadPlugins(path string, loadExtra bool, sink pluginSink) error {
 	var errs error
 
 	// Load from global config file
-	if err := p.load(AppPluginsFile); err != nil {
+	if err := loadPluginFile(AppPluginsFile, PluginSourceGlobal, sink); err != nil {
 		errs = errors.Join(errs, err)
 	}
 
 	// Load from cluster/context config
-	if err := p.load(path); err != nil {
+	if err := loadPluginFile(path, PluginSourceContext, sink); err != nil {
 		errs = errors.Join(errs, err)
 	}
 
 	if !loadExtra {
 		return errs
 	}
-	// Load from XDG dirs
-	const k9sPluginsDir = "k9s/plugins"
-	for _, dir := range append(xdg.DataDirs, xdg.DataHome, xdg.ConfigHome) {
-		path := filepath.Join(dir, k9sPluginsDir)
-		if err := p.loadDir(path); err != nil {
+	for _, root := range xdgPluginRoots() {
+		if err := loadPluginDir(root.path, root.source, sink); err != nil {
 			errs = errors.Join(errs, err)
 		}
 	}
@@ -147,7 +200,39 @@ func (p Plugins) Load(path string, loadExtra bool) error {
 	return errs
 }
 
-func (p *Plugins) load(path string) error {
+func xdgPluginRoots() []pluginRoot {
+	const k9sPluginsDir = "k9s/plugins"
+
+	roots := make([]pluginRoot, 0, len(xdg.DataDirs)+2)
+	for _, dir := range xdg.DataDirs {
+		if dir == "" {
+			continue
+		}
+		roots = append(roots, pluginRoot{
+			path:   filepath.Join(dir, k9sPluginsDir),
+			source: PluginSourceXDGDataDir,
+		})
+	}
+	if xdg.DataHome != "" {
+		roots = append(roots, pluginRoot{
+			path:   filepath.Join(xdg.DataHome, k9sPluginsDir),
+			source: PluginSourceXDGDataHome,
+		})
+	}
+	if xdg.ConfigHome != "" {
+		roots = append(roots, pluginRoot{
+			path:   filepath.Join(xdg.ConfigHome, k9sPluginsDir),
+			source: PluginSourceXDGConfig,
+		})
+	}
+
+	return roots
+}
+
+func loadPluginFile(path string, source PluginSource, sink pluginSink) error {
+	if path == "" {
+		return nil
+	}
 	if _, err := os.Stat(path); errors.Is(err, fs.ErrNotExist) {
 		return nil
 	}
@@ -176,7 +261,7 @@ func (p *Plugins) load(path string) error {
 		if err := o.Validate(); err != nil {
 			return fmt.Errorf("plugin validation failed for %s: %w", path, err)
 		}
-		p.Plugins[strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))] = o
+		sink(strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)), o, path, source)
 	case json.PluginsSchema:
 		var oo Plugins
 		if err := yaml.Unmarshal(bb, &oo); err != nil {
@@ -187,7 +272,7 @@ func (p *Plugins) load(path string) error {
 			if err := plug.Validate(); err != nil {
 				return fmt.Errorf("plugin %q validation failed for %s: %w", k, path, err)
 			}
-			p.Plugins[k] = plug
+			sink(k, plug, path, source)
 		}
 	case json.PluginMultiSchema:
 		var oo plugins
@@ -199,14 +284,17 @@ func (p *Plugins) load(path string) error {
 			if err := plug.Validate(); err != nil {
 				return fmt.Errorf("plugin %q validation failed for %s: %w", k, path, err)
 			}
-			p.Plugins[k] = plug
+			sink(k, plug, path, source)
 		}
 	}
 
 	return nil
 }
 
-func (p Plugins) loadDir(dir string) error {
+func loadPluginDir(dir string, source PluginSource, sink pluginSink) error {
+	if dir == "" {
+		return nil
+	}
 	if _, err := os.Stat(dir); errors.Is(err, fs.ErrNotExist) {
 		return nil
 	}
@@ -218,7 +306,7 @@ func (p Plugins) loadDir(dir string) error {
 			if de.IsDir() || !isYamlFile(de.Name()) {
 				return nil
 			}
-			errs = errors.Join(errs, p.load(path))
+			errs = errors.Join(errs, loadPluginFile(path, source, sink))
 			return nil
 		},
 		ErrorCallback: func(osPathname string, err error) godirwalk.ErrorAction {
@@ -228,4 +316,16 @@ func (p Plugins) loadDir(dir string) error {
 	}))
 
 	return errs
+}
+
+func (p *Plugins) load(path string) error {
+	return loadPluginFile(path, PluginSourceGlobal, func(name string, plugin Plugin, _ string, _ PluginSource) {
+		p.Plugins[name] = plugin
+	})
+}
+
+func (p Plugins) loadDir(dir string) error {
+	return loadPluginDir(dir, PluginSourceXDGDataDir, func(name string, plugin Plugin, _ string, _ PluginSource) {
+		p.Plugins[name] = plugin
+	})
 }

--- a/internal/config/plugin_test.go
+++ b/internal/config/plugin_test.go
@@ -244,3 +244,60 @@ func TestPluginLoadSymlink(t *testing.T) {
 
 	assert.Equal(t, ee, p)
 }
+
+func TestPluginCatalogLoad(t *testing.T) {
+	tmp := t.TempDir()
+	globalPath := filepath.Join(tmp, "config", "plugins.yaml")
+	contextPath := filepath.Join(tmp, "contexts", "plugins.yaml")
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(globalPath), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(contextPath), 0o755))
+	require.NoError(t, os.WriteFile(globalPath, []byte(`plugins:
+  shared:
+    shortCut: Shift-G
+    description: global
+    scopes:
+      - all
+    command: kubectl
+  global-only:
+    shortCut: Shift-O
+    description: global only
+    scopes:
+      - all
+    command: kubectl
+`), 0o600))
+	require.NoError(t, os.WriteFile(contextPath, []byte(`plugins:
+  shared:
+    shortCut: Shift-C
+    description: context
+    scopes:
+      - pods
+    command: kubectl
+  context-only:
+    shortCut: Shift-X
+    description: context only
+    scopes:
+      - pods
+    command: kubectl
+`), 0o600))
+
+	origPluginsFile := AppPluginsFile
+	AppPluginsFile = globalPath
+	t.Cleanup(func() {
+		AppPluginsFile = origPluginsFile
+	})
+
+	catalog := NewPluginCatalog()
+	require.NoError(t, catalog.Load(contextPath, false))
+	require.Len(t, catalog.Entries, 3)
+
+	assert.Equal(t, PluginSourceContext, catalog.Entries["shared"].Source)
+	assert.Equal(t, contextPath, catalog.Entries["shared"].Path)
+	assert.Equal(t, "context", catalog.Entries["shared"].Plugin.Description)
+
+	assert.Equal(t, PluginSourceGlobal, catalog.Entries["global-only"].Source)
+	assert.Equal(t, globalPath, catalog.Entries["global-only"].Path)
+
+	assert.Equal(t, PluginSourceContext, catalog.Entries["context-only"].Source)
+	assert.Equal(t, contextPath, catalog.Entries["context-only"].Path)
+}

--- a/internal/dao/plugin.go
+++ b/internal/dao/plugin.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+import (
+	"context"
+	"sort"
+
+	"github.com/derailed/k9s/internal"
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/render"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ Accessor = (*Plugin)(nil)
+
+// Plugin lists the effective K9s plugins plus their source files.
+type Plugin struct {
+	NonResource
+}
+
+// NewPlugin returns a new plugin accessor.
+func NewPlugin(f Factory) *Plugin {
+	var p Plugin
+	p.Init(f, client.PlgGVR)
+	return &p
+}
+
+// List returns the effective plugin catalog.
+func (*Plugin) List(ctx context.Context, _ string) ([]runtime.Object, error) {
+	path, _ := ctx.Value(internal.KeyPath).(string)
+
+	catalog := config.NewPluginCatalog()
+	if err := catalog.Load(path, true); err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(catalog.Entries))
+	for name := range catalog.Entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	oo := make([]runtime.Object, 0, len(names))
+	for _, name := range names {
+		entry := catalog.Entries[name]
+		oo = append(oo, render.PluginRes{
+			Name:   entry.Name,
+			Path:   entry.Path,
+			Source: entry.Source,
+			Plugin: entry.Plugin,
+		})
+	}
+
+	return oo, nil
+}

--- a/internal/dao/plugin_test.go
+++ b/internal/dao/plugin_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/adrg/xdg"
+	"github.com/derailed/k9s/internal"
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/dao"
+	"github.com/derailed/k9s/internal/render"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPlugin(t *testing.T) {
+	tmp := t.TempDir()
+	globalPath := filepath.Join(tmp, "config", "plugins.yaml")
+	contextPath := filepath.Join(tmp, "contexts", "plugins.yaml")
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(globalPath), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(contextPath), 0o755))
+	require.NoError(t, os.WriteFile(globalPath, []byte(`plugins:
+  global-only:
+    shortCut: Shift-G
+    description: global
+    scopes:
+      - all
+    command: kubectl
+`), 0o600))
+	require.NoError(t, os.WriteFile(contextPath, []byte(`plugins:
+  context-only:
+    shortCut: Shift-C
+    description: context
+    scopes:
+      - pods
+    command: kubectl
+`), 0o600))
+
+	origPluginsFile := config.AppPluginsFile
+	origDataHome, origConfigHome, origDataDirs := xdg.DataHome, xdg.ConfigHome, xdg.DataDirs
+	config.AppPluginsFile = globalPath
+	xdg.DataHome = filepath.Join(tmp, "xdg-data")
+	xdg.ConfigHome = filepath.Join(tmp, "xdg-config")
+	xdg.DataDirs = nil
+	t.Cleanup(func() {
+		config.AppPluginsFile = origPluginsFile
+		xdg.DataHome, xdg.ConfigHome, xdg.DataDirs = origDataHome, origConfigHome, origDataDirs
+	})
+
+	p := dao.NewPlugin(nil)
+	ctx := context.WithValue(context.Background(), internal.KeyPath, contextPath)
+	oo, err := p.List(ctx, "")
+
+	require.NoError(t, err)
+	require.Len(t, oo, 2)
+
+	first, ok := oo[0].(render.PluginRes)
+	require.True(t, ok)
+	assert.Equal(t, "context-only", first.Name)
+
+	second, ok := oo[1].(render.PluginRes)
+	require.True(t, ok)
+	assert.Equal(t, "global-only", second.Name)
+}

--- a/internal/dao/registry.go
+++ b/internal/dao/registry.go
@@ -225,6 +225,14 @@ func loadK9s(m ResourceMetas) {
 		Verbs:        []string{},
 		Categories:   []string{k9sCat},
 	}
+	m[client.PlgGVR] = &metav1.APIResource{
+		Name:         "plugins",
+		Kind:         "Plugins",
+		SingularName: "plugin",
+		ShortNames:   []string{"plg"},
+		Verbs:        []string{},
+		Categories:   []string{k9sCat},
+	}
 	m[client.CtGVR] = &metav1.APIResource{
 		Name:         client.CtGVR.String(),
 		Kind:         "Contexts",

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -83,6 +83,10 @@ var Registry = map[*client.GVR]ResourceMeta{
 		DAO:      new(dao.Alias),
 		Renderer: new(render.Alias),
 	},
+	client.PlgGVR: {
+		DAO:      new(dao.Plugin),
+		Renderer: new(render.Plugin),
+	},
 
 	// Discovery...
 	client.EpsGVR: {

--- a/internal/render/plugin.go
+++ b/internal/render/plugin.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/model1"
+	"github.com/derailed/tcell/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const pluginRowIDSep = "\x1f"
+
+// Plugin renders a K9s plugin catalog entry.
+type Plugin struct{}
+
+// IsGeneric identifies a generic handler.
+func (Plugin) IsGeneric() bool {
+	return false
+}
+
+// Healthy checks if the resource is healthy.
+func (Plugin) Healthy(context.Context, any) error {
+	return nil
+}
+
+// ColorerFunc colors a resource row.
+func (Plugin) ColorerFunc() model1.ColorerFunc {
+	return func(string, model1.Header, *model1.RowEvent) tcell.Color {
+		return tcell.ColorLightSeaGreen
+	}
+}
+
+func (Plugin) SetViewSetting(*config.ViewSetting) {}
+
+// Header returns a header row.
+func (Plugin) Header(string) model1.Header {
+	return model1.Header{
+		model1.HeaderColumn{Name: "NAME"},
+		model1.HeaderColumn{Name: "SHORTCUT"},
+		model1.HeaderColumn{Name: "SCOPES"},
+		model1.HeaderColumn{Name: "LOCATION"},
+		model1.HeaderColumn{Name: "COMMAND"},
+		model1.HeaderColumn{Name: "SOURCE", Attrs: model1.Attrs{Wide: true}},
+	}
+}
+
+// Render renders a plugin catalog entry to screen.
+func (Plugin) Render(o any, _ string, r *model1.Row) error {
+	p, ok := o.(PluginRes)
+	if !ok {
+		return fmt.Errorf("expected PluginRes, but got %T", o)
+	}
+
+	r.ID = PluginRowID(p.Path, p.Name)
+	r.Fields = append(r.Fields,
+		p.Name,
+		p.Plugin.ShortCut,
+		strings.Join(p.Plugin.Scopes, ", "),
+		string(p.Source),
+		p.Plugin.Command,
+		p.Path,
+	)
+
+	return nil
+}
+
+// PluginRowID builds a stable row identifier.
+func PluginRowID(path, name string) string {
+	return path + pluginRowIDSep + name
+}
+
+// ParsePluginRowID extracts the file path and plugin name from a row id.
+func ParsePluginRowID(id string) (path, name string) {
+	path, name, _ = strings.Cut(id, pluginRowIDSep)
+	return path, name
+}
+
+// PluginRes represents an effective K9s plugin.
+type PluginRes struct {
+	Name   string
+	Path   string
+	Source config.PluginSource
+	Plugin config.Plugin
+}
+
+// GetObjectKind returns a schema object.
+func (PluginRes) GetObjectKind() schema.ObjectKind {
+	return nil
+}
+
+// DeepCopyObject returns a container copy.
+func (p PluginRes) DeepCopyObject() runtime.Object {
+	return p
+}

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -655,9 +655,11 @@ func (b *Browser) refreshActions() {
 	}
 	b.Actions().Merge(aa)
 
-	if err := pluginActions(b, b.Actions()); err != nil {
-		slog.Warn("Plugins load failed", slogs.Error, err)
-		b.app.Logo().Warn("Plugins load failed!")
+	if b.GVR() != client.PlgGVR {
+		if err := pluginActions(b, b.Actions()); err != nil {
+			slog.Warn("Plugins load failed", slogs.Error, err)
+			b.app.Logo().Warn("Plugins load failed!")
+		}
 	}
 	if err := hotKeyActions(b, b.Actions()); err != nil {
 		slog.Warn("Hotkeys load failed", slogs.Error, err)

--- a/internal/view/cmd/interpreter.go
+++ b/internal/view/cmd/interpreter.go
@@ -185,6 +185,11 @@ func (c *Interpreter) IsAliasCmd() bool {
 	return aliasCmd.Has(c.cmd)
 }
 
+// IsPluginCmd returns true if plugin cmd is detected.
+func (c *Interpreter) IsPluginCmd() bool {
+	return pluginCmd.Has(c.cmd)
+}
+
 // IsXrayCmd returns true if xray cmd is detected.
 func (c *Interpreter) IsXrayCmd() bool {
 	return xrayCmd.Has(c.cmd)

--- a/internal/view/cmd/types.go
+++ b/internal/view/cmd/types.go
@@ -69,6 +69,11 @@ var (
 		"alias",
 		"aliases",
 	)
+	pluginCmd = sets.New(
+		"plugin",
+		"plugins",
+		"plg",
+	)
 	xrayCmd = sets.New(
 		"x",
 		"xr",

--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -143,6 +143,15 @@ func (c *Command) aliasCmd(p *cmd.Interpreter, pushCmd bool) error {
 	return c.exec(p, client.AliGVR, v, false, pushCmd)
 }
 
+func (c *Command) pluginCmd(p *cmd.Interpreter, pushCmd bool) error {
+	filter, _ := p.FilterArg()
+
+	v := NewPlugin(client.PlgGVR)
+	v.SetFilter(filter, true)
+
+	return c.exec(p, client.PlgGVR, v, false, pushCmd)
+}
+
 func (c *Command) xrayCmd(p *cmd.Interpreter, pushCmd bool) error {
 	arg, cns, ok := p.XrayArgs()
 	if !ok {
@@ -281,6 +290,10 @@ func (c *Command) specialCmd(p *cmd.Interpreter, pushCmd bool) bool {
 		_ = c.app.helpCmd(nil)
 	case p.IsAliasCmd():
 		if err := c.aliasCmd(p, pushCmd); err != nil {
+			c.app.Flash().Err(err)
+		}
+	case p.IsPluginCmd():
+		if err := c.pluginCmd(p, pushCmd); err != nil {
 			c.app.Flash().Err(err)
 		}
 	case p.IsXrayCmd():

--- a/internal/view/plugin.go
+++ b/internal/view/plugin.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+
+	"github.com/derailed/k9s/internal"
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/config/data"
+	"github.com/derailed/k9s/internal/render"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/k9s/internal/ui/dialog"
+	"github.com/derailed/tcell/v2"
+)
+
+const (
+	pluginAddGlobalLabel  = "Global (all contexts)"
+	pluginAddContextLabel = "Current context only"
+	pluginSeedYAML        = `plugins:
+  plugin-name:
+    shortCut: Shift-X
+    description: Describe your plugin
+    scopes:
+      - all
+    command: kubectl
+    args:
+      - version
+`
+)
+
+// Plugin presents the effective plugin catalog.
+type Plugin struct {
+	ResourceViewer
+}
+
+// NewPlugin returns a new plugin catalog viewer.
+func NewPlugin(gvr *client.GVR) ResourceViewer {
+	p := Plugin{
+		ResourceViewer: NewBrowser(gvr),
+	}
+	p.GetTable().SetBorderFocusColor(tcell.ColorMediumAquamarine)
+	p.GetTable().SetSelectedStyle(tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorMediumAquamarine).Attributes(tcell.AttrNone))
+	p.AddBindKeysFn(p.bindKeys)
+	p.SetContextFn(p.pluginContext)
+
+	return &p
+}
+
+// Init initializes the view.
+func (p *Plugin) Init(ctx context.Context) error {
+	if err := p.ResourceViewer.Init(ctx); err != nil {
+		return err
+	}
+	p.GetTable().GetModel().SetNamespace(client.NotNamespaced)
+
+	return nil
+}
+
+func (p *Plugin) pluginContext(ctx context.Context) context.Context {
+	path, err := p.App().Config.ContextPluginsPath()
+	if err == nil && path != "" {
+		ctx = context.WithValue(ctx, internal.KeyPath, path)
+	}
+
+	return ctx
+}
+
+func (p *Plugin) bindKeys(aa *ui.KeyActions) {
+	aa.Delete(ui.KeyShiftA, ui.KeyShiftS, tcell.KeyCtrlSpace, ui.KeySpace)
+	aa.Delete(tcell.KeyCtrlW, tcell.KeyCtrlL)
+	aa.Bulk(ui.KeyMap{
+		tcell.KeyEnter: ui.NewKeyAction("View", p.viewCmd, true),
+		ui.KeyY:        ui.NewKeyAction(yamlAction, p.viewCmd, true),
+		ui.KeyShiftN:   ui.NewKeyAction("Sort Name", p.GetTable().SortColCmd("NAME", true), false),
+		ui.KeyShiftK:   ui.NewKeyAction("Sort Shortcut", p.GetTable().SortColCmd("SHORTCUT", true), false),
+		ui.KeyShiftC:   ui.NewKeyAction("Sort Command", p.GetTable().SortColCmd("COMMAND", true), false),
+		ui.KeyShiftS:   ui.NewKeyAction("Sort Source", p.GetTable().SortColCmd("SOURCE", true), false),
+	})
+	if !p.App().Config.IsReadOnly() {
+		aa.Add(ui.KeyA, ui.NewKeyAction("Add", p.addCmd, true))
+		aa.Add(ui.KeyE, ui.NewKeyAction("Edit", p.editCmd, true))
+	}
+}
+
+func (p *Plugin) selectedPlugin() (path, name string, ok bool) {
+	id := p.GetTable().GetSelectedItem()
+	if id == "" {
+		return "", "", false
+	}
+
+	path, name = render.ParsePluginRowID(id)
+	return path, name, path != "" && name != ""
+}
+
+func (p *Plugin) viewCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path, name, ok := p.selectedPlugin()
+	if !ok {
+		return evt
+	}
+
+	bb, err := os.ReadFile(path)
+	if err != nil {
+		p.App().Flash().Err(err)
+		return nil
+	}
+
+	details := NewDetails(p.App(), yamlAction, name, contentYAML, true).Update(string(bb))
+	if err := p.App().inject(details, false); err != nil {
+		p.App().Flash().Err(err)
+	}
+
+	return nil
+}
+
+func (p *Plugin) editCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path, _, ok := p.selectedPlugin()
+	if !ok {
+		return evt
+	}
+
+	p.editFile(path)
+
+	return nil
+}
+
+func (p *Plugin) addCmd(evt *tcell.EventKey) *tcell.EventKey {
+	type target struct {
+		label string
+		path  string
+	}
+
+	targets := []target{{
+		label: pluginAddGlobalLabel,
+		path:  config.AppPluginsFile,
+	}}
+	if path, err := p.App().Config.ContextPluginsPath(); err == nil && path != "" {
+		targets = append(targets, target{
+			label: pluginAddContextLabel,
+			path:  path,
+		})
+	}
+
+	openTarget := func(t target) {
+		if err := seedPluginFile(t.path); err != nil {
+			p.App().Flash().Err(err)
+			return
+		}
+		p.editFile(t.path)
+	}
+
+	if len(targets) == 1 {
+		openTarget(targets[0])
+		return nil
+	}
+
+	options := make([]string, 0, len(targets))
+	for _, t := range targets {
+		options = append(options, t.label)
+	}
+	d := p.App().Styles.Dialog()
+	dialog.ShowSelection(&d, p.App().Content.Pages, "Add Plugin", options, func(index int) {
+		if index < 0 || index >= len(targets) {
+			return
+		}
+		openTarget(targets[index])
+	})
+
+	return nil
+}
+
+func (p *Plugin) editFile(path string) {
+	p.Stop()
+	defer p.Start()
+	if !edit(p.App(), &shellOpts{clear: true, args: []string{path}}) {
+		p.App().Flash().Errf("Failed to launch editor")
+		return
+	}
+	p.Refresh()
+}
+
+func seedPluginFile(path string) error {
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	if err := data.EnsureDirPath(path, data.DefaultDirMod); err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, []byte(pluginSeedYAML), data.DefaultFileMod)
+}

--- a/internal/view/registrar.go
+++ b/internal/view/registrar.go
@@ -84,6 +84,9 @@ func miscViewers(vv MetaViewers) {
 	vv[client.AliGVR] = MetaViewer{
 		viewerFn: NewAlias,
 	}
+	vv[client.PlgGVR] = MetaViewer{
+		viewerFn: NewPlugin,
+	}
 	vv[client.RefGVR] = MetaViewer{
 		viewerFn: NewReference,
 	}


### PR DESCRIPTION
## Summary
This PR adds a native plugins catalog view so users can inspect and manage the plugins K9s actually loads without manually hunting through config files.

## What changed
- add a non-resource `plugins` view backed by the effective plugin catalog
- register `:plugin`, `:plugins`, and `:plg` aliases
- list effective plugins merged from the global `plugins.yaml`, current context config, and XDG plugin directories
- surface plugin source metadata in the view so users can see where each effective entry came from
- open the source YAML in the built-in viewer with `Enter` or `y`
- open the source file in the configured editor with `e`
- add an `a` flow that prompts for persistence scope first, then opens or seeds the correct `plugins.yaml`
- add DAO, render, and config coverage for plugin catalog loading and source precedence
- wire the view into the registry and command system like other built-in artifact views

## Notes
- this is a catalog and edit flow for plugins already present on disk; it does not install third-party plugin dependencies
- the view shows effective plugin resolution, including precedence across global, context, and XDG plugin sources
- the add flow follows the same scope-selection pattern used by the skin picker: `Global (all contexts)` or `Current context only`

## Related context
I could not find an existing upstream issue that exactly matches this feature from this environment.
This PR is intentionally parallel in scope and style to #3999, but for plugins instead of skins.
