### PR TITLE
Fix pod status for sidecar init containers

### DIFF
--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -626,7 +626,7 @@ func hasPodReadyCondition(conditions []v1.PodCondition) bool {
 	return false
 }
 
-func initContainerStatus(pod *v1.Pod) (bool, string) {
+func initContainerStatus(pod *v1.Pod) (initializing bool, reason string) {
 	sidecars := make(map[string]bool)
 	for i := range pod.Spec.InitContainers {
 		if isSideCarContainer(pod.Spec.InitContainers[i].RestartPolicy) {

--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -539,6 +539,10 @@ func checkInitContainerStatus(cs *v1.ContainerStatus, count, initCount int, rest
 		if cs.State.Terminated.ExitCode == 0 {
 			return ""
 		}
+		// Sidecar containers are expected to be terminated when the pod completes.
+		if restartable {
+			return ""
+		}
 		if cs.State.Terminated.Reason != "" {
 			return "Init:" + cs.State.Terminated.Reason
 		}
@@ -570,11 +574,21 @@ func PodStatus(pod *v1.Pod) string {
 		}
 	}
 
+	sidecars := make(map[string]bool)
+	for i := range pod.Spec.InitContainers {
+		if isSideCarContainer(pod.Spec.InitContainers[i].RestartPolicy) {
+			sidecars[pod.Spec.InitContainers[i].Name] = true
+		}
+	}
+
 	var initializing bool
 	for i := range pod.Status.InitContainerStatuses {
 		container := pod.Status.InitContainerStatuses[i]
 		switch {
 		case container.State.Terminated != nil && container.State.Terminated.ExitCode == 0:
+			continue
+		case container.State.Terminated != nil && sidecars[container.Name]:
+			// Sidecar containers are expected to be terminated when the pod completes.
 			continue
 		case container.State.Terminated != nil:
 			if container.State.Terminated.Reason == "" {
@@ -591,6 +605,9 @@ func PodStatus(pod *v1.Pod) string {
 			reason = "Init:" + container.State.Waiting.Reason
 			initializing = true
 		default:
+			if sidecars[container.Name] {
+				continue
+			}
 			reason = fmt.Sprintf("Init:%d/%d", i, len(pod.Spec.InitContainers))
 			initializing = true
 		}

--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -574,44 +574,9 @@ func PodStatus(pod *v1.Pod) string {
 		}
 	}
 
-	sidecars := make(map[string]bool)
-	for i := range pod.Spec.InitContainers {
-		if isSideCarContainer(pod.Spec.InitContainers[i].RestartPolicy) {
-			sidecars[pod.Spec.InitContainers[i].Name] = true
-		}
-	}
-
-	var initializing bool
-	for i := range pod.Status.InitContainerStatuses {
-		container := pod.Status.InitContainerStatuses[i]
-		switch {
-		case container.State.Terminated != nil && container.State.Terminated.ExitCode == 0:
-			continue
-		case container.State.Terminated != nil && sidecars[container.Name]:
-			// Sidecar containers are expected to be terminated when the pod completes.
-			continue
-		case container.State.Terminated != nil:
-			if container.State.Terminated.Reason == "" {
-				if container.State.Terminated.Signal != 0 {
-					reason = fmt.Sprintf("Init:Signal:%d", container.State.Terminated.Signal)
-				} else {
-					reason = fmt.Sprintf("Init:ExitCode:%d", container.State.Terminated.ExitCode)
-				}
-			} else {
-				reason = "Init:" + container.State.Terminated.Reason
-			}
-			initializing = true
-		case container.State.Waiting != nil && container.State.Waiting.Reason != "" && container.State.Waiting.Reason != "PodInitializing":
-			reason = "Init:" + container.State.Waiting.Reason
-			initializing = true
-		default:
-			if sidecars[container.Name] {
-				continue
-			}
-			reason = fmt.Sprintf("Init:%d/%d", i, len(pod.Spec.InitContainers))
-			initializing = true
-		}
-		break
+	initializing, initReason := initContainerStatus(pod)
+	if initializing {
+		reason = initReason
 	}
 	if !initializing {
 		var hasRunning bool
@@ -659,6 +624,43 @@ func hasPodReadyCondition(conditions []v1.PodCondition) bool {
 	}
 
 	return false
+}
+
+func initContainerStatus(pod *v1.Pod) (bool, string) {
+	sidecars := make(map[string]bool)
+	for i := range pod.Spec.InitContainers {
+		if isSideCarContainer(pod.Spec.InitContainers[i].RestartPolicy) {
+			sidecars[pod.Spec.InitContainers[i].Name] = true
+		}
+	}
+
+	for i := range pod.Status.InitContainerStatuses {
+		container := pod.Status.InitContainerStatuses[i]
+		switch {
+		case container.State.Terminated != nil && container.State.Terminated.ExitCode == 0:
+			continue
+		case container.State.Terminated != nil && sidecars[container.Name]:
+			// Sidecar containers are expected to be terminated when the pod completes.
+			continue
+		case container.State.Terminated != nil:
+			if container.State.Terminated.Reason == "" {
+				if container.State.Terminated.Signal != 0 {
+					return true, fmt.Sprintf("Init:Signal:%d", container.State.Terminated.Signal)
+				}
+				return true, fmt.Sprintf("Init:ExitCode:%d", container.State.Terminated.ExitCode)
+			}
+			return true, "Init:" + container.State.Terminated.Reason
+		case container.State.Waiting != nil && container.State.Waiting.Reason != "" && container.State.Waiting.Reason != "PodInitializing":
+			return true, "Init:" + container.State.Waiting.Reason
+		default:
+			if sidecars[container.Name] {
+				continue
+			}
+			return true, fmt.Sprintf("Init:%d/%d", i, len(pod.Spec.InitContainers))
+		}
+	}
+
+	return false, ""
 }
 
 func isSideCarContainer(p *v1.ContainerRestartPolicy) bool {

--- a/internal/render/pod_test.go
+++ b/internal/render/pod_test.go
@@ -534,6 +534,88 @@ func TestCheckPodStatus(t *testing.T) {
 			},
 			e: "Running",
 		},
+		"sidecar-terminated-after-completion": {
+			pod: v1.Pod{
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name:          "sidecar",
+							RestartPolicy: ptrRestartPolicy(v1.ContainerRestartPolicyAlways),
+						},
+					},
+					Containers: []v1.Container{
+						{Name: "main"},
+					},
+				},
+				Status: v1.PodStatus{
+					Phase: v1.PodSucceeded,
+					InitContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "sidecar",
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									ExitCode: 137,
+									Reason:   "Error",
+								},
+							},
+						},
+					},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "main",
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									ExitCode: 0,
+									Reason:   "Completed",
+								},
+							},
+						},
+					},
+				},
+			},
+			e: "Completed",
+		},
+		"sidecar-terminated-signal": {
+			pod: v1.Pod{
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name:          "sidecar",
+							RestartPolicy: ptrRestartPolicy(v1.ContainerRestartPolicyAlways),
+						},
+					},
+					Containers: []v1.Container{
+						{Name: "main"},
+					},
+				},
+				Status: v1.PodStatus{
+					Phase: v1.PodSucceeded,
+					InitContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "sidecar",
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									ExitCode: 137,
+									Signal:   9,
+								},
+							},
+						},
+					},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "main",
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									ExitCode: 0,
+									Reason:   "Completed",
+								},
+							},
+						},
+					},
+				},
+			},
+			e: "Completed",
+		},
 	}
 
 	for k := range uu {
@@ -542,6 +624,10 @@ func TestCheckPodStatus(t *testing.T) {
 			assert.Equal(t, u.e, render.PodStatus(&u.pod))
 		})
 	}
+}
+
+func ptrRestartPolicy(p v1.ContainerRestartPolicy) *v1.ContainerRestartPolicy {
+	return &p
 }
 
 func TestCheckPhase(t *testing.T) {
@@ -649,6 +735,47 @@ func TestCheckPhase(t *testing.T) {
 				},
 			},
 			e: "Init:0/1",
+		},
+		"sidecar-terminated": {
+			pod: v1.Pod{
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name:          "ic1",
+							RestartPolicy: &always,
+						},
+					},
+					Containers: []v1.Container{
+						{Name: "c1"},
+					},
+				},
+				Status: v1.PodStatus{
+					Phase: v1.PodSucceeded,
+					InitContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "ic1",
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									ExitCode: 137,
+									Reason:   "Error",
+								},
+							},
+						},
+					},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "c1",
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									ExitCode: 0,
+									Reason:   "Completed",
+								},
+							},
+						},
+					},
+				},
+			},
+			e: "Completed",
 		},
 	}
 


### PR DESCRIPTION
Closes: #3101 #3985

Pods with sidecar init containers (`restartPolicy: Always`) show up as `Init:Error` after the job completes successfully. This happens because when the main container finishes, the kubelet kills the sidecar, and k9s sees that non-zero exit code and thinks init failed.

This updates both `checkInitContainerStatus` and `PodStatus` to recognize that a terminated sidecar is normal when the pod is done, so the status column correctly shows `Completed` instead of `Init:Error`.

Note: the sidecar container itself will still show a failed/terminated status if you drill into the pod details, since it technically is getting killed by the kubelet on shutdown. But the overall pod status will correctly show as completed, which imo is the right behavior here.