### PR TITLE
Implement auto-detection of terminal background for skin inversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
+	golang.org/x/term v0.42.0
 	golang.org/x/text v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.20.2
@@ -362,7 +363,6 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -13,11 +13,13 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/config/data"
 	"github.com/derailed/k9s/internal/slogs"
+	"github.com/derailed/k9s/internal/termdetect"
 )
 
 type gpuVendors map[string]string
@@ -62,7 +64,11 @@ type K9s struct {
 	conn                client.Connection
 	ks                  data.KubeSettings
 	mx                  sync.RWMutex
-	contextSwitch       bool
+	contextSwitch     bool
+	autoDetectDone    atomic.Bool
+	autoDetectResult  atomic.Bool
+	terminalLightDone atomic.Bool
+	terminalLightVal  atomic.Bool
 }
 
 // NewK9s create a new K9s configuration.
@@ -373,12 +379,83 @@ func (k *K9s) IsSplashless() bool {
 }
 
 // IsInvert returns invert setting.
+// When invert is forced (true), the terminal's perceived background is inverted
+// via OSC 11 before comparing with the skin theme. Falls back to force-invert
+// if OSC 11 fails.
+// When invert is false, auto-detects and inverts only if terminal and skin
+// themes differ.
 func (k *K9s) IsInvert() bool {
 	if IsBoolSet(k.UI.manualInvert) {
+		return k.forceInvert()
+	}
+	if k.UI.Invert {
+		return k.forceInvert()
+	}
+	return k.autoDetect()
+}
+
+func (k *K9s) getTerminalLight() (light, ok bool) {
+	if k.terminalLightDone.Load() {
+		return k.terminalLightVal.Load(), true
+	}
+	l, err := termdetect.IsBackgroundLight()
+	if err != nil {
+		k.terminalLightDone.Store(true)
+		return false, false
+	}
+	k.terminalLightVal.Store(l)
+	k.terminalLightDone.Store(true)
+	return l, true
+}
+
+func (k *K9s) skinIsLight() bool {
+	skinName := k.ResolveSkinName()
+	if skinName == "" {
+		return false
+	}
+	v, err := termdetect.SkinIsLight(SkinFileFromName(skinName))
+	if err != nil {
+		return false
+	}
+	return v
+}
+
+func (k *K9s) forceInvert() bool {
+	terminalLight, ok := k.getTerminalLight()
+	if !ok {
 		return true
 	}
+	return k.skinIsLight() != !terminalLight
+}
 
-	return k.UI.Invert
+func (k *K9s) autoDetect() bool {
+	if k.autoDetectDone.Load() {
+		return k.autoDetectResult.Load()
+	}
+	terminalLight, ok := k.getTerminalLight()
+	invert := false
+	if ok {
+		invert = k.skinIsLight() != terminalLight
+	}
+	k.autoDetectResult.Store(invert)
+	k.autoDetectDone.Store(true)
+	return invert
+}
+
+// ResolveSkinName resolves the active skin name.
+// Returns empty string if using stock skin.
+func (k *K9s) ResolveSkinName() string {
+	if envSkin := os.Getenv("K9S_SKIN"); envSkin != "" {
+		if _, err := os.Stat(SkinFileFromName(envSkin)); err == nil {
+			return envSkin
+		}
+	}
+	if ct, err := k.ActiveContext(); err == nil && ct.Skin != "" {
+		if _, err := os.Stat(SkinFileFromName(ct.Skin)); err == nil {
+			return ct.Skin
+		}
+	}
+	return k.UI.Skin
 }
 
 // GetRefreshRate returns the current refresh rate.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -37,7 +37,10 @@ type UI struct {
 	// NoIcons toggles icons display.
 	NoIcons bool `json:"noIcons" yaml:"noIcons"`
 
-	// Invert inverts all skin colors using Oklch lightness inversion.
+	// Invert controls the color inversion mode.
+	// When true, forces skin color inversion using Oklch lightness inversion.
+	// When false, auto-detects terminal background and inverts only if it
+	// differs from the skin theme.
 	Invert bool `json:"invert" yaml:"invert"`
 
 	// Skin reference the general k9s skin name.

--- a/internal/termdetect/detect.go
+++ b/internal/termdetect/detect.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package termdetect
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lucasb-eyer/go-colorful"
+	"golang.org/x/term"
+)
+
+const osc11QueryTimeout = 200 * time.Millisecond
+
+func IsBackgroundLight() (bool, error) {
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return false, fmt.Errorf("open /dev/tty: %w", err)
+	}
+	defer tty.Close()
+
+	fd := int(tty.Fd())
+	oldState, err := term.GetState(fd)
+	if err != nil {
+		return false, fmt.Errorf("get terminal state: %w", err)
+	}
+	defer term.Restore(fd, oldState)
+
+	if _, err := term.MakeRaw(fd); err != nil {
+		return false, fmt.Errorf("make raw: %w", err)
+	}
+
+	if _, err := tty.Write([]byte("\033]11;?\033\\")); err != nil {
+		return false, fmt.Errorf("write osc 11 query: %w", err)
+	}
+
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		buf := make([]byte, 128)
+		n, err := tty.Read(buf)
+		ch <- result{buf[:n], err}
+	}()
+
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			return false, fmt.Errorf("read osc 11 response: %w", r.err)
+		}
+		col, err := parseOSC11(r.data)
+		if err != nil {
+			return false, err
+		}
+		return luminance(col) > 0.5, nil
+	case <-time.After(osc11QueryTimeout):
+		return false, fmt.Errorf("osc 11 query timed out")
+	}
+}
+
+func parseOSC11(data []byte) (colorful.Color, error) {
+	s := string(data)
+	idx := strings.Index(s, "rgb:")
+	if idx < 0 {
+		return colorful.Color{}, fmt.Errorf("no rgb: prefix in osc 11 response")
+	}
+	rgb := s[idx+4:]
+	for i, c := range rgb {
+		if c == '\033' || c == '\a' {
+			rgb = rgb[:i]
+			break
+		}
+	}
+	parts := strings.Split(rgb, "/")
+	if len(parts) != 3 {
+		return colorful.Color{}, fmt.Errorf("expected 3 rgb components, got %d", len(parts))
+	}
+	r, err := parseComp(parts[0])
+	if err != nil {
+		return colorful.Color{}, fmt.Errorf("parse red: %w", err)
+	}
+	g, err := parseComp(parts[1])
+	if err != nil {
+		return colorful.Color{}, fmt.Errorf("parse green: %w", err)
+	}
+	b, err := parseComp(parts[2])
+	if err != nil {
+		return colorful.Color{}, fmt.Errorf("parse blue: %w", err)
+	}
+	return colorful.Color{R: r, G: g, B: b}, nil
+}
+
+func parseComp(s string) (float64, error) {
+	v, err := strconv.ParseUint(s, 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid hex %q: %w", s, err)
+	}
+	maxVal := float64(uint64(1)<<(4*uint(len(s))) - 1)
+	return float64(v) / maxVal, nil
+}
+
+func luminance(c colorful.Color) float64 {
+	return 0.2126*c.R + 0.7152*c.G + 0.0722*c.B
+}

--- a/internal/termdetect/skin.go
+++ b/internal/termdetect/skin.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package termdetect
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/derailed/tcell/v2"
+	"github.com/lucasb-eyer/go-colorful"
+	"gopkg.in/yaml.v3"
+)
+
+func SkinIsLight(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	var s struct {
+		K9s struct {
+			Body struct {
+				BgColor string `yaml:"bgColor"`
+			} `yaml:"body"`
+		} `yaml:"k9s"`
+	}
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		return false, err
+	}
+	if s.K9s.Body.BgColor == "" || s.K9s.Body.BgColor == "-" || s.K9s.Body.BgColor == "default" {
+		return false, nil
+	}
+	tc := tcell.GetColor(s.K9s.Body.BgColor).TrueColor()
+	hex := tc.Hex()
+	if hex < 0 {
+		return false, nil
+	}
+	col, err := colorful.Hex(fmt.Sprintf("#%06x", hex))
+	if err != nil {
+		return false, nil
+	}
+	return luminance(col) > 0.5, nil
+}


### PR DESCRIPTION
Query the terminal's background color via OSC 11 to automatically match the TUI to the terminal's light/dark theme.


- invert: false (default) — invert skin colors only when the terminal and skin have opposite light/dark themes
- invert: true / --invert — semantically inverts the terminal's light/dark state: makes the TUI appear dark on a light terminal, or light on a dark terminal
- When OSC 11 is unavailable: invert: true always inverts, invert: false does nothing
- CLI flags, YAML config format, and skin system unchanged — fully backward compatible