### PR TITLE
docs: update Apache license link to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1505,4 +1505,4 @@ We always enjoy hearing from folks who benefit from our work!
 
 ---
 
-<img src="assets/imhotep_logo.png" width="32" height="auto" alt="Imhotep"/> &nbsp;© 2026 Imhotep Software LLC. All materials licensed under [Apache v2.0](http://www.apache.org/licenses/LICENSE-2.0)
+<img src="assets/imhotep_logo.png" width="32" height="auto" alt="Imhotep"/> &nbsp;© 2026 Imhotep Software LLC. All materials licensed under [Apache v2.0](https://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
Update the Apache v2.0 license link in README footer from HTTP to HTTPS.