### PR TITLE
Fix 'J'umping to owner of cluster scoped resources

### DIFF
--- a/internal/view/owner_extender.go
+++ b/internal/view/owner_extender.go
@@ -109,7 +109,7 @@ func (v *OwnerExtender) jumpOwner(ns string, owner *metav1.OwnerReference) error
 	if namespaced {
 		ownerFQN = client.FQN(ns, owner.Name)
 	} else {
-		ownerFQN = owner.Name
+		ownerFQN = client.FQN(client.ClusterScope, owner.Name)
 	}
 
 	v.App().gotoResource(gvr.String(), ownerFQN, false, true)


### PR DESCRIPTION
When pressing 'J' on a cluster scoped resource (like Open Data Hub's `DataScienceCluster`) to jump to its owner, an error message is shown:
```
Watcher failed for datasciencecluster.opendatahub.io/v1/datascienceclusters -- an empty namespace may not be set when a resource name is provided
```

This PR fixes the issue.