### PR TITLE
fix: preserve quoted args for editor and pipe commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.8
 
 require (
 	github.com/adrg/xdg v0.5.3
+	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
 	github.com/anchore/clio v0.0.0-20250715152405-a0fa658e5084
 	github.com/anchore/grype v0.110.0
 	github.com/anchore/syft v1.42.3

--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	shlex "github.com/anmitsu/go-shlex"
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/model"
@@ -52,6 +53,15 @@ type shellOpts struct {
 
 func (s shellOpts) String() string {
 	return fmt.Sprintf("%s %s", s.binary, strings.Join(s.args, " "))
+}
+
+func splitCommandLine(s string) ([]string, error) {
+	tokens, err := shlex.Split(s, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return tokens, nil
 }
 
 func runK(a *App, opts *shellOpts) error {
@@ -136,7 +146,17 @@ func edit(a *App, opts *shellOpts) bool {
 		// followed by some arguments (e.g. "code -w" to make it work with vscode)
 		//
 		// In such cases, the actual binary is only the first token
-		envTokens := strings.Split(env, " ")
+		envTokens, splitErr := splitCommandLine(env)
+		if splitErr != nil {
+			slog.Warn("Unable to parse editor command, falling back to whitespace splitting",
+				slogs.Command, env,
+				slogs.Error, splitErr,
+			)
+			envTokens = strings.Fields(env)
+		}
+		if len(envTokens) == 0 {
+			continue
+		}
 
 		if bin, err = exec.LookPath(envTokens[0]); err == nil {
 			// Make sure the path is at the end (this allows running editors
@@ -205,18 +225,33 @@ func execute(opts *shellOpts, statusChan chan<- string) error {
 		// followed by some arguments (e.g. "code -w" to make it work with vscode)
 		//
 		// In such cases, the actual binary is only the first token
-		binTokens := strings.Split(env, " ")
-
-		if bin, err := exec.LookPath(binTokens[0]); err == nil {
-			binTokens[0] = bin
-			cmd.Env = append(os.Environ(), fmt.Sprintf("KUBE_EDITOR=%s", strings.Join(binTokens, " ")))
+		binTokens, splitErr := splitCommandLine(env)
+		if splitErr != nil {
+			slog.Warn("Unable to parse K9S_EDITOR, falling back to whitespace splitting",
+				slogs.Command, env,
+				slogs.Error, splitErr,
+			)
+			binTokens = strings.Fields(env)
+		}
+		if len(binTokens) > 0 {
+			if bin, err := exec.LookPath(binTokens[0]); err == nil {
+				binTokens[0] = bin
+				cmd.Env = append(os.Environ(), fmt.Sprintf("KUBE_EDITOR=%s", strings.Join(binTokens, " ")))
+			}
 		}
 	}
 
 	cmds = append(cmds, cmd)
 
 	for _, p := range opts.pipes {
-		tokens := strings.Split(p, " ")
+		tokens, splitErr := splitCommandLine(p)
+		if splitErr != nil {
+			slog.Warn("Unable to parse pipe command, falling back to whitespace splitting",
+				slogs.Command, p,
+				slogs.Error, splitErr,
+			)
+			tokens = strings.Fields(p)
+		}
 		if len(tokens) < 2 {
 			continue
 		}

--- a/internal/view/exec_test.go
+++ b/internal/view/exec_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitCommandLine(t *testing.T) {
+	uu := map[string]struct {
+		in string
+		e  []string
+	}{
+		"editor with quoted path": {
+			in: `"/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" -w`,
+			e:  []string{"/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code", "-w"},
+		},
+		"pipe with quoted jq program": {
+			in: `jq -r '.items[] | .metadata.name'`,
+			e:  []string{"jq", "-r", ".items[] | .metadata.name"},
+		},
+	}
+
+	for name := range uu {
+		u := uu[name]
+		t.Run(name, func(t *testing.T) {
+			got, err := splitCommandLine(u.in)
+			require.NoError(t, err)
+			assert.Equal(t, u.e, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4013

This was splitting quoted commands with plain `strings.Split(" ")`, so legit commands got mangled.

Repro:
1. Set `K9S_EDITOR='"/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" -w'`
2. Trigger an edit action in k9s
3. The editor path gets chopped into separate tokens, so it cant launch

Same deal for plugin pipes like `jq -r '.items[] | .metadata.name'`. The quoted jq expression gets broken up too, which is pretty normal irl usage.

What changed:
- use shell-style splitting for editor env vars and pipe commands
- add regression tests for quoted editor paths and quoted pipe args

Ran `make test`
