### PR TITLE
Refactor ScaleExtender to use unified dao.Scaler and improve scaling dialog

### DIFF
--- a/internal/view/scale_extender.go
+++ b/internal/view/scale_extender.go
@@ -109,20 +109,13 @@ func (s *ScaleExtender) replicasFromReady(_ string) (string, error) {
 }
 
 func (s *ScaleExtender) replicasFromScaleSubresource(sel string) (string, error) {
-	res, err := dao.AccessorFor(s.App().factory, s.GVR())
-	if err != nil {
-		return "", err
-	}
-
-	replicasGetter, ok := res.(dao.ReplicasGetter)
-	if !ok {
-		return "", fmt.Errorf("expecting a replicasGetter resource for %q", s.GVR())
-	}
-
+	var scaler dao.Scaler
+	scaler.Init(s.App().factory, s.GVR())
+	
 	ctx, cancel := context.WithTimeout(context.Background(), s.App().Conn().Config().CallTimeout())
 	defer cancel()
 
-	replicas, err := replicasGetter.Replicas(ctx, sel)
+	replicas, err := scaler.Replicas(ctx, sel)
 	if err != nil {
 		return "", err
 	}
@@ -145,12 +138,11 @@ func (s *ScaleExtender) makeScaleForm(fqns []string) (*tview.Form, error) {
 		// For built-in resources or cases where we can't get the replicas from the CRD, we can
 		// only try to get the number of copies from the READY field.
 		if factor == "0" {
-			replicas, err := s.replicasFromReady(fqns[0])
-			if err != nil {
-				return nil, err
+			if replicas, err := s.replicasFromReady(fqns[0]); err == nil {
+				factor = replicas
+			} else {
+				slog.Warn("Unable to read replicas from ready column", slogs.Error, err)
 			}
-
-			factor = replicas
 		}
 	}
 
@@ -222,7 +214,9 @@ func (s *ScaleExtender) scale(ctx context.Context, path string, replicas int32) 
 	}
 	scaler, ok := res.(dao.Scalable)
 	if !ok {
-		return fmt.Errorf("expecting a scalable resource for %q", s.GVR())
+		var genericScaler dao.Scaler
+		genericScaler.Init(s.App().factory, s.GVR())
+		return genericScaler.Scale(ctx, path, replicas)
 	}
 
 	return scaler.Scale(ctx, path, replicas)

--- a/internal/view/scale_extender.go
+++ b/internal/view/scale_extender.go
@@ -124,7 +124,9 @@ func (s *ScaleExtender) replicasFromScaleSubresource(sel string) (string, error)
 }
 
 func (s *ScaleExtender) makeScaleForm(fqns []string) (*tview.Form, error) {
-	factor := "0"
+	// Use empty string as the "unknown" sentinel so a legitimate current
+	// replica count of 0 (e.g., paused workload) is not treated as failure.
+	factor := ""
 	if len(fqns) == 1 {
 		// If the CRD resource supports scaling, then first try to
 		// read the replicas directly from the CRD.
@@ -137,13 +139,30 @@ func (s *ScaleExtender) makeScaleForm(fqns []string) (*tview.Form, error) {
 
 		// For built-in resources or cases where we can't get the replicas from the CRD, we can
 		// only try to get the number of copies from the READY field.
-		if factor == "0" {
-			if replicas, err := s.replicasFromReady(fqns[0]); err == nil {
+		var readyErr error
+		if factor == "" {
+			replicas, err := s.replicasFromReady(fqns[0])
+			if err == nil {
 				factor = replicas
 			} else {
+				readyErr = err
 				slog.Warn("Unable to read replicas from ready column", slogs.Error, err)
 			}
 		}
+
+		// Refuse to open the dialog when we cannot determine the current
+		// replica count — otherwise a user hitting OK without editing would
+		// silently scale the workload to zero.
+		if factor == "" {
+			if readyErr != nil {
+				return nil, fmt.Errorf("unable to determine current replica count: %w", readyErr)
+			}
+			return nil, fmt.Errorf("unable to determine current replica count for %s", fqns[0])
+		}
+	} else {
+		// Bulk-scale: there is no single "current" value to pre-fill, so the
+		// user must explicitly enter a target.  Keep the documented default.
+		factor = "0"
 	}
 
 	styles := s.App().Styles.Dialog()


### PR DESCRIPTION
## Summary
- Introduces a unified `dao.Scaler` interface and implementation to replace direct type assertions in `ScaleExtender`. Cleaner handling of different resource types.
- Refuses to open the scale dialog when the current replica count cannot be determined for a single-resource scale, so a user pressing OK without editing no longer silently scales the workload to zero.

## Background
The `dao.Scaler` refactor was originally bundled into the multi-tab feature branch. Reviewer flagged it as unrelated; it has been extracted here for independent review. The `feature/tabs` PR contains two revert commits that neutralise these changes there.

## Behavioural change in `makeScaleForm`
Before: when both `replicasFromScaleSubresource` and `replicasFromReady` failed, the dialog opened with `"0"` pre-filled and only a `slog.Warn` was logged. Confirming without editing → workload scaled to zero.

After:
- `""` is used as the "unknown" sentinel instead of `"0"`, so a legitimate scaled-to-zero workload still pre-fills correctly.
- For a single-resource scale where both read paths fail, the function returns an error; `showScaleDialog` surfaces it via the flash bar and the dialog never opens.
- Bulk-scale (`len(fqns) > 1`) keeps the documented `0` default — there is no single "current" value to pre-fill there, so the user must explicitly type the target.

## Test plan
- [x] `go build ./...`
- [ ] Manual smoke: scale a deployment with working RBAC — dialog opens with current count
- [ ] Manual smoke: scale with broken metadata read (e.g., resource removed mid-flight) — flash error, no dialog, no scale
- [ ] Manual smoke: paused (replicas=0) deployment — dialog pre-fills `0` correctly
- [ ] Manual smoke: multi-select scale 2+ deployments — dialog opens with `0` default, user must type target

