### PR TITLE
fix: use BlankNamespace for NsGVR in CanForResource to avoid invalid API path

### DIFF
--- a/internal/watch/factory.go
+++ b/internal/watch/factory.go
@@ -213,7 +213,14 @@ func (f *Factory) CanForResource(ns string, gvr *client.GVR, verbs []string) (in
 		return nil, fmt.Errorf("%v access denied on resource %q:%q", verbs, ns, gvr)
 	}
 
-	return f.ForResource(ns, gvr)
+	// Namespaces are cluster-scoped; passing a specific namespace to ForResource
+	// would cause the informer factory to build an invalid path like
+	// /api/v1/namespaces/default/namespaces instead of /api/v1/namespaces.
+	forNs := ns
+	if gvr == client.NsGVR {
+		forNs = client.BlankNamespace
+	}
+	return f.ForResource(forNs, gvr)
 }
 
 // CanForInstance return an informer is user has access.

--- a/internal/watch/factory_test.go
+++ b/internal/watch/factory_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package watch
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	version "k8s.io/apimachinery/pkg/version"
+	disk "k8s.io/client-go/discovery/cached/disk"
+	"k8s.io/client-go/dynamic"
+	dfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	versioned "k8s.io/metrics/pkg/client/clientset/versioned"
+)
+
+func init() {
+	slog.SetDefault(slog.New(slog.DiscardHandler))
+}
+
+// TestCanForResourceNsGVRUsesBlankNamespace verifies that CanForResource for the
+// namespaces GVR always creates a cluster-scoped informer factory (keyed by
+// BlankNamespace) regardless of the active namespace. Before the fix, passing
+// ns="default" caused ensureFactory to create a namespace-scoped factory, which
+// in turn built the invalid API path /api/v1/namespaces/default/namespaces.
+func TestCanForResourceNsGVRUsesBlankNamespace(t *testing.T) {
+	uu := map[string]struct {
+		ns string
+	}{
+		"active-namespace": {ns: "default"},
+		"other-namespace":  {ns: "kube-system"},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			conn := newMockConn()
+			f := NewFactory(conn)
+
+			_, err := f.CanForResource(u.ns, client.NsGVR, client.ListAccess)
+			require.NoError(t, err)
+
+			// The factory for the namespaces GVR must be keyed by BlankNamespace,
+			// not by the active namespace, so the API path stays cluster-scoped.
+			_, hasBlank := f.factories[client.BlankNamespace]
+			assert.True(t, hasBlank, "expected cluster-scoped factory (BlankNamespace key)")
+
+			_, hasNs := f.factories[u.ns]
+			assert.False(t, hasNs, "unexpected namespace-scoped factory for %q — would produce invalid API path /api/v1/namespaces/%s/namespaces", u.ns, u.ns)
+		})
+	}
+}
+
+// mockConn satisfies client.Connection for tests; DynDial returns a no-op fake.
+type mockConn struct{}
+
+func newMockConn() mockConn { return mockConn{} }
+
+func (mockConn) CanI(string, *client.GVR, string, []string) (bool, error) { return true, nil }
+func (mockConn) Config() *client.Config                                    { return nil }
+func (mockConn) ConnectionOK() bool                                        { return true }
+func (mockConn) Dial() (kubernetes.Interface, error)                       { return nil, nil }
+func (mockConn) DialLogs() (kubernetes.Interface, error)                   { return nil, nil }
+func (mockConn) SwitchContext(string) error                                { return nil }
+func (mockConn) CachedDiscovery() (*disk.CachedDiscoveryClient, error)    { return nil, nil }
+func (mockConn) RestConfig() (*restclient.Config, error)                   { return nil, nil }
+func (mockConn) MXDial() (*versioned.Clientset, error)                    { return nil, nil }
+func (mockConn) DynDial() (dynamic.Interface, error) {
+	return dfake.NewSimpleDynamicClient(scheme.Scheme), nil
+}
+func (mockConn) HasMetrics() bool                                 { return false }
+func (mockConn) ValidNamespaceNames() (client.NamespaceNames, error) { return nil, nil }
+func (mockConn) IsValidNamespace(string) bool                     { return true }
+func (mockConn) ServerVersion() (*version.Info, error)            { return nil, nil }
+func (mockConn) CheckConnectivity() bool                          { return false }
+func (mockConn) ActiveContext() string                            { return "" }
+func (mockConn) ActiveNamespace() string                          { return "" }
+func (mockConn) IsActiveNamespace(string) bool                    { return false }


### PR DESCRIPTION
## Problem

When k9s is active in a specific namespace (e.g. `default`), it issues a request to:

```
GET /api/v1/namespaces/default/namespaces
```

This path does not exist in Kubernetes — `namespaces` is a cluster-scoped resource and has no namespace prefix. The API server returns `404`.

## Root Cause

`CanForResource` in `internal/watch/factory.go` correctly uses the active namespace for the RBAC `CanI` check (needed for RoleBinding resolution within that namespace), but then passes that same namespace straight to `ForResource`:

```go
// before
return f.ForResource(ns, gvr)  // ns = "default"
```

`ForResource` calls `ensureFactory(ns)`, which creates a `DynamicSharedInformerFactory` scoped to `"default"`. That factory appends the namespace to every resource path, producing `/api/v1/namespaces/default/namespaces` instead of `/api/v1/namespaces`.

## Fix

For `NsGVR` (and any other cluster-scoped GVR that gets this treatment), pass `BlankNamespace` to `ForResource` so `ensureFactory` creates a cluster-scoped factory:

```go
// after
forNs := ns
if gvr == client.NsGVR {
    forNs = client.BlankNamespace
}
return f.ForResource(forNs, gvr)
```

The `CanI` call is unchanged — it still uses the real namespace for correct RBAC evaluation.

## Test

Added `TestCanForResourceNsGVRUsesBlankNamespace` in `internal/watch/factory_test.go`. It creates a `Factory` with a fake dynamic client, calls `CanForResource` with `ns="default"` / `ns="kube-system"` and `gvr=NsGVR`, then asserts:

- `factories[BlankNamespace]` exists (cluster-scoped factory was created)
- `factories[ns]` does **not** exist (no namespace-scoped factory was created)