### PR TITLE
Preserve Sort, Label, Filter State in Navigation History

### DIFF
--- a/internal/model/history.go
+++ b/internal/model/history.go
@@ -127,6 +127,15 @@ func (h *History) Push(c string) {
 	h.currentIdx = len(h.commands) - 1
 }
 
+// Update rewrites the entry at the current position in place, consolidating
+// interactive view changes into a single snapshot. No-op if the stack is empty.
+func (h *History) Update(c string) {
+	if c == "" || h.currentIdx < 0 || h.currentIdx >= len(h.commands) {
+		return
+	}
+	h.commands[h.currentIdx] = strings.ToLower(c)
+}
+
 // Clear clears out the stack.
 func (h *History) Clear() {
 	h.commands = nil

--- a/internal/model/history_test.go
+++ b/internal/model/history_test.go
@@ -33,6 +33,48 @@ func TestHistoryPush(t *testing.T) {
 	assert.Equal(t, []string{"cmd1", "cmd2", "cmd3"}, h.List())
 }
 
+func TestHistoryUpdate(t *testing.T) {
+	t.Run("empty-is-noop", func(t *testing.T) {
+		h := model.NewHistory(3)
+		h.Update("pods /nginx")
+		assert.True(t, h.Empty())
+	})
+
+	t.Run("rewrites-current", func(t *testing.T) {
+		h := model.NewHistory(3)
+		h.Push("pods")
+		h.Update("pods /nginx")
+
+		top, ok := h.Top()
+		assert.True(t, ok)
+		assert.Equal(t, "pods /nginx", top)
+		assert.Len(t, h.List(), 1)
+	})
+
+	t.Run("lower-cases", func(t *testing.T) {
+		h := model.NewHistory(3)
+		h.Push("pods")
+		h.Update("pods sort:AGE:asc")
+
+		top, _ := h.Top()
+		assert.Equal(t, "pods sort:age:asc", top)
+	})
+
+	t.Run("rewrites-back-entry", func(t *testing.T) {
+		h := model.NewHistory(3)
+		h.Push("pods")
+		h.Push("nodes")
+
+		back, ok := h.Back()
+		assert.True(t, ok)
+		assert.Equal(t, "pods", back)
+
+		h.Update("pods /nginx")
+		assert.Equal(t, []string{"pods /nginx", "nodes"}, h.List())
+		assert.Len(t, h.List(), 2)
+	})
+}
+
 func TestHistoryTop(t *testing.T) {
 	uu := map[string]struct {
 		push []string

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -41,6 +41,7 @@ type Table struct {
 	gvr            *client.GVR
 	sortCol        model1.SortColumn
 	selectedColIdx int
+	selColInit     bool
 	manualSort     bool
 	Path           string
 	Extras         string
@@ -58,6 +59,7 @@ type Table struct {
 	readOnly       bool
 	noIcon         bool
 	fullGVR        bool
+	sortChangeFn   func(sc model1.SortColumn)
 }
 
 // NewTable returns a new table view.
@@ -121,6 +123,11 @@ func (t *Table) getSortCol() model1.SortColumn {
 	return t.sortCol
 }
 
+// GetSortCol returns the active sort column and direction.
+func (t *Table) GetSortCol() model1.SortColumn {
+	return t.getSortCol()
+}
+
 func (t *Table) setMSort(b bool) {
 	t.mx.Lock()
 	defer t.mx.Unlock()
@@ -142,11 +149,18 @@ func (t *Table) getSelectedColIdx() int {
 	return t.selectedColIdx
 }
 
+func (t *Table) GetSelectedColIdx() int {
+	return t.getSelectedColIdx()
+}
+
 // initSelectedColumn initializes the selected column index based on current sort column.
-func (t *Table) initSelectedColumn() {
-	data := t.GetFilteredData()
+func (t *Table) initSelectedColumn() bool {
+	return t.initSelectedColumnFor(t.GetFilteredData())
+}
+
+func (t *Table) initSelectedColumnFor(data *model1.TableData) bool {
 	if data == nil || data.HeaderCount() == 0 {
-		return
+		return false
 	}
 
 	sc := t.getSortCol()
@@ -154,7 +168,7 @@ func (t *Table) initSelectedColumn() {
 		t.mx.Lock()
 		t.selectedColIdx = 0
 		t.mx.Unlock()
-		return
+		return true
 	}
 
 	// Find the visual column index for the current sort column
@@ -168,7 +182,7 @@ func (t *Table) initSelectedColumn() {
 			t.mx.Lock()
 			t.selectedColIdx = visibleCol
 			t.mx.Unlock()
-			return
+			return true
 		}
 		visibleCol++
 	}
@@ -177,6 +191,8 @@ func (t *Table) initSelectedColumn() {
 	t.mx.Lock()
 	t.selectedColIdx = 0
 	t.mx.Unlock()
+
+	return true
 }
 
 // moveSelectedColumn moves the column selection by delta (-1 for left, +1 for right).
@@ -264,6 +280,7 @@ func (t *Table) SortSelectedColumn() {
 	t.SetSortCol(colName, asc)
 	t.setMSort(true)
 	t.Refresh()
+	t.fireSortChange()
 }
 
 // SetViewSetting sets custom view config is present.
@@ -421,6 +438,22 @@ func (t *Table) SetSortCol(name string, asc bool) {
 	t.setSortCol(model1.SortColumn{Name: name, ASC: asc})
 }
 
+// SetManualSort flags the sort as user-driven so config defaults don't override it.
+func (t *Table) SetManualSort(b bool) {
+	t.setMSort(b)
+}
+
+// SetSortChangeFn registers a callback invoked after an interactive sort change.
+func (t *Table) SetSortChangeFn(fn func(model1.SortColumn)) {
+	t.sortChangeFn = fn
+}
+
+func (t *Table) fireSortChange() {
+	if t.sortChangeFn != nil {
+		t.sortChangeFn(t.getSortCol())
+	}
+}
+
 // Update table content.
 func (t *Table) Update(data *model1.TableData, hasMetrics bool) *model1.TableData {
 	if t.decorateFn != nil {
@@ -452,11 +485,15 @@ func (t *Table) doUpdate(data *model1.TableData) *model1.TableData {
 	oldSortCol := t.getSortCol()
 	t.setSortCol(data.ComputeSortCol(t.GetViewSetting(), t.getSortCol(), t.getMSort()))
 
-	// Initialize selected column index to match the current sort column
-	// This ensures the highlight starts at the sorted column
+	// Initialize selected column index to match the current sort column so the
+	// highlight follows the sorted column. Run on the first render (e.g. when a
+	// sort is restored from navigation history before any data arrives) and
+	// whenever the sort column changes.
 	newSortCol := t.getSortCol()
-	if oldSortCol.Name != newSortCol.Name {
-		t.initSelectedColumn()
+	if !t.selColInit || oldSortCol.Name != newSortCol.Name {
+		if t.initSelectedColumnFor(data) {
+			t.selColInit = true
+		}
 	}
 
 	return data
@@ -576,6 +613,7 @@ func (t *Table) SortColCmd(name string, asc bool) func(evt *tcell.EventKey) *tce
 		t.initSelectedColumn()
 
 		t.Refresh()
+		t.fireSortChange()
 		return nil
 	}
 }
@@ -584,6 +622,7 @@ func (t *Table) SortColCmd(name string, asc bool) func(evt *tcell.EventKey) *tce
 func (t *Table) SortInvertCmd(*tcell.EventKey) *tcell.EventKey {
 	t.toggleSortCol()
 	t.Refresh()
+	t.fireSortChange()
 
 	return nil
 }

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -248,6 +248,16 @@ func (b *Browser) BufferActive(state bool, _ model.BufferKind) {
 			b.App().filterHistory.Push(b.CmdBuff().GetText())
 		}
 	})
+
+	text := b.CmdBuff().GetText()
+	if b.command != nil {
+		if internal.IsLabelSelector(text) {
+			b.command.SetLabelArg(strings.TrimPrefix(text, "-l "))
+		} else {
+			b.command.SetFilterArg(text)
+		}
+		b.syncHistory()
+	}
 }
 
 func (b *Browser) prepareContext() context.Context {

--- a/internal/view/cmd/args.go
+++ b/internal/view/cmd/args.go
@@ -16,6 +16,7 @@ const (
 	fuzzyKey   = "fuzzy"
 	labelKey   = "labels"
 	contextKey = "context"
+	sortKey    = "sort"
 )
 
 type args map[string]string
@@ -50,6 +51,9 @@ func newArgs(p *Interpreter, aa []string) args {
 
 		case strings.Index(a, contextFlag) == 0:
 			arguments[contextKey] = a[1:]
+
+		case strings.HasPrefix(a, sortFlag):
+			arguments[sortKey] = a[len(sortFlag):] // "<COLUMN>:<asc|desc>"
 
 		case isLabelArg(a):
 			arguments[labelKey] = strings.ToLower(a)
@@ -92,6 +96,8 @@ func (a args) String() string {
 			v = filterFlag + v
 		case contextKey:
 			v = contextFlag + v
+		case sortKey:
+			v = sortFlag + v
 		}
 		ss = append(ss, v)
 	}

--- a/internal/view/cmd/interpreter.go
+++ b/internal/view/cmd/interpreter.go
@@ -313,3 +313,58 @@ func (c *Interpreter) HasContext() (string, bool) {
 func (c *Interpreter) LabelsSelector() (labels.Selector, error) {
 	return labels.Parse(c.args[labelKey])
 }
+
+// SortArg returns the persisted sort column and direction if any.
+func (c *Interpreter) SortArg() (col string, asc, ok bool) {
+	v, found := c.args[sortKey]
+	if !found || v == "" {
+		return "", false, false
+	}
+	name, dir, _ := strings.Cut(v, ":")
+	if name == "" {
+		return "", false, false
+	}
+
+	return strings.ToUpper(name), dir != "desc", true
+}
+
+func (c *Interpreter) rebuild() {
+	if c.args == nil {
+		c.args = make(args)
+	}
+	c.line = strings.TrimSpace(c.cmd + " " + c.args.String())
+}
+
+// SetSortArg records the sort column/direction, replacing any prior sort.
+func (c *Interpreter) SetSortArg(col string, asc bool) {
+	dir := "asc"
+	if !asc {
+		dir = "desc"
+	}
+	c.args[sortKey] = col + ":" + dir
+	c.rebuild()
+}
+
+// SetFilterArg records a regex filter, clearing label/fuzzy (mutually exclusive).
+func (c *Interpreter) SetFilterArg(f string) {
+	delete(c.args, labelKey)
+	delete(c.args, fuzzyKey)
+	if f == "" {
+		delete(c.args, filterKey)
+	} else {
+		c.args[filterKey] = strings.ToLower(f)
+	}
+	c.rebuild()
+}
+
+// SetLabelArg records a label selector, clearing filter/fuzzy (mutually exclusive).
+func (c *Interpreter) SetLabelArg(sel string) {
+	delete(c.args, filterKey)
+	delete(c.args, fuzzyKey)
+	if sel == "" {
+		delete(c.args, labelKey)
+	} else {
+		c.args[labelKey] = strings.ToLower(sel)
+	}
+	c.rebuild()
+}

--- a/internal/view/cmd/interpreter_test.go
+++ b/internal/view/cmd/interpreter_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/derailed/k9s/internal/view/cmd"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRbacCmd(t *testing.T) {
@@ -704,4 +705,115 @@ func Test_grokLabels(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSortArg(t *testing.T) {
+	uu := map[string]struct {
+		cmd string
+		ok  bool
+		col string
+		asc bool
+	}{
+		"empty": {},
+
+		"none": {
+			cmd: "pods",
+		},
+
+		"desc": {
+			cmd: "pods sort:AGE:desc",
+			ok:  true,
+			col: "AGE",
+			asc: false,
+		},
+
+		"asc": {
+			cmd: "pods sort:age:asc",
+			ok:  true,
+			col: "AGE",
+			asc: true,
+		},
+
+		"default-asc": {
+			cmd: "pods sort:name",
+			ok:  true,
+			col: "NAME",
+			asc: true,
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			p := cmd.NewInterpreter(u.cmd)
+			col, asc, ok := p.SortArg()
+			assert.Equal(t, u.ok, ok)
+			if u.ok {
+				assert.Equal(t, u.col, col)
+				assert.Equal(t, u.asc, asc)
+			}
+		})
+	}
+}
+
+func TestSetSortArg(t *testing.T) {
+	p := cmd.NewInterpreter("pods app=frontend")
+	p.SetSortArg("AGE", false)
+
+	col, asc, ok := p.SortArg()
+	assert.True(t, ok)
+	assert.Equal(t, "AGE", col)
+	assert.False(t, asc)
+	assert.Contains(t, p.GetLine(), "sort:AGE:desc")
+	assert.Contains(t, p.GetLine(), "'app=frontend'")
+
+	// Replacing a prior sort.
+	p.SetSortArg("NAME", true)
+	col, asc, ok = p.SortArg()
+	assert.True(t, ok)
+	assert.Equal(t, "NAME", col)
+	assert.True(t, asc)
+	assert.Contains(t, p.GetLine(), "sort:NAME:asc")
+	assert.NotContains(t, p.GetLine(), "sort:AGE")
+}
+
+func TestSetFilterArg(t *testing.T) {
+	p := cmd.NewInterpreter("pods app=frontend")
+	p.SetFilterArg("nginx")
+
+	f, ok := p.FilterArg()
+	assert.True(t, ok)
+	assert.Equal(t, "nginx", f)
+
+	// Label must be cleared (mutual exclusivity).
+	sel, err := p.LabelsSelector()
+	require.NoError(t, err)
+	assert.True(t, sel.Empty())
+	assert.Contains(t, p.GetLine(), "/nginx")
+	assert.NotContains(t, p.GetLine(), "app=frontend")
+
+	// Empty filter clears it.
+	p.SetFilterArg("")
+	_, ok = p.FilterArg()
+	assert.False(t, ok)
+}
+
+func TestSetLabelArg(t *testing.T) {
+	p := cmd.NewInterpreter("pods /nginx")
+	p.SetLabelArg("app=frontend")
+
+	sel, err := p.LabelsSelector()
+	require.NoError(t, err)
+	assert.Equal(t, "app=frontend", sel.String())
+
+	// Filter must be cleared (mutual exclusivity).
+	_, ok := p.FilterArg()
+	assert.False(t, ok)
+	assert.NotContains(t, p.GetLine(), "/nginx")
+
+	// Empty selector clears it.
+	p.SetLabelArg("")
+	sel, err = p.LabelsSelector()
+	require.NoError(t, err)
+	assert.True(t, sel.Empty())
 }

--- a/internal/view/cmd/types.go
+++ b/internal/view/cmd/types.go
@@ -23,6 +23,7 @@ const (
 	label
 	fuzzyFlag   = "-f"
 	contextFlag = "@"
+	sortFlag    = "sort:" // internal-only: sort:<COLUMN>:<asc|desc>
 )
 
 var (

--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -226,16 +226,21 @@ func (c *Command) run(p *cmd.Interpreter, fqn string, clearStack, pushCmd bool) 
 	co := c.componentFor(gvr, fqn, v)
 	co.SetFilter("", true)
 	co.SetLabelSelector(labels.Everything(), true)
-	if f, ok := p.FilterArg(); ok {
+
+	// Filter and label selector are mutually exclusive; label wins if both present.
+	if sel, err := p.LabelsSelector(); err != nil {
+		slog.Error("Unable to grok labels selector", slogs.Error, err)
+	} else if !sel.Empty() {
+		co.SetLabelSelector(sel, false)
+	} else if f, ok := p.FilterArg(); ok {
 		co.SetFilter(f, true)
-	}
-	if f, ok := p.FuzzyArg(); ok {
+	} else if f, ok := p.FuzzyArg(); ok {
 		co.SetFilter("-f "+f, true)
 	}
-	if sel, err := p.LabelsSelector(); err == nil {
-		co.SetLabelSelector(sel, false)
-	} else {
-		slog.Error("Unable to grok labels selector", slogs.Error, err)
+
+	if col, asc, ok := p.SortArg(); ok {
+		co.GetTable().SetSortCol(col, asc)
+		co.GetTable().SetManualSort(true)
 	}
 
 	return c.exec(p, gvr, co, clearStack, pushCmd)

--- a/internal/view/table.go
+++ b/internal/view/table.go
@@ -13,6 +13,7 @@ import (
 	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/model"
+	"github.com/derailed/k9s/internal/model1"
 	"github.com/derailed/k9s/internal/render"
 	"github.com/derailed/k9s/internal/slogs"
 	"github.com/derailed/k9s/internal/ui"
@@ -63,6 +64,15 @@ func (t *Table) Init(ctx context.Context) (err error) {
 	}
 	t.SetInputCapture(t.keyboard)
 	t.bindKeys()
+	t.SetSortChangeFn(func(sc model1.SortColumn) {
+		if t.command == nil {
+			return
+		}
+		t.command.SetSortArg(sc.Name, sc.ASC)
+		if t.app != nil {
+			t.app.cmdHistory.Update(t.command.GetLine())
+		}
+	})
 	t.GetModel().SetRefreshRate(t.app.Config.K9s.RefreshDuration())
 	t.CmdBuff().AddListener(t)
 
@@ -72,6 +82,19 @@ func (t *Table) Init(ctx context.Context) (err error) {
 // SetCommand sets the current command.
 func (t *Table) SetCommand(i *cmd.Interpreter) {
 	t.command = i
+}
+
+// syncHistory consolidates the view's current filter/label + sort into the
+// current navigation-history entry.
+func (t *Table) syncHistory() {
+	if t.command == nil || t.app == nil {
+		return
+	}
+	sc := t.GetSortCol()
+	if sc.Name != "" {
+		t.command.SetSortArg(sc.Name, sc.ASC)
+	}
+	t.app.cmdHistory.Update(t.command.GetLine())
 }
 
 var stripHeaderRX = regexp.MustCompile(`\[.+\](\w+)\[.+\]`)
@@ -177,6 +200,17 @@ func (t *Table) Start() {
 		}
 	}
 	t.App().CustomView().AddListeners(t.Table, cmds...)
+
+	// Re-assert any sort carried on the command (e.g. restored from
+	// navigation history) so it wins over a custom-view default sort.
+	// AddListeners above fires ViewSettingsChanged which resets the manual
+	// sort flag, so this must run afterwards.
+	if t.command != nil {
+		if col, asc, ok := t.command.SortArg(); ok {
+			t.SetSortCol(col, asc)
+			t.SetManualSort(true)
+		}
+	}
 }
 
 // Stop terminates the component.

--- a/internal/view/table_int_test.go
+++ b/internal/view/table_int_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/derailed/k9s/internal/model1"
 	"github.com/derailed/k9s/internal/render"
 	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/k9s/internal/view/cmd"
 	"github.com/derailed/tview"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -167,6 +169,103 @@ func TestTableViewSort(t *testing.T) {
 			assert.Equal(t, s, v.GetCell(i+1, 0).Text)
 		}
 	}
+}
+
+func TestTableSortCapturesHistory(t *testing.T) {
+	v := NewTable(client.NewGVR("test"))
+	require.NoError(t, v.Init(makeContext(t)))
+	v.SetModel(new(mockTableModel))
+	v.SetCommand(cmd.NewInterpreter("test"))
+	v.app.cmdHistory.Push("test")
+
+	v.SortColCmd("NAME", true)(nil)
+
+	top, ok := v.app.cmdHistory.Top()
+	require.True(t, ok)
+	assert.Equal(t, "test sort:name:asc", top)
+}
+
+func TestTableRestoreSort(t *testing.T) {
+	v := NewTable(client.NewGVR("test"))
+
+	// Restore in Command.run happens BEFORE the component is initialized.
+	v.SetSortCol("FRED", true)
+	v.SetManualSort(true)
+
+	require.NoError(t, v.Init(makeContext(t)))
+	v.SetCommand(cmd.NewInterpreter("test sort:fred:asc"))
+	// Start registers the table as a view-config listener, which fires
+	// ViewSettingsChanged and may reset the restored manual sort.
+	v.Start()
+
+	data := model1.NewTableDataWithRows(
+		client.NewGVR("test"),
+		model1.Header{
+			model1.HeaderColumn{Name: "NAMESPACE"},
+			model1.HeaderColumn{Name: "NAME"},
+			model1.HeaderColumn{Name: "FRED"},
+			model1.HeaderColumn{Name: "AGE", Attrs: model1.Attrs{Time: true, Decorator: render.AgeDecorator}},
+		},
+		model1.NewRowEventsWithEvts(
+			model1.RowEvent{Row: model1.Row{Fields: model1.Fields{"ns1", "a", "30", "3m"}}},
+			model1.RowEvent{Row: model1.Row{Fields: model1.Fields{"ns1", "b", "10", "1m"}}},
+			model1.RowEvent{Row: model1.Row{Fields: model1.Fields{"ns1", "c", "20", "2m"}}},
+		),
+	)
+	cdata := v.Update(data, false)
+	v.UpdateUI(cdata, data)
+
+	assert.Equal(t, "FRED", v.GetSortCol().Name)
+	// FRED ascending => 10,20,30 => rows b,c,a
+	assert.Equal(t, "b", strings.TrimSpace(v.GetCell(1, 1).Text))
+	assert.Equal(t, "c", strings.TrimSpace(v.GetCell(2, 1).Text))
+	assert.Equal(t, "a", strings.TrimSpace(v.GetCell(3, 1).Text))
+	// Visible cols: NAMESPACE=0, NAME=1, FRED=2.
+	// The highlighted column must follow the restored sort column.
+	assert.Equal(t, 2, v.GetSelectedColIdx())
+}
+
+func TestTableRestoreSortWithCustomView(t *testing.T) {
+	v := NewTable(client.NewGVR("test"))
+
+	// Restore in Command.run happens BEFORE the component is initialized.
+	v.SetSortCol("FRED", true)
+	v.SetManualSort(true)
+
+	require.NoError(t, v.Init(makeContext(t)))
+	v.SetCommand(cmd.NewInterpreter("test sort:fred:asc"))
+
+	// Simulate a custom view config (views.yaml) with a different default
+	// sort column. Registering the listener fires ViewSettingsChanged which
+	// must not clobber the restored sort.
+	v.app.CustomView().Views["test"] = config.ViewSetting{SortColumn: "NAME:desc"}
+	v.Start()
+
+	data := model1.NewTableDataWithRows(
+		client.NewGVR("test"),
+		model1.Header{
+			model1.HeaderColumn{Name: "NAMESPACE"},
+			model1.HeaderColumn{Name: "NAME"},
+			model1.HeaderColumn{Name: "FRED"},
+			model1.HeaderColumn{Name: "AGE", Attrs: model1.Attrs{Time: true, Decorator: render.AgeDecorator}},
+		},
+		model1.NewRowEventsWithEvts(
+			model1.RowEvent{Row: model1.Row{Fields: model1.Fields{"ns1", "a", "30", "3m"}}},
+			model1.RowEvent{Row: model1.Row{Fields: model1.Fields{"ns1", "b", "10", "1m"}}},
+			model1.RowEvent{Row: model1.Row{Fields: model1.Fields{"ns1", "c", "20", "2m"}}},
+		),
+	)
+	cdata := v.Update(data, false)
+	v.UpdateUI(cdata, data)
+
+	assert.Equal(t, "FRED", v.GetSortCol().Name)
+	// FRED ascending => 10,20,30 => rows b,c,a
+	assert.Equal(t, "b", strings.TrimSpace(v.GetCell(1, 1).Text))
+	assert.Equal(t, "c", strings.TrimSpace(v.GetCell(2, 1).Text))
+	assert.Equal(t, "a", strings.TrimSpace(v.GetCell(3, 1).Text))
+	// Visible cols: NAMESPACE=0, NAME=1, FRED=2.
+	// The highlighted column must follow the restored sort column.
+	assert.Equal(t, 2, v.GetSelectedColIdx())
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Issue: #3220

**What's Fixed**
Navigation history now properly reapplies all view settings when you go back/forward between resources. Previously, filters and labels were not being restored. This PR fixes that and adds sort column/direction to the mix.

**Background**
My previous attempt (#3519) was abandoned. This second implementation takes a more complete approach: not only does the sort column persist, but the sort direction (ascending/descending).

**How It Works**
View state is encoded in the command line and saved to history. For example: `pods /test sort:AGE:DESC`

This is fully compatible with existing filter and label syntax. They all work together seamlessly.

**What Gets Preserved Now**
- Filters and labels (now working correctly)
- Sort column name
- Sort direction (ascending/descending)

So if you sort by Age descending, add a filter, switch to another resource, then navigate back, you'll find the exact same view restored.