### PR TITLE
fix: correct arm64 docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # -----------------------------------------------------------------------------
 # The base image for building the k9s binary
-FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine3.21 AS build
+FROM --platform=$BUILDPLATFORM golang:1.25.11-alpine3.23 AS build
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -15,15 +15,18 @@ RUN apk --no-cache add --update make libx11-dev git gcc libc-dev curl \
   && make build
 
 # -----------------------------------------------------------------------------
-# Build the final Docker image
-FROM --platform=$BUILDPLATFORM alpine:3.23.3
+# Build the final Docker image for the target platform (not the build host).
+# Pinning this stage to $BUILDPLATFORM would yield an amd64 runtime image (incl.
+# kubectl) even for the arm64 manifest entry, so we let it default to
+# $TARGETPLATFORM and use buildx's TARGETARCH to fetch the matching kubectl.
+FROM alpine:3.23.3
 ARG KUBECTL_VERSION="v1.32.2"
+ARG TARGETARCH
 
 COPY --from=build /k9s/execs/k9s /bin/k9s
 RUN apk --no-cache add --update ca-certificates \
   && apk --no-cache add --update -t deps curl vim \
-  && TARGET_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
-  && curl -f -L https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGET_ARCH}/kubectl -o /usr/local/bin/kubectl \
+  && curl -f -L https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl -o /usr/local/bin/kubectl \
   && chmod +x /usr/local/bin/kubectl \
   && apk del --purge deps
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,26 @@ Binaries for Linux, Windows and Mac are available as tarballs in the [release pa
   docker run --rm -it -v ~/.kube/config:/root/.kube/config k9s-docker:0.1
   ```
 
+#### Building a multi-platform image
+
+  The `make imgx` target builds for `linux/amd64` and `linux/arm64` via Docker
+  buildx:
+
+  ```shell
+  make imgx
+  ```
+
+  Cross-architecture builds rely on QEMU emulation. Docker Desktop includes
+  this out of the box. On a plain Docker Engine install, see the
+  [buildx multi-platform docs](https://docs.docker.com/build/building/multi-platform/)
+  for enabling emulation.
+
+  Override the defaults with `BUILD_PLATFORMS`, `IMG_NAME` and `VERSION`:
+
+  ```shell
+  make imgx BUILD_PLATFORMS=linux/amd64,linux/arm64 IMG_NAME=your-org/k9s VERSION=v0.0.1
+  ```
+
 ---
 
 ## PreFlight Checks


### PR DESCRIPTION
## What this does

The k9s container image was only usable on amd64. Building for arm64 produced an image that failed at runtime on ARM hosts (the `exec format error` reported in #2849), and even when it ran it shipped an amd64 kubectl inside the arm64 image.

I traced this to two problems in the Dockerfile:

1. The final stage was pinned with `FROM --platform=$BUILDPLATFORM alpine`. That forces the runtime image to the build host architecture, so when buildx builds the linux/arm64 target on an amd64 runner the base layers and the bundled kubectl come out as amd64 even though the k9s binary is cross compiled to arm64. The result is a broken arm64 manifest entry.

2. kubectl was selected at build time with `arch`, which reports the build host architecture rather than the target. So the wrong kubectl gets baked in whenever the build host and target differ.

## Changes

- Drop `--platform=$BUILDPLATFORM` on the final stage so it defaults to `$TARGETPLATFORM`. The runtime image is now built for the target arch.
- Replace the runtime `arch` detection with buildx's `TARGETARCH` build arg so the matching kubectl is fetched for each target.
- Bump the builder image from `golang:1.25.5-alpine3.21` to `golang:1.25.11-alpine3.23`. The build was failing because go.mod now requires go 1.25.8 and the alpine3.21 variant stopped at 1.25.5.

With these changes the existing multi-arch build (`make pushx`, which already targets `linux/amd64,linux/arm64`) produces a correct manifest list, so users on ARM pull a working image automatically.

## Testing

- Built `linux/arm64` with `docker buildx build --platform linux/arm64` and confirmed both binaries are arm64:
  - `/bin/k9s`: ELF 64-bit ARM aarch64
  - `/usr/local/bin/kubectl`: ELF 64-bit ARM aarch64
- Loaded the image into a local kind cluster and ran `k9s version` in a pod successfully.

Closes #3208
Closes #2849