### PR TITLE
fix(exec): use shlex for shell-aware command parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -203,6 +203,7 @@ require (
 	github.com/google/licensecheck v0.3.1 // indirect
 	github.com/google/pprof v0.0.0-20250630185457-6e76a2b096b5 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.17.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/fvbommel/sortorder v1.1.0
 	github.com/go-errors/errors v1.5.1
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/itchyny/gojq v0.12.18
 	github.com/karrick/godirwalk v1.17.0
 	github.com/lmittmann/tint v1.1.3
@@ -203,7 +204,6 @@ require (
 	github.com/google/licensecheck v0.3.1 // indirect
 	github.com/google/pprof v0.0.0-20250630185457-6e76a2b096b5 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -631,6 +631,8 @@ github.com/google/pprof v0.0.0-20250630185457-6e76a2b096b5/go.mod h1:5hDyRhoBCxV
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -173,6 +173,13 @@ func edit(a *App, opts *shellOpts) bool {
 	return status
 }
 
+func shellQuote(s string) string {
+	if !strings.ContainsAny(s, " \t\n\"'\\") {
+		return s
+	}
+	return `"` + strings.ReplaceAll(strings.ReplaceAll(s, `\`, `\\`), `"`, `\"`) + `"`
+}
+
 func execute(opts *shellOpts, statusChan chan<- string) error {
 	if opts.clear {
 		clearScreen()
@@ -212,6 +219,9 @@ func execute(opts *shellOpts, statusChan chan<- string) error {
 		if binTokens, err := shlex.Split(env); err == nil && len(binTokens) > 0 {
 			if bin, err := exec.LookPath(binTokens[0]); err == nil {
 				binTokens[0] = bin
+				for i := range binTokens {
+					binTokens[i] = shellQuote(binTokens[i])
+				}
 				cmd.Env = append(os.Environ(), fmt.Sprintf("KUBE_EDITOR=%s", strings.Join(binTokens, " ")))
 			}
 		}

--- a/internal/view/exec.go
+++ b/internal/view/exec.go
@@ -24,6 +24,7 @@ import (
 	"github.com/derailed/k9s/internal/slogs"
 	"github.com/derailed/k9s/internal/ui/dialog"
 	"github.com/fatih/color"
+	"github.com/google/shlex"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -136,7 +137,10 @@ func edit(a *App, opts *shellOpts) bool {
 		// followed by some arguments (e.g. "code -w" to make it work with vscode)
 		//
 		// In such cases, the actual binary is only the first token
-		envTokens := strings.Split(env, " ")
+		envTokens, shlexErr := shlex.Split(env)
+		if shlexErr != nil || len(envTokens) == 0 {
+			continue
+		}
 
 		if bin, err = exec.LookPath(envTokens[0]); err == nil {
 			// Make sure the path is at the end (this allows running editors
@@ -205,19 +209,19 @@ func execute(opts *shellOpts, statusChan chan<- string) error {
 		// followed by some arguments (e.g. "code -w" to make it work with vscode)
 		//
 		// In such cases, the actual binary is only the first token
-		binTokens := strings.Split(env, " ")
-
-		if bin, err := exec.LookPath(binTokens[0]); err == nil {
-			binTokens[0] = bin
-			cmd.Env = append(os.Environ(), fmt.Sprintf("KUBE_EDITOR=%s", strings.Join(binTokens, " ")))
+		if binTokens, err := shlex.Split(env); err == nil && len(binTokens) > 0 {
+			if bin, err := exec.LookPath(binTokens[0]); err == nil {
+				binTokens[0] = bin
+				cmd.Env = append(os.Environ(), fmt.Sprintf("KUBE_EDITOR=%s", strings.Join(binTokens, " ")))
+			}
 		}
 	}
 
 	cmds = append(cmds, cmd)
 
 	for _, p := range opts.pipes {
-		tokens := strings.Split(p, " ")
-		if len(tokens) < 2 {
+		tokens, err := shlex.Split(p)
+		if err != nil || len(tokens) < 2 {
 			continue
 		}
 		cmd := exec.CommandContext(ctx, tokens[0], tokens[1:]...)

--- a/internal/view/exec_test.go
+++ b/internal/view/exec_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShellQuote(t *testing.T) {
+	uu := map[string]struct {
+		input string
+		e     string
+	}{
+		"no-special-chars": {
+			input: "simple",
+			e:     "simple",
+		},
+		"path-with-spaces": {
+			input: "/tmp/my editor/vi",
+			e:     `"/tmp/my editor/vi"`,
+		},
+		"arg-with-spaces": {
+			input: "set number",
+			e:     `"set number"`,
+		},
+		"with-double-quotes": {
+			input: `path"with"quotes`,
+			e:     `"path\"with\"quotes"`,
+		},
+		"with-backslash": {
+			input: `path\with\backslash`,
+			e:     `"path\\with\\backslash"`,
+		},
+		"with-tabs": {
+			input: "path\twith\ttabs",
+			e:     "\"path\twith\ttabs\"",
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, shellQuote(u.input))
+		})
+	}
+}


### PR DESCRIPTION
Closes #4013

  Editor and pipe commands were split on plain spaces using `strings.Split`,
  causing paths with spaces (e.g. `/Applications/Visual Studio Code.app/...`)
  and quoted jq expressions to break before running.

  Replaced with `github.com/google/shlex` which handles quoted arguments
  the same way a shell would.