### PR TITLE
ui: add enablePromptCursor option to show hardware cursor in prompt bars

### DIFF
--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -43,7 +43,8 @@
             "skin": {"type": "string"},
             "defaultsToFullScreen": {"type": "boolean"},
             "useFullGVRTitle": {"type": "boolean"},
-            "invert": {"type": "boolean"}
+            "invert": {"type": "boolean"},
+            "enablePromptCursor": {"type": "boolean"}
           }
         },
         "shellPod": {

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -393,6 +393,11 @@ func (k *K9s) IsInvert() bool {
 	return k.UI.Invert
 }
 
+// IsPromptCursorEnabled returns whether the hardware cursor is shown in prompt bars.
+func (k *K9s) IsPromptCursorEnabled() bool {
+	return k.UI.EnablePromptCursor
+}
+
 // GetRefreshRate returns the current refresh rate.
 func (k *K9s) GetRefreshRate() float32 {
 	k.mx.Lock()

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -50,6 +50,11 @@ type UI struct {
 	// UseFullGVRTitle toggles the display of full GVR (group/version/resource) vs R in views title.
 	UseFullGVRTitle bool `json:"useFullGVRTitle" yaml:"useFullGVRTitle"`
 
+	// EnablePromptCursor shows the terminal hardware cursor in the filter and
+	// command prompt bars. Requires derailed/tview to honor TextView.ShowCursor.
+	// Default is false to preserve existing behavior.
+	EnablePromptCursor bool `json:"enablePromptCursor" yaml:"enablePromptCursor"`
+
 	manualHeadless   *bool
 	manualLogoless   *bool
 	manualCrumbsless *bool

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -266,7 +266,7 @@ func (p *Prompt) SuggestionChanged(text, suggestion string) {
 // BufferActive indicates the buff activity changed.
 func (p *Prompt) BufferActive(activate bool, kind model.BufferKind) {
 	if activate {
-		p.ShowCursor(true)
+		p.ShowCursor(p.app.Config.K9s.IsPromptCursorEnabled())
 		p.SetBorder(true)
 		p.SetTextColor(p.styles.FgColor())
 		p.SetBorderColor(p.colorFor(kind))


### PR DESCRIPTION
Adds ui.enablePromptCursor (default: false) to config.yaml. When true, the terminal hardware cursor is shown in the filter (/) and command (:) prompt bars, positioned at the current input location.

Default is false to preserve existing behavior for all users — the prompt bars continue to show no cursor unless this option is explicitly set.

This requires a corresponding change in derailed/tview (skaven81/tview branch fix-textview-showcursor) which makes TextView.Draw() honor the ShowCursor flag. Without that tview change, this config flag has no visible effect. With only the tview change and not this k9s change, the cursor would appear unconditionally — so both changes are needed together to keep the default behavior unchanged.

To enable:
```
  # ~/.config/k9s/config.yaml
  k9s:
    ui:
      enablePromptCursor: true
```

See also https://github.com/derailed/tview/pull/11