### PR TITLE
fix(config): add portForwardAddress json tag and shellPod.hostPathVolume schema

### DIFF
--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -83,6 +83,18 @@
                   "name": { "type": "string" }
                 }
               }
+            },
+            "hostPathVolume": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" },
+                  "mountPath": { "type": "string" },
+                  "hostPath": { "type": "string" },
+                  "readOnly": { "type": "boolean" }
+                }
+              }
             }
           },
           "required": ["image", "namespace", "limits"]

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -42,7 +42,7 @@ type K9s struct {
 	MaxConnRetry        int32      `json:"maxConnRetry" yaml:"maxConnRetry"`
 	ReadOnly            bool       `json:"readOnly" yaml:"readOnly"`
 	NoExitOnCtrlC       bool       `json:"noExitOnCtrlC" yaml:"noExitOnCtrlC"`
-	PortForwardAddress  string     `yaml:"portForwardAddress"`
+	PortForwardAddress  string     `json:"portForwardAddress" yaml:"portForwardAddress"`
 	UI                  UI         `json:"ui" yaml:"ui"`
 	SkipLatestRevCheck  bool       `json:"skipLatestRevCheck" yaml:"skipLatestRevCheck"`
 	DisablePodCounting  bool       `json:"disablePodCounting" yaml:"disablePodCounting"`


### PR DESCRIPTION
## Summary

Two small config consistency fixes discovered while auditing the config docs vs. the code/schema:

- **`portForwardAddress` json tag** — `K9s.PortForwardAddress` only had a `yaml` tag; added the matching `json` tag for consistency with the rest of the struct.
- **`shellPod.hostPathVolume` schema** — the `ShellPod` struct supports `hostPathVolume`, but it was missing from the JSON schema, so configs using it would fail schema validation. Added the definition.

## Commits

- `fix(config): add portForwardAddress json tag`
- `fix(config): add shellPod.hostPathVolume to JSON schema`

## Testing

- `go build ./internal/config/...` passes
- `go test ./internal/config/...` passes (incl. JSON schema validation)