### PR TITLE
fix: replace cache sync timeout by GVR-specifc sync verification with exponential backoff

### DIFF
--- a/internal/watch/factory.go
+++ b/internal/watch/factory.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	defaultResync   = 10 * time.Minute
-	defaultWaitTime = 500 * time.Millisecond
+	defaultWaitTime = 2000 * time.Millisecond
 )
 
 // Factory tracks various resource informers.

--- a/internal/watch/factory.go
+++ b/internal/watch/factory.go
@@ -21,8 +21,7 @@ import (
 )
 
 const (
-	defaultResync   = 10 * time.Minute
-	defaultWaitTime = 2000 * time.Millisecond
+	defaultResync = 10 * time.Minute
 )
 
 // Factory tracks various resource informers.
@@ -91,7 +90,9 @@ func (f *Factory) List(gvr *client.GVR, ns string, wait bool, lbls labels.Select
 		return oo, err
 	}
 
-	f.waitForCacheSync(ns)
+	if !f.waitForCacheSync(ns, gvr) {
+		return nil, fmt.Errorf("cache sync timeout for %s in namespace %s", gvr, ns)
+	}
 	if client.IsClusterScoped(ns) {
 		return inf.Lister().List(lbls)
 	}
@@ -129,7 +130,9 @@ func (f *Factory) Get(gvr *client.GVR, fqn string, wait bool, _ labels.Selector)
 		return o, err
 	}
 
-	f.waitForCacheSync(ns)
+	if !f.waitForCacheSync(ns, gvr) {
+		return nil, fmt.Errorf("cache sync timeout for %s in namespace %s", fqn, ns)
+	}
 	if client.IsClusterScoped(ns) {
 		return inf.Lister().Get(n)
 	}
@@ -137,25 +140,53 @@ func (f *Factory) Get(gvr *client.GVR, fqn string, wait bool, _ labels.Selector)
 	return inf.Lister().ByNamespace(ns).Get(n)
 }
 
-func (f *Factory) waitForCacheSync(ns string) {
+func (f *Factory) waitForCacheSync(ns string, gvr *client.GVR) bool {
 	if client.IsClusterWide(ns) {
 		ns = client.BlankNamespace
 	}
 
 	f.mx.RLock()
-	defer f.mx.RUnlock()
 	fac, ok := f.factories[ns]
+	f.mx.RUnlock()
 	if !ok {
-		return
+		return false
 	}
 
-	// Hang for a sec for the cache to refresh if still not done bail out!
-	c := make(chan struct{})
-	go func(c chan struct{}) {
-		<-time.After(defaultWaitTime)
-		close(c)
-	}(c)
-	_ = fac.WaitForCacheSync(c)
+	// Get the specific informer for this GVR
+	inf := fac.ForResource(gvr.GVR())
+	if inf == nil {
+		slog.Warn("No informer found for GVR",
+			slogs.GVR, gvr,
+			slogs.Namespace, ns,
+		)
+		return false
+	}
+
+	// Sync verification only for this specific informer
+	maxWait := 10 * time.Second
+	pollInterval := 50 * time.Millisecond
+	maxPollInterval := 500 * time.Millisecond
+	deadline := time.Now().Add(maxWait)
+	startTime := time.Now()
+
+	for time.Now().Before(deadline) {
+		// Check if this specific informer has synced
+		if inf.Informer().HasSynced() {
+			duration := time.Since(startTime)
+			slog.Debug("Cache synced for resource", slogs.GVR, gvr, slogs.Namespace, ns, slogs.Duration, duration)
+			return true
+		}
+
+		// Wait with exponential backoff
+		time.Sleep(pollInterval)
+		pollInterval *= 2
+		if pollInterval > maxPollInterval {
+			pollInterval = maxPollInterval
+		}
+	}
+
+	slog.Warn("Cache sync timeout for resource", slogs.GVR, gvr, slogs.Namespace, ns, slogs.Duration, maxWait)
+	return false
 }
 
 // WaitForCacheSync waits for all factories to update their cache.


### PR DESCRIPTION
This fixes the following issue:
1. on a pod, press `J` to jump to the owner (I have ~60 pods in this namespace and ~500 in the cluster overall)
2. a ` Watcher failed for apps/v1/replicasets -- replicasets.apps "pod-64c67669c4" not found` message appears and the screen is empty
3. press `esc` to get back to the pod view
4. press `J` again -- now it works as expected

Debugging this I found that `inf.Informer().HasSynced()` is still `false` at https://github.com/derailed/k9s/blob/9050e085814fb83b11c44da6f0ef553d2414aadc/internal/watch/factory.go#L137
After increasing `defaultWaitTime` it was `true` at this point and "jump to owner" worked at the first attempt.

This might be a "big cluster" issue similar to https://github.com/derailed/k9s/pull/3253 and occurs even with a k9s build that has https://github.com/derailed/k9s/pull/3987 and/or https://github.com/derailed/k9s/pull/3986.

**Update 2026-08-16:** Instead of blindly increasing the timeout, replace it with GVR-specific cache sync verification using exponential backoff.

### Key Changes
- Removed `defaultWaitTime` constant
- Modified `waitForCacheSync()`: added GVR parameter, returns bool, implements exponential backoff (50ms-500ms), max wait 10s
- Updated `List()` and `Get()`: pass GVR, return explicit timeout errors, moved RLock unlock before sync