### PR TITLE
fix(customJump): enhance viewer handling to preserve built-in enter-chains

### DIFF
--- a/internal/view/custom_jump.go
+++ b/internal/view/custom_jump.go
@@ -37,8 +37,20 @@ func customJump(app *App, sourceGVR *client.GVR, sourcePath string, rule *config
 		return err
 	}
 
-	// Create new view for target resource
-	v := NewBrowser(targetGVR)
+	// Use the registered viewer so built-in enter-chains (e.g. deploy -> pods -> logs) still work.
+	var v ResourceViewer
+	if mv, ok := customViewers[targetGVR]; ok {
+		if mv.viewerFn != nil {
+			v = mv.viewerFn(targetGVR)
+		} else {
+			v = NewBrowser(targetGVR)
+			if mv.enterFn != nil {
+				v.GetTable().SetEnterFn(mv.enterFn)
+			}
+		}
+	} else {
+		v = NewScaleExtender(NewOwnerExtender(NewBrowser(targetGVR)))
+	}
 
 	// Build label selector if specified
 	var labelSel labels.Selector


### PR DESCRIPTION
Closes: #4059 #4081

When landing on a well-known resource via a custom jump (e.g. ArgoCD app -> deployments), pressing Enter would show `kubectl describe` instead of continuing the normal chain (pods -> containers -> logs).

The fix makes `customJump` look up the target GVR in the viewer registry, same as normal navigation does. So if you jump to deployments you get the real deployment viewer with all its enter behavior intact. Unknown CRDs fall back to the same default browser the normal flow uses.