### PR TITLE
docs(jumps): clarify field selector key constraints for resource jumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,13 +869,15 @@ jumps:
 
 ### Template Syntax
 
-Both `labelSelector` and `fieldSelector` support Go template syntax to dynamically reference fields from the selected resource:
+Both `labelSelector` and `fieldSelector` support Go template syntax to dynamically reference fields from the selected (source) resource. Any field of the source object can be used on the **value** side of a selector:
 
 * `{{.metadata.name}}` - The resource name
 * `{{.metadata.namespace}}` - The resource namespace
 * `{{.metadata.labels.key}}` - A specific label value
-* `{{.spec.fieldName}}` - Any field from the resource spec
-* `{{.status.field}}` - Any field from the resource status
+* `{{.spec.fieldName}}` - Any field from the source resource spec
+* `{{.status.field}}` - Any field from the source resource status
+
+> **Note:** The template above only controls the selector *value* (the right-hand side, computed from the source resource). The selector *key* is still validated by the Kubernetes API server against the **target** resource. Label selector keys can be any label, but **field selector keys are restricted**: for most resources only `metadata.name`/`metadata.namespace` are selectable, and for CRDs the target field must be declared in the CRD's `spec.versions[].selectableFields`. k9s passes the field selector straight to the API server (no local filtering), so referencing a non-selectable field returns `field label not supported`. See the Kubernetes docs on [CRD selectable fields](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#crd-selectable-fields).
 
 ### Examples
 


### PR DESCRIPTION
The Resource Jumps docs imply `fieldSelector` supports any field, but the selector **key** is validated by the API server (CRDs only allow declared `selectableFields`). Clarifies the value-vs-key distinction with a link to the Kubernetes docs. Verified against the code path (no client-side filtering).

Closes #4060