### PR TITLE
fix(scale): prevent "no column index for READY" when replicas=0

### DIFF
--- a/internal/view/scale_extender.go
+++ b/internal/view/scale_extender.go
@@ -135,16 +135,18 @@ func (s *ScaleExtender) makeScaleForm(fqns []string) (*tview.Form, error) {
 	if len(fqns) == 1 {
 		// If the CRD resource supports scaling, then first try to
 		// read the replicas directly from the CRD.
+		gotReplicas := false
 		if meta, _ := dao.MetaAccess.MetaFor(s.GVR()); dao.IsScalable(meta) {
 			replicas, err := s.replicasFromScaleSubresource(fqns[0])
 			if err == nil && replicas != "" {
 				factor = replicas
+				gotReplicas = true
 			}
 		}
 
 		// For built-in resources or cases where we can't get the replicas from the CRD, we can
 		// only try to get the number of copies from the READY field.
-		if factor == "0" {
+		if !gotReplicas {
 			replicas, err := s.replicasFromReady(fqns[0])
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Summary

When a deployment is scaled to 0 replicas, `replicasFromScaleSubresource` succeeds and returns `"0"`. The previous fallback condition `if factor == "0"` would then also trigger `replicasFromReady`, which fails with `😡 no column index for READY` if that column is absent from the current table view.

**Root cause:** the fallback used the value `"0"` as a proxy for "no replicas fetched", conflating a legitimate 0-replica deployment with a failed lookup.

**Fix:** introduce a `gotReplicas` boolean to track whether the subresource call succeeded, and only fall back to `replicasFromReady` when it didn't.

## Steps to reproduce

1. Scale a deployment down to 0 replicas
2. Press `s` on that deployment in k9s
3. Observe: `😡 no column index for READY`

## Test plan
- [ ] Scale a deployment with >0 replicas → dialog opens pre-filled with correct count
- [ ] Scale a deployment with 0 replicas → dialog opens pre-filled with `0`, no error
- [ ] Scale a CRD resource → dialog still works correctly