### PR TITLE
feat(plugin): add runWithNoSelection option

### DIFF
--- a/internal/config/json/schemas/plugin-multi.json
+++ b/internal/config/json/schemas/plugin-multi.json
@@ -16,6 +16,7 @@
       "command": { "type": "string" },
       "background": { "type": "boolean" },
       "overwriteOutput": { "type": "boolean" },
+      "runWithNoSelection": { "type": "boolean" },
       "args": {
         "type": "array",
         "items": { "type": ["string", "number"] }

--- a/internal/config/json/schemas/plugin.json
+++ b/internal/config/json/schemas/plugin.json
@@ -16,6 +16,7 @@
       "command": { "type": "string" },
       "background": { "type": "boolean" },
       "overwriteOutput": { "type": "boolean" },
+      "runWithNoSelection": { "type": "boolean" },
       "args": {
         "type": "array",
         "items": { "type": ["string", "number"] }

--- a/internal/config/json/schemas/plugins.json
+++ b/internal/config/json/schemas/plugins.json
@@ -20,6 +20,7 @@
           "command": { "type": "string" },
           "background": { "type": "boolean" },
           "overwriteOutput": { "type": "boolean" },
+          "runWithNoSelection": { "type": "boolean" },
           "args": {
             "type": "array",
             "items": { "type": ["string", "number"] }

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -52,18 +52,22 @@ type PluginInput struct {
 
 // Plugin describes a K9s plugin.
 type Plugin struct {
-	Scopes          []string      `yaml:"scopes"`
-	Args            []string      `yaml:"args"`
-	ShortCut        string        `yaml:"shortCut"`
-	Override        bool          `yaml:"override"`
-	Pipes           []string      `yaml:"pipes"`
-	Description     string        `yaml:"description"`
-	Command         string        `yaml:"command"`
-	Confirm         *bool         `yaml:"confirm"`
-	Background      bool          `yaml:"background"`
-	Dangerous       bool          `yaml:"dangerous"`
-	OverwriteOutput bool          `yaml:"overwriteOutput"`
-	Inputs          []PluginInput `yaml:"inputs"`
+	Scopes          []string `yaml:"scopes"`
+	Args            []string `yaml:"args"`
+	ShortCut        string   `yaml:"shortCut"`
+	Override        bool     `yaml:"override"`
+	Pipes           []string `yaml:"pipes"`
+	Description     string   `yaml:"description"`
+	Command         string   `yaml:"command"`
+	Confirm         *bool    `yaml:"confirm"`
+	Background      bool     `yaml:"background"`
+	Dangerous       bool     `yaml:"dangerous"`
+	OverwriteOutput bool     `yaml:"overwriteOutput"`
+	// RunWithNoSelection allows the plugin to run even when no resource is
+	// selected (e.g. when viewing an empty namespace). Defaults to false so
+	// existing plugins keep requiring a selection.
+	RunWithNoSelection bool          `yaml:"runWithNoSelection"`
+	Inputs             []PluginInput `yaml:"inputs"`
 }
 
 func (p Plugin) String() string {

--- a/internal/config/plugin_test.go
+++ b/internal/config/plugin_test.go
@@ -71,6 +71,21 @@ func TestPluginLoad(t *testing.T) {
 			},
 		},
 
+		"run-with-no-selection": {
+			path: "testdata/plugins/run-no-selection.yaml",
+			ee: Plugins{
+				Plugins: plugins{
+					"run-no-selection": Plugin{
+						Scopes:             []string{"po"},
+						ShortCut:           "Shift-B",
+						Description:        "debug",
+						Command:            "bash",
+						RunWithNoSelection: true,
+					},
+				},
+			},
+		},
+
 		"toast-no-file": {
 			path: "testdata/plugins/plugins-bozo.yaml",
 			ee:   NewPlugins(),

--- a/internal/config/testdata/plugins/run-no-selection.yaml
+++ b/internal/config/testdata/plugins/run-no-selection.yaml
@@ -1,0 +1,6 @@
+shortCut: Shift-B
+description: debug
+scopes:
+  - po
+command: bash
+runWithNoSelection: true

--- a/internal/view/actions.go
+++ b/internal/view/actions.go
@@ -176,7 +176,7 @@ func pluginActions(r Runner, aa *ui.KeyActions) error {
 func pluginAction(r Runner, p *config.Plugin) ui.ActionHandler {
 	return func(evt *tcell.EventKey) *tcell.EventKey {
 		path := r.GetSelectedItem()
-		if path == "" {
+		if path == "" && !p.RunWithNoSelection {
 			return evt
 		}
 		if r.EnvFn() == nil {

--- a/internal/view/table.go
+++ b/internal/view/table.go
@@ -146,6 +146,13 @@ func (t *Table) defaultEnv() Env {
 	if env["FILTER"] == "" {
 		env["NAMESPACE"], env["FILTER"] = client.Namespaced(path)
 	}
+	// Without a selection (e.g. an empty namespace), fall back to the viewer's
+	// namespace so plugins relying on $NAMESPACE still work.
+	if env["NAMESPACE"] == "" {
+		if ns := t.GetModel().GetNamespace(); !client.IsAllNamespaces(ns) {
+			env["NAMESPACE"] = client.CleanseNamespace(ns)
+		}
+	}
 	env["RESOURCE_GROUP"] = t.GVR().G()
 	env["RESOURCE_VERSION"] = t.GVR().V()
 	env["RESOURCE_NAME"] = t.GVR().R()


### PR DESCRIPTION
Plugins currently exit early when no resource is selected, so they cannot be triggered in an empty namespace (#3992).

This adds an opt-in `runWithNoSelection` plugin option (default false, so existing plugins are unaffected). When enabled, the plugin runs even without a selection, and `$NAMESPACE` falls back to the current view namespace so namespace-scoped plugins keep working.

Tested with `go build`, the config/view unit tests, and manually against a live cluster: a plugin with the flag runs in an empty namespace with `$NAMESPACE` populated, while a plugin without it behaves as before.

Closes #3992