### PR TITLE
hotfix: lint error in metrics.go and helper_test.go

### DIFF
--- a/internal/client/metrics.go
+++ b/internal/client/metrics.go
@@ -18,8 +18,8 @@ import (
 )
 
 const (
-	mxCacheSize    = 100
-	mxCacheExpiry  = 1 * time.Minute
+	mxCacheSize           = 100
+	mxCacheExpiry         = 1 * time.Minute
 	metricsPageSize int64 = 500
 )
 

--- a/internal/model1/helpers_test.go
+++ b/internal/model1/helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSortLabels(t *testing.T) {
@@ -162,7 +163,7 @@ func TestParallelRender(t *testing.T) {
 				results[i] = i + 1
 				return nil
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			for i := range u.n {
 				assert.Equal(t, i+1, results[i], "index %d", i)
 			}
@@ -177,7 +178,7 @@ func TestParallelRenderError(t *testing.T) {
 		}
 		return nil
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "boom")
 }
 


### PR DESCRIPTION
#3987 introduced a lint errors
