### PR TITLE
feat: add favorites management for namespaces with toggle functionality

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,6 +207,50 @@ func (c *Config) SetActiveNamespace(ns string) error {
 	return ct.Namespace.SetActive(ns, c.settings)
 }
 
+// AddFavNamespace adds a namespace to favorites and locks the list.
+func (c *Config) AddFavNamespace(ns string) error {
+	ct, err := c.K9s.ActiveContext()
+	if err != nil {
+		return err
+	}
+	ct.Namespace.AddFavNS(ns)
+	ct.Namespace.SetLockFavorites(true)
+
+	return nil
+}
+
+// RemoveFavNamespace removes a namespace from favorites.
+func (c *Config) RemoveFavNamespace(ns string) error {
+	ct, err := c.K9s.ActiveContext()
+	if err != nil {
+		return err
+	}
+	ct.Namespace.RmFavNS(ns)
+
+	return nil
+}
+
+// IsFavNamespace checks if a namespace is in the favorites list.
+func (c *Config) IsFavNamespace(ns string) bool {
+	ct, err := c.K9s.ActiveContext()
+	if err != nil {
+		return false
+	}
+
+	return ct.Namespace.IsFav(ns)
+}
+
+// UnlockFavNamespaces re-enables dynamic favorite assignment.
+func (c *Config) UnlockFavNamespaces() error {
+	ct, err := c.K9s.ActiveContext()
+	if err != nil {
+		return err
+	}
+	ct.Namespace.SetLockFavorites(false)
+
+	return nil
+}
+
 // ActiveView returns the active view in the current context.
 func (c *Config) ActiveView() string {
 	ct, err := c.K9s.ActiveContext()

--- a/internal/config/data/ns.go
+++ b/internal/config/data/ns.go
@@ -104,6 +104,14 @@ func (n *Namespace) isAllNamespaces() bool {
 	return n.Active == client.NamespaceAll || n.Active == ""
 }
 
+// AddFavNS adds a namespace to favorites if not already present.
+func (n *Namespace) AddFavNS(ns string) {
+	n.mx.Lock()
+	defer n.mx.Unlock()
+
+	n.addFavNS(ns)
+}
+
 func (n *Namespace) addFavNS(ns string) {
 	if slices.Contains(n.Favorites, ns) {
 		return
@@ -119,11 +127,15 @@ func (n *Namespace) addFavNS(ns string) {
 	n.Favorites = nfv
 }
 
-func (n *Namespace) rmFavNS(ns string) {
-	if n.LockFavorites {
-		return
-	}
+// RmFavNS removes a namespace from favorites.
+func (n *Namespace) RmFavNS(ns string) {
+	n.mx.Lock()
+	defer n.mx.Unlock()
 
+	n.rmFavNS(ns)
+}
+
+func (n *Namespace) rmFavNS(ns string) {
 	victim := -1
 	for i, f := range n.Favorites {
 		if f == ns {
@@ -136,6 +148,22 @@ func (n *Namespace) rmFavNS(ns string) {
 	}
 
 	n.Favorites = append(n.Favorites[:victim], n.Favorites[victim+1:]...)
+}
+
+// SetLockFavorites enables or disables the lock on favorites.
+func (n *Namespace) SetLockFavorites(lock bool) {
+	n.mx.Lock()
+	defer n.mx.Unlock()
+
+	n.LockFavorites = lock
+}
+
+// IsFav checks if a namespace is in the favorites list.
+func (n *Namespace) IsFav(ns string) bool {
+	n.mx.RLock()
+	defer n.mx.RUnlock()
+
+	return slices.Contains(n.Favorites, ns)
 }
 
 func (n *Namespace) trimFavNs() {

--- a/internal/model1/table_data.go
+++ b/internal/model1/table_data.go
@@ -40,6 +40,7 @@ const spacer = " "
 
 type FilterOpts struct {
 	Toast  bool
+	Favs   bool
 	Filter string
 	Invert bool
 }
@@ -146,6 +147,9 @@ func (t *TableData) Filter(f FilterOpts) *TableData {
 	if f.Toast {
 		td.rowEvents = t.filterToast()
 	}
+	if f.Favs {
+		td.rowEvents = t.filterFavs()
+	}
 	if f.Filter == "" || internal.IsLabelSelector(f.Filter) {
 		return td
 	}
@@ -226,6 +230,18 @@ func (t *TableData) filterToast() *RowEvents {
 	}
 	t.rowEvents.Range(func(_ int, re RowEvent) bool {
 		if re.Row.Fields[idx] != "" {
+			rr.Add(re)
+		}
+		return true
+	})
+
+	return rr
+}
+
+func (t *TableData) filterFavs() *RowEvents {
+	rr := NewRowEvents(10)
+	t.rowEvents.Range(func(_ int, re RowEvent) bool {
+		if len(re.Row.Fields) > 0 && strings.HasSuffix(re.Row.Fields[0], "+") {
 			rr.Add(re)
 		}
 		return true

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -52,6 +52,7 @@ type Table struct {
 	decorateFn     DecorateFunc
 	wide           bool
 	toast          bool
+	favs           bool
 	hasMetrics     bool
 	ctx            context.Context
 	mx             sync.RWMutex
@@ -353,6 +354,12 @@ func (t *Table) ToggleToast() {
 	t.Refresh()
 }
 
+// ToggleFavs toggles to show only favorite resources.
+func (t *Table) ToggleFavs() {
+	t.favs = !t.favs
+	t.Refresh()
+}
+
 // ToggleWide toggles wide col display.
 func (t *Table) ToggleWide() {
 	t.wide = !t.wide
@@ -644,6 +651,7 @@ func (t *Table) AddHeaderCell(col int, h model1.HeaderColumn) {
 func (t *Table) filtered(data *model1.TableData) *model1.TableData {
 	return data.Filter(model1.FilterOpts{
 		Toast:  t.toast,
+		Favs:   t.favs,
 		Filter: t.cmdBuff.GetText(),
 	})
 }

--- a/internal/view/ns.go
+++ b/internal/view/ns.go
@@ -35,8 +35,50 @@ func NewNamespace(gvr *client.GVR) ResourceViewer {
 
 func (n *Namespace) bindKeys(aa *ui.KeyActions) {
 	aa.Bulk(ui.KeyMap{
-		ui.KeyU: ui.NewKeyAction("Use", n.useNsCmd, true),
+		ui.KeyU:        ui.NewKeyAction("Use", n.useNsCmd, true),
+		tcell.KeyCtrlF: ui.NewKeyAction("Toggle Favorites", n.toggleFavsCmd, true),
+		ui.KeyF:        ui.NewKeyAction("Fav/Unfav", n.toggleFavCmd, true),
+		tcell.KeyCtrlL: ui.NewKeyAction("Unlock Favorites", n.unlockFavsCmd, true),
 	})
+}
+
+func (n *Namespace) toggleFavsCmd(*tcell.EventKey) *tcell.EventKey {
+	n.GetTable().ToggleFavs()
+	return nil
+}
+
+func (n *Namespace) toggleFavCmd(*tcell.EventKey) *tcell.EventKey {
+	path := n.GetTable().GetSelectedItem()
+	if path == "" {
+		return nil
+	}
+	_, ns := client.Namespaced(path)
+	if n.App().Config.IsFavNamespace(ns) {
+		if err := n.App().Config.RemoveFavNamespace(ns); err != nil {
+			n.App().Flash().Err(err)
+			return nil
+		}
+		n.App().Flash().Infof("Removed %q from favorites", ns)
+	} else {
+		if err := n.App().Config.AddFavNamespace(ns); err != nil {
+			n.App().Flash().Err(err)
+			return nil
+		}
+		n.App().Flash().Infof("Added %q to favorites (auto-locked)", ns)
+	}
+	n.Refresh()
+
+	return nil
+}
+
+func (n *Namespace) unlockFavsCmd(*tcell.EventKey) *tcell.EventKey {
+	if err := n.App().Config.UnlockFavNamespaces(); err != nil {
+		n.App().Flash().Err(err)
+		return nil
+	}
+	n.App().Flash().Info("Favorites unlocked - dynamic assignment enabled")
+
+	return nil
 }
 
 func (n *Namespace) switchNs(app *App, _ ui.Tabular, _ *client.GVR, path string) {

--- a/internal/view/ns_test.go
+++ b/internal/view/ns_test.go
@@ -17,5 +17,5 @@ func TestNSCleanser(t *testing.T) {
 
 	require.NoError(t, ns.Init(makeCtx(t)))
 	assert.Equal(t, "Namespaces", ns.Name())
-	assert.Len(t, ns.Hints(), 8)
+	assert.Len(t, ns.Hints(), 11)
 }


### PR DESCRIPTION
Closes: #4019 

Add/remove favorites with `f`
Toggle favorites filter with `Ctrl-F` when in `:ns`
Unlock favorites (return to dynamic assignment) with `Ctrl-L`