### PR TITLE
feat(ui): add multi-column sort support (up to 3 columns)

### DIFF
--- a/internal/config/styles.go
+++ b/internal/config/styles.go
@@ -218,6 +218,8 @@ type (
 		FgColor                 Color `json:"fgColor" yaml:"fgColor"`
 		BgColor                 Color `json:"bgColor" yaml:"bgColor"`
 		SorterColor             Color `json:"sorterColor" yaml:"sorterColor"`
+		SecondarySorterColor    Color `json:"secondarySorterColor" yaml:"secondarySorterColor"`
+		TertiarySorterColor     Color `json:"tertiarySorterColor" yaml:"tertiarySorterColor"`
 		SelectedSortColumnColor Color `json:"selectedSortColumnColor" yaml:"selectedSortColumnColor"`
 	}
 
@@ -439,6 +441,8 @@ func newTableHeader() TableHeader {
 		FgColor:                 "white",
 		BgColor:                 "black",
 		SorterColor:             "aqua",
+		SecondarySorterColor:    "cadetblue",
+		TertiarySorterColor:     "grey",
 		SelectedSortColumnColor: "lightskyblue",
 	}
 }
@@ -715,6 +719,8 @@ func (t *TableHeader) Invert() {
 	t.FgColor = t.FgColor.InvertColor()
 	t.BgColor = t.BgColor.InvertColor()
 	t.SorterColor = t.SorterColor.InvertColor()
+	t.SecondarySorterColor = t.SecondarySorterColor.InvertColor()
+	t.TertiarySorterColor = t.TertiarySorterColor.InvertColor()
 	t.SelectedSortColumnColor = t.SelectedSortColumnColor.InvertColor()
 }
 

--- a/internal/model1/helpers.go
+++ b/internal/model1/helpers.go
@@ -157,6 +157,28 @@ func capacityToNumber(capacity string) int64 {
 	return quantity.Value()
 }
 
+// Compare returns -1 if v1 < v2, 0 if equal, +1 if v1 > v2.
+func Compare(isNumber, isDuration, isCapacity bool, v1, v2 string) int {
+	if v1 == v2 {
+		return 0
+	}
+	var less bool
+	switch {
+	case isNumber:
+		less = lessNumber(v1, v2)
+	case isDuration:
+		less = lessDuration(v1, v2)
+	case isCapacity:
+		less = lessCapacity(v1, v2)
+	default:
+		less = sortorder.NaturalLess(v1, v2)
+	}
+	if less {
+		return -1
+	}
+	return 1
+}
+
 // Less return true if c1 <= c2.
 func Less(isNumber, isDuration, isCapacity bool, id1, id2, v1, v2 string) bool {
 	var less bool

--- a/internal/model1/row_event.go
+++ b/internal/model1/row_event.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+
+	"github.com/fvbommel/sortorder"
 )
 
 type ReRangeFn func(int, RowEvent) bool
@@ -311,4 +313,55 @@ func (r RowEventSorter) Less(i, j int) bool {
 	}
 
 	return !less
+}
+
+// ----------------------------------------------------------------------------
+
+// SortSpec describes how to sort by a single column within a multi-column sort.
+type SortSpec struct {
+	Index      int
+	IsNumber   bool
+	IsDuration bool
+	IsCapacity bool
+	Asc        bool
+}
+
+// RowEventMultiSorter sorts row events by multiple columns in priority order.
+type RowEventMultiSorter struct {
+	Events *RowEvents
+	NS     string
+	Specs  []SortSpec
+}
+
+func (r RowEventMultiSorter) Len() int {
+	return len(r.Events.events)
+}
+
+func (r RowEventMultiSorter) Swap(i, j int) {
+	r.Events.events[i], r.Events.events[j] = r.Events.events[j], r.Events.events[i]
+}
+
+func (r RowEventMultiSorter) Less(i, j int) bool {
+	f1, f2 := r.Events.events[i].Row.Fields, r.Events.events[j].Row.Fields
+	for _, spec := range r.Specs {
+		cmp := Compare(spec.IsNumber, spec.IsDuration, spec.IsCapacity, f1[spec.Index], f2[spec.Index])
+		if cmp == 0 {
+			continue
+		}
+		if spec.Asc {
+			return cmp < 0
+		}
+		return cmp > 0
+	}
+	id1, id2 := r.Events.events[i].Row.ID, r.Events.events[j].Row.ID
+	return sortorder.NaturalLess(id1, id2)
+}
+
+// SortMulti sorts rows based on multiple column specs in priority order.
+func (r *RowEvents) SortMulti(ns string, specs []SortSpec) {
+	if len(specs) == 0 || r == nil {
+		return
+	}
+	sort.Sort(RowEventMultiSorter{Events: r, NS: ns, Specs: specs})
+	r.reindex()
 }

--- a/internal/model1/table_data.go
+++ b/internal/model1/table_data.go
@@ -36,6 +36,48 @@ func (s SortColumn) IsSet() bool {
 	return s.Name != ""
 }
 
+const MaxSortColumns = 3
+
+// SortColumns represents an ordered list of sort columns (primary first).
+type SortColumns []SortColumn
+
+func (sc SortColumns) Primary() SortColumn {
+	if len(sc) == 0 {
+		return SortColumn{}
+	}
+	return sc[0]
+}
+
+func (sc SortColumns) Has(name string) (int, bool) {
+	for i, c := range sc {
+		if c.Name == name {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func (sc SortColumns) Add(col SortColumn) SortColumns {
+	if len(sc) >= MaxSortColumns {
+		return sc
+	}
+	return append(sc, col)
+}
+
+func (sc SortColumns) Toggle(name string) SortColumns {
+	for i, c := range sc {
+		if c.Name == name {
+			sc[i].ASC = !c.ASC
+			return sc
+		}
+	}
+	return sc
+}
+
+func (sc SortColumns) IsMulti() bool {
+	return len(sc) > 1
+}
+
 const spacer = " "
 
 type FilterOpts struct {
@@ -117,6 +159,34 @@ func (t *TableData) Sort(sc SortColumn) {
 		col.Capacity,
 		sc.ASC,
 	)
+}
+
+func (t *TableData) SortMulti(cols SortColumns) {
+	if len(cols) == 0 {
+		return
+	}
+	if len(cols) == 1 {
+		t.Sort(cols[0])
+		return
+	}
+	specs := make([]SortSpec, 0, len(cols))
+	for _, sc := range cols {
+		col, idx := t.HeadCol(sc.Name, false)
+		if idx < 0 {
+			continue
+		}
+		specs = append(specs, SortSpec{
+			Index:      idx,
+			IsNumber:   col.MX,
+			IsDuration: col.Time,
+			IsCapacity: col.Capacity,
+			Asc:        sc.ASC,
+		})
+	}
+	if len(specs) == 0 {
+		return
+	}
+	t.rowEvents.SortMulti(t.GetNamespace(), specs)
 }
 
 func (t *TableData) Header() Header {

--- a/internal/ui/padding.go
+++ b/internal/ui/padding.go
@@ -15,12 +15,12 @@ import (
 type MaxyPad []int
 
 // ComputeMaxColumns figures out column max size and necessary padding.
-func ComputeMaxColumns(pads MaxyPad, sortColName string, t *model1.TableData) {
+func ComputeMaxColumns(pads MaxyPad, sortCols model1.SortColumns, t *model1.TableData) {
 	const colPadding = 1
 
 	for i, n := range t.ColumnNames(true) {
 		pads[i] = len(n)
-		if n == sortColName {
+		if _, found := sortCols.Has(n); found {
 			pads[i] += 2
 		}
 	}

--- a/internal/ui/padding_test.go
+++ b/internal/ui/padding_test.go
@@ -14,7 +14,7 @@ import (
 func TestMaxColumn(t *testing.T) {
 	uu := map[string]struct {
 		t *model1.TableData
-		s string
+		s model1.SortColumns
 		e MaxyPad
 	}{
 		"ascii col 0": {
@@ -34,7 +34,7 @@ func TestMaxColumn(t *testing.T) {
 					},
 				),
 			),
-			"A",
+			model1.SortColumns{{Name: "A", ASC: true}},
 			MaxyPad{6, 6},
 		},
 		"ascii col 1": {
@@ -54,7 +54,7 @@ func TestMaxColumn(t *testing.T) {
 					},
 				),
 			),
-			"B",
+			model1.SortColumns{{Name: "B", ASC: true}},
 			MaxyPad{6, 6},
 		},
 		"non_ascii": {
@@ -74,7 +74,7 @@ func TestMaxColumn(t *testing.T) {
 					},
 				),
 			),
-			"A",
+			model1.SortColumns{{Name: "A", ASC: true}},
 			MaxyPad{32, 6},
 		},
 	}
@@ -145,6 +145,6 @@ func BenchmarkMaxColumn(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		ComputeMaxColumns(pads, "A", table)
+		ComputeMaxColumns(pads, model1.SortColumns{{Name: "A", ASC: true}}, table)
 	}
 }

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -38,7 +38,7 @@ type (
 type Table struct {
 	*SelectTable
 	gvr            *client.GVR
-	sortCol        model1.SortColumn
+	sortCols       model1.SortColumns
 	selectedColIdx int
 	manualSort     bool
 	Path           string
@@ -67,11 +67,11 @@ func NewTable(gvr *client.GVR) *Table {
 			model: model.NewTable(gvr),
 			marks: make(map[string]struct{}),
 		},
-		ctx:     context.Background(),
-		gvr:     gvr,
-		actions: NewKeyActions(),
-		cmdBuff: model.NewFishBuff('/', model.FilterBuffer),
-		sortCol: model1.SortColumn{ASC: true},
+		ctx:      context.Background(),
+		gvr:      gvr,
+		actions:  NewKeyActions(),
+		cmdBuff:  model.NewFishBuff('/', model.FilterBuffer),
+		sortCols: model1.SortColumns{{ASC: true}},
 	}
 }
 
@@ -103,21 +103,37 @@ func (t *Table) setSortCol(sc model1.SortColumn) {
 	t.mx.Lock()
 	defer t.mx.Unlock()
 
-	t.sortCol = sc
+	t.sortCols = model1.SortColumns{sc}
+}
+
+func (t *Table) setSortCols(scs model1.SortColumns) {
+	t.mx.Lock()
+	defer t.mx.Unlock()
+
+	t.sortCols = scs
 }
 
 func (t *Table) toggleSortCol() {
 	t.mx.Lock()
 	defer t.mx.Unlock()
 
-	t.sortCol.ASC = !t.sortCol.ASC
+	if len(t.sortCols) > 0 {
+		t.sortCols[0].ASC = !t.sortCols[0].ASC
+	}
 }
 
 func (t *Table) getSortCol() model1.SortColumn {
 	t.mx.RLock()
 	defer t.mx.RUnlock()
 
-	return t.sortCol
+	return t.sortCols.Primary()
+}
+
+func (t *Table) getSortCols() model1.SortColumns {
+	t.mx.RLock()
+	defer t.mx.RUnlock()
+
+	return t.sortCols
 }
 
 func (t *Table) setMSort(b bool) {
@@ -221,6 +237,8 @@ func (t *Table) SelectPrevColumn() {
 }
 
 // SortSelectedColumn sorts by the currently selected column.
+// Pressing repeatedly on different columns stacks multi-column sort (up to 3).
+// Pressing on an already-sorted column toggles its direction.
 func (t *Table) SortSelectedColumn() {
 	data := t.GetFilteredData()
 	if data == nil || data.HeaderCount() == 0 {
@@ -232,8 +250,6 @@ func (t *Table) SortSelectedColumn() {
 		return
 	}
 
-	// Map visual column index to actual header column name
-	// (accounting for hidden columns)
 	header := data.Header()
 	visibleCol := 0
 	var colName string
@@ -252,16 +268,28 @@ func (t *Table) SortSelectedColumn() {
 		return
 	}
 
-	sc := t.getSortCol()
-
-	// Toggle direction if same column, otherwise default to ascending
-	asc := true
-	if sc.Name == colName {
-		asc = !sc.ASC
+	scs := t.getSortCols()
+	if _, found := scs.Has(colName); found {
+		scs = scs.Toggle(colName)
+	} else if !t.getMSort() {
+		scs = model1.SortColumns{{Name: colName, ASC: true}}
+	} else {
+		scs = scs.Add(model1.SortColumn{Name: colName, ASC: true})
 	}
-
-	t.SetSortCol(colName, asc)
+	t.setSortCols(scs)
 	t.setMSort(true)
+	t.Refresh()
+}
+
+// ClearMultiSort resets multi-column sort back to single-column default.
+func (t *Table) ClearMultiSort() {
+	scs := t.getSortCols()
+	if len(scs) > 1 {
+		t.setSortCols(model1.SortColumns{scs[0]})
+	} else {
+		t.setSortCols(nil)
+		t.setMSort(false)
+	}
 	t.Refresh()
 }
 
@@ -317,11 +345,12 @@ func (t *Table) GVR() *client.GVR { return t.gvr }
 func (t *Table) ViewSettingsChanged(vs *config.ViewSetting) {
 	if t.SetViewSetting(vs) {
 		if vs == nil {
-			if !t.getMSort() && !t.sortCol.IsSet() {
-				t.setSortCol(model1.SortColumn{})
+			if !t.getMSort() && !t.getSortCol().IsSet() {
+				t.setSortCols(nil)
 			}
 		} else {
 			t.setMSort(false)
+			t.setSortCols(nil)
 		}
 		t.Refresh()
 	}
@@ -449,7 +478,9 @@ func (t *Table) doUpdate(data *model1.TableData) *model1.TableData {
 	}
 
 	oldSortCol := t.getSortCol()
-	t.setSortCol(data.ComputeSortCol(t.GetViewSetting(), t.getSortCol(), t.getMSort()))
+	if !t.getSortCols().IsMulti() {
+		t.setSortCol(data.ComputeSortCol(t.GetViewSetting(), t.getSortCol(), t.getMSort()))
+	}
 
 	// Initialize selected column index to match the current sort column
 	// This ensures the highlight starts at the sorted column
@@ -484,10 +515,10 @@ func (t *Table) UpdateUI(cdata, data *model1.TableData) {
 		c.SetTextColor(fg)
 		col++
 	}
-	cdata.Sort(t.getSortCol())
+	cdata.SortMulti(t.getSortCols())
 
 	pads := make(MaxyPad, cdata.HeaderCount())
-	ComputeMaxColumns(pads, t.getSortCol().Name, cdata)
+	ComputeMaxColumns(pads, t.getSortCols(), cdata)
 	cdata.RowsRange(func(row int, re model1.RowEvent) bool {
 		ore, ok := data.FindRow(re.Row.ID)
 		if !ok {
@@ -629,11 +660,16 @@ func (t *Table) NameColIndex() int {
 
 // AddHeaderCell configures a table cell header.
 func (t *Table) AddHeaderCell(col int, h model1.HeaderColumn) {
-	sc := t.getSortCol()
-	sortCol := h.Name == sc.Name
+	scs := t.getSortCols()
+	sortRank := 0
+	asc := true
+	if idx, found := scs.Has(h.Name); found {
+		sortRank = idx + 1
+		asc = scs[idx].ASC
+	}
 	selectedCol := col == t.getSelectedColIdx()
 	styles := t.styles.Table()
-	c := tview.NewTableCell(columnIndicator(sortCol, selectedCol, sc.ASC, &styles, h.Name))
+	c := tview.NewTableCell(columnIndicator(sortRank, selectedCol, asc, &styles, h.Name))
 	c.SetExpansion(1)
 	c.SetSelectable(false)
 	c.SetAlign(h.Align)

--- a/internal/ui/table_helper.go
+++ b/internal/ui/table_helper.go
@@ -84,8 +84,7 @@ func SkinTitle(fmat string, style *config.Frame) string {
 	return fmat
 }
 
-func columnIndicator(sort, selected, asc bool, style *config.Table, name string) string {
-	// Build the column name with selection indicator
+func columnIndicator(sortRank int, selected, asc bool, style *config.Table, name string) string {
 	var displayName string
 	if selected {
 		displayName = fmt.Sprintf("[%s::]%s[::]", style.Header.SelectedSortColumnColor, name)
@@ -93,14 +92,26 @@ func columnIndicator(sort, selected, asc bool, style *config.Table, name string)
 		displayName = fmt.Sprintf("[%s::]%s[::]", style.Header.FgColor, name)
 	}
 
-	// Add sort indicator if this column is sorted
 	suffix := ""
-	if sort {
+	if sortRank > 0 {
 		order := descIndicator
 		if asc {
 			order = ascIndicator
 		}
-		suffix = fmt.Sprintf("[%s::b]%s[::]", style.Header.SorterColor, order)
+		var color config.Color
+		switch sortRank {
+		case 1:
+			color = style.Header.SorterColor
+		case 2:
+			color = style.Header.SecondarySorterColor
+		default:
+			color = style.Header.TertiarySorterColor
+		}
+		if sortRank == 1 {
+			suffix = fmt.Sprintf("[%s::b]%s[::]", color, order)
+		} else {
+			suffix = fmt.Sprintf("[%s::d]%s[::]", color, order)
+		}
 	}
 
 	return displayName + suffix

--- a/internal/view/table.go
+++ b/internal/view/table.go
@@ -229,7 +229,13 @@ func (t *Table) bindKeys() {
 		ui.KeyShiftA:           ui.NewKeyAction("Sort Age", t.SortColCmd(ageCol, true), false),
 		ui.KeyShiftS:           ui.NewKeyAction("Sort Status", t.SortColCmd(statusCol, true), false),
 		ui.KeyShiftO:           ui.NewKeyAction("Sort Selected Column", t.sortSelectedColumnCmd, false),
+		ui.KeyShiftQ:           ui.NewKeyAction("Clear Sort", t.clearSortCmd, false),
 	})
+}
+
+func (t *Table) clearSortCmd(*tcell.EventKey) *tcell.EventKey {
+	t.Table.ClearMultiSort()
+	return nil
 }
 
 func (t *Table) toggleFaultCmd(*tcell.EventKey) *tcell.EventKey {


### PR DESCRIPTION
Allow users to sort table views by multiple (upto 3) columns simultaneously. 
- Shift+O stacks sort columns (first press sets primary, subsequent presses add secondary/tertiary). 
- Shift+Q clears multi-sort. Each sort level is visually distinguished by color in the header.
- Shift-Left/Shift-Right to select columns

Tries to address https://github.com/derailed/k9s/issues/919 issue.
