### PR TITLE
Fix table column alignment for wide (CJK) characters

### DIFF
--- a/internal/ui/padding.go
+++ b/internal/ui/padding.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/derailed/k9s/internal/model1"
 	"github.com/derailed/k9s/internal/render"
+	runewidth "github.com/mattn/go-runewidth"
 )
 
 // MaxyPad tracks uniform column padding.
@@ -19,7 +20,7 @@ func ComputeMaxColumns(pads MaxyPad, sortColName string, t *model1.TableData) {
 	const colPadding = 1
 
 	for i, n := range t.ColumnNames(true) {
-		pads[i] = len(n)
+		pads[i] = runewidth.StringWidth(n)
 		if n == sortColName {
 			pads[i] += 2
 		}
@@ -28,7 +29,7 @@ func ComputeMaxColumns(pads MaxyPad, sortColName string, t *model1.TableData) {
 	var row int
 	t.RowsRange(func(_ int, re model1.RowEvent) bool {
 		for index, field := range re.Row.Fields {
-			width := len(field) + colPadding
+			width := runewidth.StringWidth(field) + colPadding
 			if index < len(pads) && width > pads[index] {
 				pads[index] = width
 			}
@@ -48,13 +49,16 @@ func IsASCII(s string) bool {
 	return true
 }
 
-// Pad a string up to the given length or truncates if greater than length.
+// Pad a string up to the given display width or truncates if greater than
+// width. Width is measured in terminal cells so wide (CJK) runes align
+// correctly.
 func Pad(s string, width int) string {
-	if len(s) == width {
+	sw := runewidth.StringWidth(s)
+	if sw == width {
 		return s
 	}
-	if len(s) > width {
+	if sw > width {
 		return render.Truncate(s, width)
 	}
-	return s + strings.Repeat(" ", width-len(s))
+	return s + strings.Repeat(" ", width-sw)
 }

--- a/internal/ui/padding_test.go
+++ b/internal/ui/padding_test.go
@@ -75,7 +75,27 @@ func TestMaxColumn(t *testing.T) {
 				),
 			),
 			"A",
-			MaxyPad{32, 6},
+			MaxyPad{30, 6},
+		},
+		"wide_cjk": {
+			model1.NewTableDataWithRows(
+				client.NewGVR("test"),
+				model1.Header{model1.HeaderColumn{Name: "A"}, model1.HeaderColumn{Name: "B"}},
+				model1.NewRowEventsWithEvts(
+					model1.RowEvent{
+						Row: model1.Row{
+							Fields: model1.Fields{"결제-서비스", "world"},
+						},
+					},
+					model1.RowEvent{
+						Row: model1.Row{
+							Fields: model1.Fields{"o", "mama"},
+						},
+					},
+				),
+			),
+			"B",
+			MaxyPad{12, 6},
 		},
 	}
 

--- a/internal/ui/table_helper.go
+++ b/internal/ui/table_helper.go
@@ -107,9 +107,5 @@ func columnIndicator(sort, selected, asc bool, style *config.Table, name string)
 }
 
 func formatCell(field string, padding int) string {
-	if IsASCII(field) {
-		return Pad(field, padding)
-	}
-
-	return field
+	return Pad(field, padding)
 }


### PR DESCRIPTION
## Description

Table cells containing wide (CJK) characters break column alignment. Two causes:

1. `formatCell()` (internal/ui/table_helper.go) skipped padding entirely for any non-ASCII cell:
   ```go
   if IsASCII(field) {
       return Pad(field, padding)
   }
   return field   // non-ASCII cell returned unpadded
   ```
   So a row with a Korean/Japanese/Chinese pod, namespace, container, or label name left its column unpadded, shifting every column to its right out of alignment.

2. `ComputeMaxColumns()` and `Pad()` (internal/ui/padding.go) measured width with `len()` (UTF-8 byte count). A Hangul rune is 3 bytes but 2 display cells, so columns were sized and padded incorrectly even when padding did run.

## Fix

Use `runewidth.StringWidth()` — already a dependency and already used elsewhere in this package (`internal/render/helpers.go`, `internal/ui/menu.go`) — to measure display width, and always pad cells. ASCII behavior is unchanged (`StringWidth == len` for ASCII).

## Example

Before (a namespace named `결제-서비스` knocks the next column out of line):
```
NAME↑                  READY   STATUS
결제-서비스 RUNNING
api-server             1/1     Running
```
After:
```
NAME↑          READY   STATUS
결제-서비스    1/1     Running
api-server     1/1     Running
```

## Testing

- Updated `TestMaxColumn/non_ascii`, whose expected value encoded the old byte-count behavior (32) rather than the correct display width (30).
- Added a `wide_cjk` case with a Hangul cell.
- `go test ./internal/ui/` passes; `gofmt` clean.
