### PR TITLE
feat: toggle to show shortened container image name

### DIFF
--- a/internal/view/container.go
+++ b/internal/view/container.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
@@ -24,18 +25,18 @@ const containerTitle = "Containers"
 // Container represents a container view.
 type Container struct {
 	ResourceViewer
+	showFullImage bool
 }
 
 // NewContainer returns a new container view.
 func NewContainer(gvr *client.GVR) ResourceViewer {
-	c := Container{}
+	c := Container{showFullImage: true}
 	c.ResourceViewer = NewLogsExtender(NewBrowser(gvr), c.logOptions)
 	c.SetEnvFn(c.k9sEnv)
 	c.GetTable().SetEnterFn(c.viewLogs)
 	c.GetTable().SetDecorateFn(c.decorateRows)
 	c.GetTable().SetSortCol("IDX", true)
 	c.AddBindKeysFn(c.bindKeys)
-	c.GetTable().SetDecorateFn(c.portForwardIndicator)
 
 	return &c
 }
@@ -55,7 +56,39 @@ func (c *Container) portForwardIndicator(data *model1.TableData) {
 }
 
 func (c *Container) decorateRows(data *model1.TableData) {
+	c.portForwardIndicator(data)
+	c.decorateImageNames(data)
 	decorateCpuMemHeaderRows(c.App(), data)
+}
+
+func (c *Container) decorateImageNames(data *model1.TableData) {
+	if c.showFullImage {
+		return
+	}
+	col, ok := data.IndexOfHeader("IMAGE")
+	if !ok {
+		return
+	}
+
+	data.RowsRange(func(_ int, re model1.RowEvent) bool {
+		if col >= len(re.Row.Fields) {
+			return true
+		}
+		re.Row.Fields[col] = ShortContainerImageName(re.Row.Fields[col])
+
+		return true
+	})
+}
+
+func ShortContainerImageName(img string) string {
+	if idx := strings.Index(img, "@"); idx >= 0 {
+		img = img[:idx]
+	}
+	if idx := strings.LastIndex(img, "/"); idx >= 0 {
+		img = img[idx+1:]
+	}
+
+	return img
 }
 
 // Name returns the component name.
@@ -90,7 +123,19 @@ func (c *Container) bindKeys(aa *ui.KeyActions) {
 	aa.Bulk(ui.KeyMap{
 		ui.KeyF:      ui.NewKeyAction("Show PortForward", c.showPFCmd, true),
 		ui.KeyShiftF: ui.NewKeyAction("PortForward", c.portFwdCmd, true),
+		ui.KeyI:      ui.NewKeyAction("Toggle Full Image", c.toggleImageNameCmd, true),
 	})
+}
+
+func (c *Container) toggleImageNameCmd(evt *tcell.EventKey) *tcell.EventKey {
+	if c.App().InCmdMode() {
+		return evt
+	}
+
+	c.showFullImage = !c.showFullImage
+	c.GetTable().Refresh()
+
+	return nil
 }
 
 func (c *Container) k9sEnv() Env {

--- a/internal/view/container_test.go
+++ b/internal/view/container_test.go
@@ -17,5 +17,18 @@ func TestContainerNew(t *testing.T) {
 
 	require.NoError(t, c.Init(makeCtx(t)))
 	assert.Equal(t, "Containers", c.Name())
-	assert.Len(t, c.Hints(), 13)
+	assert.Len(t, c.Hints(), 14)
+}
+
+func TestShortContainerImageName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("digest and registry", func(t *testing.T) {
+		in := "europe-west3-docker.pkg.dev/acme/ghcr-io-proxy/derailed/k9s:latest@sha256:947974108bb93df64469fedaa0ab7191cdf86c608217d6ff9b497c4e96ff1069"
+		assert.Equal(t, "k9s:latest", view.ShortContainerImageName(in))
+	})
+
+	t.Run("keeps simple image", func(t *testing.T) {
+		assert.Equal(t, "busybox:1.37", view.ShortContainerImageName("busybox:1.37"))
+	})
 }


### PR DESCRIPTION
## Motivation

Some of our workloads are using a combination of container image proxy service (prefixes the container registry), as well as strictly pinning image versions using hash digest (suffixes the image tag). This results in impractically long image names. 

## This PR
Introduces a new feature to toggle displaying a shortened version of the container image name. It is bound to `i` key on the container view. When toggled on, the image name is reduced to the last part and its tag, minus the digest. The full name is displayed per default to preserve the current behaviour.

## Screenshots

<img width="1577" height="1061" alt="image" src="https://github.com/user-attachments/assets/3604cd0d-ae8f-43e7-837e-1e9db4a5c628" />

<img width="1577" height="1061" alt="image" src="https://github.com/user-attachments/assets/a9513000-c948-4e24-94d1-ec93b5b52d25" />
