### PR TITLE
perf: reduce idle CPU, paginate metrics, fix nil-pointer crash on bad config

### DIFF
--- a/internal/client/metrics.go
+++ b/internal/client/metrics.go
@@ -20,6 +20,7 @@ import (
 const (
 	mxCacheSize   = 100
 	mxCacheExpiry = 1 * time.Minute
+	mxPageSize    = 500
 )
 
 // MetricsDial tracks global metric server handle.
@@ -164,13 +165,26 @@ func (m *MetricsServer) FetchNodesMetrics(ctx context.Context) (*mv1beta1.NodeMe
 		return mxList, nil
 	}
 
-	client, err := m.MXDial()
+	dial, err := m.MXDial()
 	if err != nil {
 		return mx, err
 	}
-	mxList, err := client.MetricsV1beta1().NodeMetricses().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return mx, err
+
+	mxList := new(mv1beta1.NodeMetricsList)
+	var cont string
+	for {
+		page, err := dial.MetricsV1beta1().NodeMetricses().List(ctx, metav1.ListOptions{
+			Limit:    mxPageSize,
+			Continue: cont,
+		})
+		if err != nil {
+			return mx, err
+		}
+		mxList.Items = append(mxList.Items, page.Items...)
+		cont = page.Continue
+		if cont == "" {
+			break
+		}
 	}
 	m.cache.Add(key, mxList, mxCacheExpiry)
 
@@ -235,17 +249,30 @@ func (m *MetricsServer) FetchPodsMetrics(ctx context.Context, ns string) (*mv1be
 		return mxList, nil
 	}
 
-	client, err := m.MXDial()
+	dial, err := m.MXDial()
 	if err != nil {
 		return mx, err
 	}
-	mxList, err := client.MetricsV1beta1().PodMetricses(ns).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return mx, err
+
+	mxList := new(mv1beta1.PodMetricsList)
+	var cont string
+	for {
+		page, err := dial.MetricsV1beta1().PodMetricses(ns).List(ctx, metav1.ListOptions{
+			Limit:    mxPageSize,
+			Continue: cont,
+		})
+		if err != nil {
+			return mx, err
+		}
+		mxList.Items = append(mxList.Items, page.Items...)
+		cont = page.Continue
+		if cont == "" {
+			break
+		}
 	}
 	m.cache.Add(key, mxList, mxCacheExpiry)
 
-	return mxList, err
+	return mxList, nil
 }
 
 // FetchContainersMetrics returns a pod's containers metrics.

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -114,12 +114,19 @@ func (k *K9s) Save(contextName, clusterName string, force bool) error {
 	)
 
 	if _, err := os.Stat(path); errors.Is(err, fs.ErrNotExist) || force {
+		cfg := k.getActiveConfig()
+		if cfg == nil {
+			slog.Warn("[CONFIG] Skipping save: no active context config loaded",
+				slogs.Context, k.getActiveContextName(),
+			)
+			return nil
+		}
 		slog.Debug("[CONFIG] Saving context config to disk",
 			slogs.Path, path,
-			slogs.Cluster, k.getActiveConfig().Context.GetClusterName(),
+			slogs.Cluster, cfg.Context.GetClusterName(),
 			slogs.Context, k.getActiveContextName(),
 		)
-		return k.dir.Save(path, k.getActiveConfig())
+		return k.dir.Save(path, cfg)
 	}
 
 	return nil

--- a/internal/model/table.go
+++ b/internal/model/table.go
@@ -23,7 +23,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const initRefreshRate = 300 * time.Millisecond
+const (
+	initRefreshRate = 300 * time.Millisecond
+
+	// ageForceRefreshRate controls how often the table fires events even when
+	// no row data changed, so that time columns (AGE) stay up to date in the UI.
+	ageForceRefreshRate = 15 * time.Second
+)
 
 // TableListener represents a table model listener.
 type TableListener interface {
@@ -48,6 +54,7 @@ type Table struct {
 	labelSelector labels.Selector
 	mx            sync.RWMutex
 	vs            *config.ViewSetting
+	lastFireTime  time.Time
 }
 
 // NewTable returns a new table model.
@@ -233,9 +240,21 @@ func (t *Table) refresh(ctx context.Context) error {
 	}
 	defer atomic.StoreInt32(&t.inUpdate, 0)
 
+	prevCount := t.data.RowCount()
 	if err := t.reconcile(ctx); err != nil {
 		return err
 	}
+	currCount := t.data.RowCount()
+
+	// Skip the expensive Clone+fire when the informer cache hasn't changed.
+	// Still fire every ageForceRefreshRate so time columns (AGE) stay current.
+	dataChanged := currCount != prevCount || t.data.HasChanges()
+	forceRefresh := time.Since(t.lastFireTime) >= ageForceRefreshRate
+	if !dataChanged && !forceRefresh {
+		return nil
+	}
+	t.lastFireTime = time.Now()
+
 	data := t.Peek()
 	if data.RowCount() == 0 {
 		t.fireNoData(data)

--- a/internal/model1/row_event.go
+++ b/internal/model1/row_event.go
@@ -254,6 +254,17 @@ func (r *RowEvents) FindIndex(id string) (int, bool) {
 	return i, ok
 }
 
+// HasChanges returns true if any row event has a kind other than EventUnchanged.
+// Used to skip unnecessary UI refreshes when the informer cache is idle.
+func (r *RowEvents) HasChanges() bool {
+	for _, e := range r.events {
+		if e.Kind != EventUnchanged {
+			return true
+		}
+	}
+	return false
+}
+
 // Sort rows based on column index and order.
 func (r *RowEvents) Sort(ns string, sortCol int, isDuration, numCol, isCapacity, asc bool) {
 	if sortCol == -1 || r == nil {

--- a/internal/model1/table_data.go
+++ b/internal/model1/table_data.go
@@ -481,6 +481,15 @@ func (t *TableData) Delete(newKeys sets.Set[string]) {
 	}
 }
 
+// HasChanges returns true if any row has a kind other than EventUnchanged.
+// Time columns (AGE) are excluded from delta computation, so a purely
+// age-driven cycle returns false here.
+func (t *TableData) HasChanges() bool {
+	t.mx.RLock()
+	defer t.mx.RUnlock()
+	return t.rowEvents.HasChanges()
+}
+
 // Diff checks if two tables are equal.
 func (t *TableData) Diff(t2 *TableData) bool {
 	if t2 == nil || t.namespace != t2.namespace || t.header.Diff(t2.header) {

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -539,7 +539,9 @@ func (a *App) BailOut(exitCode int) {
 	}
 
 	a.stopImgScanner()
-	a.factory.Terminate()
+	if a.factory != nil {
+		a.factory.Terminate()
+	}
 	a.App.BailOut(exitCode)
 }
 

--- a/internal/watch/factory.go
+++ b/internal/watch/factory.go
@@ -21,8 +21,14 @@ import (
 )
 
 const (
-	defaultResync   = 10 * time.Minute
-	defaultWaitTime = 500 * time.Millisecond
+	// defaultResync=0 disables the periodic resync that replays all cached objects
+	// through event handlers on a timer. Informers rely on the watch stream for
+	// real-time updates; the periodic resync only burns CPU without benefit.
+	defaultResync = 0
+
+	// defaultWaitTime is raised from 500ms to give large clusters enough time
+	// for HasSynced() to return true before falling back to a direct list.
+	defaultWaitTime = 2 * time.Second
 )
 
 // Factory tracks various resource informers.


### PR DESCRIPTION
## Summary

This PR bundles two groups of changes targeting performance and crash resilience:

### Performance improvements

**Skip redundant UI refreshes on idle clusters** (`model/table`, `model1`)

The reconcile loop fires `Clone()` + `fireTableChanged()` every 2 s even when the informer cache hasn't changed. On clusters with many pods this burns CPU and allocates memory needlessly. Added `RowEvents.HasChanges()` / `TableData.HasChanges()` which return `true` only when at least one row has kind `EventAdd`, `EventUpdate`, or was deleted. The table model now skips the clone+fire when nothing changed, and force-refreshes every 15 s so `AGE` columns stay current.

**Disable periodic informer resync** (`watch/factory`)

`defaultResync = 10 * time.Minute` caused all cached objects to be replayed through event handlers every 10 min, burning CPU with no benefit — the watch stream already provides real-time updates. Set to `0` to disable. Also raised `defaultWaitTime` from 500 ms to 2 s so `HasSynced()` has enough time to return `true` on large clusters (fixes silent failures in "jump to owner", related to #3911).

**Paginate metrics API calls** (`client/metrics`)

`FetchPodsMetrics` and `FetchNodesMetrics` issued a single unbounded `LIST` that hits the API server `max-request-bytes` limit on clusters with 10 k+ pods, causing timeouts. Now paginated at 500 items/page with a `Continue` loop (same approach as proposed in #3987).

### Bug fixes

**Nil pointer crash when context config YAML is invalid** (`config/k9s`, `view/app`)

When `ActivateContext()` fails (e.g. corrupted `config.yaml` — duplicate/misindented lines), `setActiveConfig()` is never called, leaving `activeConfig` nil. The subsequent `Save()` call in `loadConfiguration()` then dereferences `getActiveConfig().Context` unconditionally → panic → "Boom!!" on startup. Added a nil guard that logs a warning and returns early instead.

Also guarded `factory.Terminate()` in `BailOut()` against a nil factory, which occurs when `Init()` exits before the factory is created.

## Test plan

- [x] `go test ./internal/model1/... ./internal/model/... ./internal/watch/... ./internal/client/... ./internal/config/... ./internal/view/...` — all pass
- [x] Binary built and manually tested against a real EKS cluster
- [ ] Verify idle CPU reduction with `top` on a cluster with 100+ pods
- [ ] Verify metrics pagination on a cluster with 1000+ pods