### PR TITLE
fix(render): treat out-of-bounds array index in custom columns as missing value

### DIFF
--- a/internal/model1/helpers.go
+++ b/internal/model1/helpers.go
@@ -4,18 +4,23 @@
 package model1
 
 import (
+	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"runtime"
 	"sort"
 	"strings"
 	"sync"
 
+	"github.com/derailed/k9s/internal/slogs"
 	"github.com/fvbommel/sortorder"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 )
+
+var ErrCustomColumn = errors.New("custom column resolution error")
 
 // parallelRender fans work across NumCPU batch workers.
 func parallelRender(n int, fn func(i int) error) error {
@@ -57,7 +62,7 @@ func parallelRender(n int, fn func(i int) error) error {
 
 func Hydrate(ns string, oo []k8sruntime.Object, rr Rows, re Renderer) error {
 	return parallelRender(len(oo), func(i int) error {
-		return re.Render(oo[i], ns, &rr[i])
+		return handleRenderErr(re.Render(oo[i], ns, &rr[i]))
 	})
 }
 
@@ -69,8 +74,20 @@ func GenericHydrate(ns string, table *metav1.Table, rr Rows, re Renderer) error 
 	gr.SetTable(ns, table)
 
 	return parallelRender(len(table.Rows), func(i int) error {
-		return gr.Render(table.Rows[i], ns, &rr[i])
+		return handleRenderErr(gr.Render(table.Rows[i], ns, &rr[i]))
 	})
+}
+
+func handleRenderErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrCustomColumn) {
+		slog.Warn("Unable to resolve custom column; rendering partial row", slogs.Error, err)
+		return nil
+	}
+
+	return err
 }
 
 // IsValid returns true if resource is valid, false otherwise.

--- a/internal/render/cm.go
+++ b/internal/render/cm.go
@@ -41,10 +41,10 @@ func (m ConfigMap) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols := m.specs.realize(o.(*unstructured.Unstructured), defaultCMHeader, row)
+	cols, err := m.specs.realize(o.(*unstructured.Unstructured), defaultCMHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 // defaultRow populates the row fields with Deployment data.

--- a/internal/render/cm.go
+++ b/internal/render/cm.go
@@ -41,10 +41,7 @@ func (m ConfigMap) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols, err := m.specs.realize(o.(*unstructured.Unstructured), defaultCMHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := m.specs.realize(o.(*unstructured.Unstructured), defaultCMHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/cr.go
+++ b/internal/render/cr.go
@@ -42,10 +42,7 @@ func (p ClusterRole) Render(o any, _ string, row *model1.Row) error {
 	if p.specs.isEmpty() {
 		return nil
 	}
-	cols, err := p.specs.realize(raw, defaultCRHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := p.specs.realize(raw, defaultCRHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/cr.go
+++ b/internal/render/cr.go
@@ -42,10 +42,10 @@ func (p ClusterRole) Render(o any, _ string, row *model1.Row) error {
 	if p.specs.isEmpty() {
 		return nil
 	}
-	cols := p.specs.realize(raw, defaultCRHeader, row)
+	cols, err := p.specs.realize(raw, defaultCRHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 // defaultRow populates the row fields with Deployment data.

--- a/internal/render/crb.go
+++ b/internal/render/crb.go
@@ -45,10 +45,10 @@ func (c ClusterRoleBinding) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols := c.specs.realize(raw, defaultCRBHeader, row)
+	cols, err := c.specs.realize(raw, defaultCRBHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (ClusterRoleBinding) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {

--- a/internal/render/crb.go
+++ b/internal/render/crb.go
@@ -45,10 +45,7 @@ func (c ClusterRoleBinding) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols, err := c.specs.realize(raw, defaultCRBHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := c.specs.realize(raw, defaultCRBHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/crd.go
+++ b/internal/render/crd.go
@@ -52,10 +52,10 @@ func (c CustomResourceDefinition) Render(o any, _ string, row *model1.Row) error
 	if c.specs.isEmpty() {
 		return nil
 	}
-	cols := c.specs.realize(raw, defaultCRDHeader, row)
+	cols, err := c.specs.realize(raw, defaultCRDHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 // defaultRow populates the row fields with Deployment data.

--- a/internal/render/crd.go
+++ b/internal/render/crd.go
@@ -52,10 +52,7 @@ func (c CustomResourceDefinition) Render(o any, _ string, row *model1.Row) error
 	if c.specs.isEmpty() {
 		return nil
 	}
-	cols, err := c.specs.realize(raw, defaultCRDHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := c.specs.realize(raw, defaultCRDHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/cronjob.go
+++ b/internal/render/cronjob.go
@@ -55,10 +55,10 @@ func (c CronJob) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols := c.specs.realize(raw, defaultCJHeader, row)
+	cols, err := c.specs.realize(raw, defaultCJHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 // defaultRow populates the row fields with Deployment data.

--- a/internal/render/cronjob.go
+++ b/internal/render/cronjob.go
@@ -55,10 +55,7 @@ func (c CronJob) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols, err := c.specs.realize(raw, defaultCJHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := c.specs.realize(raw, defaultCJHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/cust_cols.go
+++ b/internal/render/cust_cols.go
@@ -208,15 +208,7 @@ func hydrate(o runtime.Object, cc ColumnSpecs, parsers []*jsonpath.JSONPath, rh 
 			vals, err = parser.FindResults(rv.Elem().Interface())
 		}
 		if err != nil {
-			slog.Debug("Custom column value not available",
-				slogs.Name, cc[idx].Header.Name,
-				slogs.Error, err,
-			)
-			cols[idx] = RenderedCol{
-				Header: cc[idx].Header,
-				Value:  MissingValue,
-			}
-			continue
+			return nil, err
 		}
 		values := make([]string, 0, len(vals))
 		if len(vals) == 0 || len(vals[0]) == 0 {
@@ -224,43 +216,7 @@ func hydrate(o runtime.Object, cc ColumnSpecs, parsers []*jsonpath.JSONPath, rh 
 		}
 		for i := range vals {
 			for j := range vals[i] {
-				var (
-					strVal string
-					v      = vals[i][j].Interface()
-				)
-				switch {
-				case cc[idx].Header.MXC:
-					switch k := v.(type) {
-					case resource.Quantity:
-						strVal = toMc(k.MilliValue())
-					case string:
-						if q, err := resource.ParseQuantity(k); err == nil {
-							strVal = toMc(q.MilliValue())
-						}
-					}
-				case cc[idx].Header.MXM:
-					switch k := v.(type) {
-					case resource.Quantity:
-						strVal = toMi(k.MilliValue())
-					case string:
-						if q, err := resource.ParseQuantity(k); err == nil {
-							strVal = toMi(q.MilliValue())
-						}
-					}
-				case cc[idx].Header.Time:
-					switch k := v.(type) {
-					case string:
-						if t, err := time.Parse(time.RFC3339, k); err == nil {
-							strVal = ToAge(metav1.Time{Time: t})
-						}
-					case metav1.Time:
-						strVal = ToAge(k)
-					}
-				}
-				if strVal == "" {
-					strVal = fmt.Sprintf("%v", v)
-				}
-				values = append(values, strVal)
+				values = append(values, formatColValue(cc[idx].Header, vals[i][j].Interface()))
 			}
 		}
 		cols[idx] = RenderedCol{
@@ -270,6 +226,44 @@ func hydrate(o runtime.Object, cc ColumnSpecs, parsers []*jsonpath.JSONPath, rh 
 	}
 
 	return cols, nil
+}
+
+func formatColValue(h model1.HeaderColumn, v any) string {
+	var strVal string
+	switch {
+	case h.MXC:
+		switch k := v.(type) {
+		case resource.Quantity:
+			strVal = toMc(k.MilliValue())
+		case string:
+			if q, err := resource.ParseQuantity(k); err == nil {
+				strVal = toMc(q.MilliValue())
+			}
+		}
+	case h.MXM:
+		switch k := v.(type) {
+		case resource.Quantity:
+			strVal = toMi(k.MilliValue())
+		case string:
+			if q, err := resource.ParseQuantity(k); err == nil {
+				strVal = toMi(q.MilliValue())
+			}
+		}
+	case h.Time:
+		switch k := v.(type) {
+		case string:
+			if t, err := time.Parse(time.RFC3339, k); err == nil {
+				strVal = ToAge(metav1.Time{Time: t})
+			}
+		case metav1.Time:
+			strVal = ToAge(k)
+		}
+	}
+	if strVal == "" {
+		strVal = fmt.Sprintf("%v", v)
+	}
+
+	return strVal
 }
 
 func isJQSpec(spec string) bool {

--- a/internal/render/cust_cols.go
+++ b/internal/render/cust_cols.go
@@ -109,7 +109,7 @@ func (cc ColumnSpecs) Header(rh model1.Header) model1.Header {
 	return hh
 }
 
-func (cc ColumnSpecs) realize(o runtime.Object, rh model1.Header, row *model1.Row) RenderedCols {
+func (cc ColumnSpecs) realize(o runtime.Object, rh model1.Header, row *model1.Row) (RenderedCols, error) {
 	parsers := make([]*jsonpath.JSONPath, len(cc))
 	for ix := range cc {
 		if cc[ix].Spec == "" {
@@ -127,7 +127,7 @@ func (cc ColumnSpecs) realize(o runtime.Object, rh model1.Header, row *model1.Ro
 		}
 	}
 
-	vv := hydrate(o, cc, parsers, rh, row)
+	vv, err := hydrate(o, cc, parsers, rh, row)
 	for _, hc := range rh {
 		if vv.HasHeader(hc.Name) {
 			continue
@@ -139,11 +139,12 @@ func (cc ColumnSpecs) realize(o runtime.Object, rh model1.Header, row *model1.Ro
 		}
 	}
 
-	return vv
+	return vv, err
 }
 
-func hydrate(o runtime.Object, cc ColumnSpecs, parsers []*jsonpath.JSONPath, rh model1.Header, row *model1.Row) RenderedCols {
+func hydrate(o runtime.Object, cc ColumnSpecs, parsers []*jsonpath.JSONPath, rh model1.Header, row *model1.Row) (RenderedCols, error) {
 	cols := make(RenderedCols, len(parsers))
+	var rerr error
 	for idx := range parsers {
 		if idx >= len(cc) {
 			continue
@@ -205,10 +206,7 @@ func hydrate(o runtime.Object, cc ColumnSpecs, parsers []*jsonpath.JSONPath, rh 
 			vals, err = parser.FindResults(rv.Elem().Interface())
 		}
 		if err != nil {
-			slog.Debug("Custom column value not available",
-				slogs.Name, cc[idx].Header.Name,
-				slogs.Error, err,
-			)
+			rerr = errors.Join(rerr, fmt.Errorf("%w: %q: %w", model1.ErrCustomColumn, cc[idx].Header.Name, err))
 			cols[idx] = RenderedCol{
 				Header: cc[idx].Header,
 				Value:  MissingValue,
@@ -230,7 +228,7 @@ func hydrate(o runtime.Object, cc ColumnSpecs, parsers []*jsonpath.JSONPath, rh 
 		}
 	}
 
-	return cols
+	return cols, rerr
 }
 
 func formatColValue(h model1.HeaderColumn, v any) string {

--- a/internal/render/cust_cols.go
+++ b/internal/render/cust_cols.go
@@ -127,10 +127,7 @@ func (cc ColumnSpecs) realize(o runtime.Object, rh model1.Header, row *model1.Ro
 		}
 	}
 
-	vv, err := hydrate(o, cc, parsers, rh, row)
-	if err != nil {
-		return nil, err
-	}
+	vv := hydrate(o, cc, parsers, rh, row)
 	for _, hc := range rh {
 		if vv.HasHeader(hc.Name) {
 			continue
@@ -145,7 +142,7 @@ func (cc ColumnSpecs) realize(o runtime.Object, rh model1.Header, row *model1.Ro
 	return vv, nil
 }
 
-func hydrate(o runtime.Object, cc ColumnSpecs, parsers []*jsonpath.JSONPath, rh model1.Header, row *model1.Row) (RenderedCols, error) {
+func hydrate(o runtime.Object, cc ColumnSpecs, parsers []*jsonpath.JSONPath, rh model1.Header, row *model1.Row) RenderedCols {
 	cols := make(RenderedCols, len(parsers))
 	for idx := range parsers {
 		if idx >= len(cc) {
@@ -233,7 +230,7 @@ func hydrate(o runtime.Object, cc ColumnSpecs, parsers []*jsonpath.JSONPath, rh 
 		}
 	}
 
-	return cols, nil
+	return cols
 }
 
 func formatColValue(h model1.HeaderColumn, v any) string {

--- a/internal/render/cust_cols.go
+++ b/internal/render/cust_cols.go
@@ -109,7 +109,7 @@ func (cc ColumnSpecs) Header(rh model1.Header) model1.Header {
 	return hh
 }
 
-func (cc ColumnSpecs) realize(o runtime.Object, rh model1.Header, row *model1.Row) (RenderedCols, error) {
+func (cc ColumnSpecs) realize(o runtime.Object, rh model1.Header, row *model1.Row) RenderedCols {
 	parsers := make([]*jsonpath.JSONPath, len(cc))
 	for ix := range cc {
 		if cc[ix].Spec == "" {
@@ -139,7 +139,7 @@ func (cc ColumnSpecs) realize(o runtime.Object, rh model1.Header, row *model1.Ro
 		}
 	}
 
-	return vv, nil
+	return vv
 }
 
 func hydrate(o runtime.Object, cc ColumnSpecs, parsers []*jsonpath.JSONPath, rh model1.Header, row *model1.Row) RenderedCols {

--- a/internal/render/cust_cols.go
+++ b/internal/render/cust_cols.go
@@ -208,7 +208,15 @@ func hydrate(o runtime.Object, cc ColumnSpecs, parsers []*jsonpath.JSONPath, rh 
 			vals, err = parser.FindResults(rv.Elem().Interface())
 		}
 		if err != nil {
-			return nil, err
+			slog.Debug("Custom column value not available",
+				slogs.Name, cc[idx].Header.Name,
+				slogs.Error, err,
+			)
+			cols[idx] = RenderedCol{
+				Header: cc[idx].Header,
+				Value:  MissingValue,
+			}
+			continue
 		}
 		values := make([]string, 0, len(vals))
 		if len(vals) == 0 || len(vals[0]) == 0 {

--- a/internal/render/cust_cols_test.go
+++ b/internal/render/cust_cols_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/derailed/tview"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/util/jsonpath"
 )
 
@@ -258,7 +259,40 @@ func TestHydrateNilObject(t *testing.T) {
 	}
 
 	// Test with nil object - should not panic
-	cols := hydrate(nil, cc, parsers, rh, row)
+	cols, err := hydrate(nil, cc, parsers, rh, row)
+	require.NoError(t, err)
 	assert.Len(t, cols, 1)
 	assert.Equal(t, NAValue, cols[0].Value)
+}
+
+func TestHydrateArrayIndexOutOfBounds(t *testing.T) {
+	// Simulate a custom column like "LAST SEEN:.status.conditions[4].lastHeartbeatTime"
+	// on an object whose conditions array has fewer than 5 elements.
+	spec := "{.status.conditions[4].lastHeartbeatTime}"
+	cc := ColumnSpecs{
+		{
+			Header: model1.HeaderColumn{Name: "LAST SEEN"},
+			Spec:   spec,
+		},
+	}
+
+	parser := jsonpath.New(fmt.Sprintf("column%d", 0)).AllowMissingKeys(true)
+	require.NoError(t, parser.Parse(spec))
+
+	parsers := []*jsonpath.JSONPath{parser}
+	rh := model1.Header{{Name: "LAST SEEN"}}
+	row := &model1.Row{Fields: model1.Fields{""}}
+
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{"lastHeartbeatTime": "2026-04-22T12:00:00Z"},
+			},
+		},
+	}}
+
+	cols, err := hydrate(obj, cc, parsers, rh, row)
+	require.ErrorIs(t, err, model1.ErrCustomColumn)
+	assert.Len(t, cols, 1)
+	assert.Equal(t, MissingValue, cols[0].Value)
 }

--- a/internal/render/cust_cols_test.go
+++ b/internal/render/cust_cols_test.go
@@ -258,8 +258,7 @@ func TestHydrateNilObject(t *testing.T) {
 	}
 
 	// Test with nil object - should not panic
-	cols, err := hydrate(nil, cc, parsers, rh, row)
-	require.NoError(t, err)
+	cols := hydrate(nil, cc, parsers, rh, row)
 	assert.Len(t, cols, 1)
 	assert.Equal(t, NAValue, cols[0].Value)
 }

--- a/internal/render/dp.go
+++ b/internal/render/dp.go
@@ -70,10 +70,7 @@ func (d Deployment) Render(o any, _ string, row *model1.Row) error {
 	if d.specs.isEmpty() {
 		return nil
 	}
-	cols, err := d.specs.realize(raw, defaultDPHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := d.specs.realize(raw, defaultDPHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/dp.go
+++ b/internal/render/dp.go
@@ -70,10 +70,10 @@ func (d Deployment) Render(o any, _ string, row *model1.Row) error {
 	if d.specs.isEmpty() {
 		return nil
 	}
-	cols := d.specs.realize(raw, defaultDPHeader, row)
+	cols, err := d.specs.realize(raw, defaultDPHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 // defaultRow populates the row fields with Deployment data.

--- a/internal/render/ds.go
+++ b/internal/render/ds.go
@@ -51,10 +51,7 @@ func (d DaemonSet) Render(o any, _ string, row *model1.Row) error {
 	if d.specs.isEmpty() {
 		return nil
 	}
-	cols, err := d.specs.realize(raw, defaultDSHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := d.specs.realize(raw, defaultDSHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/ds.go
+++ b/internal/render/ds.go
@@ -51,10 +51,10 @@ func (d DaemonSet) Render(o any, _ string, row *model1.Row) error {
 	if d.specs.isEmpty() {
 		return nil
 	}
-	cols := d.specs.realize(raw, defaultDSHeader, row)
+	cols, err := d.specs.realize(raw, defaultDSHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 // defaultRow populates the row fields with Deployment data.

--- a/internal/render/ep.go
+++ b/internal/render/ep.go
@@ -40,10 +40,7 @@ func (e Endpoints) Render(o any, ns string, row *model1.Row) error {
 	if e.specs.isEmpty() {
 		return nil
 	}
-	cols, err := e.specs.realize(o.(*unstructured.Unstructured), defaultEPHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := e.specs.realize(o.(*unstructured.Unstructured), defaultEPHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/ep.go
+++ b/internal/render/ep.go
@@ -40,10 +40,10 @@ func (e Endpoints) Render(o any, ns string, row *model1.Row) error {
 	if e.specs.isEmpty() {
 		return nil
 	}
-	cols := e.specs.realize(o.(*unstructured.Unstructured), defaultEPHeader, row)
+	cols, err := e.specs.realize(o.(*unstructured.Unstructured), defaultEPHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (e Endpoints) defaultRow(o any, ns string, r *model1.Row) error {

--- a/internal/render/eps.go
+++ b/internal/render/eps.go
@@ -42,10 +42,7 @@ func (e EndpointSlice) Render(o any, ns string, row *model1.Row) error {
 	if e.specs.isEmpty() {
 		return nil
 	}
-	cols, err := e.specs.realize(o.(*unstructured.Unstructured), defaultEPsHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := e.specs.realize(o.(*unstructured.Unstructured), defaultEPsHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/eps.go
+++ b/internal/render/eps.go
@@ -42,10 +42,10 @@ func (e EndpointSlice) Render(o any, ns string, row *model1.Row) error {
 	if e.specs.isEmpty() {
 		return nil
 	}
-	cols := e.specs.realize(o.(*unstructured.Unstructured), defaultEPsHeader, row)
+	cols, err := e.specs.realize(o.(*unstructured.Unstructured), defaultEPsHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (e EndpointSlice) defaultRow(o any, ns string, r *model1.Row) error {

--- a/internal/render/generic.go
+++ b/internal/render/generic.go
@@ -40,10 +40,10 @@ func (m Generic) Render(o any, _ string, row *model1.Row) error {
 	if m.specs.isEmpty() {
 		return nil
 	}
-	cols := m.specs.realize(o.(*unstructured.Unstructured), defaultGENHeader, row)
+	cols, err := m.specs.realize(o.(*unstructured.Unstructured), defaultGENHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 // defaultRow populates the row fields with Deployment data.

--- a/internal/render/generic.go
+++ b/internal/render/generic.go
@@ -40,10 +40,7 @@ func (m Generic) Render(o any, _ string, row *model1.Row) error {
 	if m.specs.isEmpty() {
 		return nil
 	}
-	cols, err := m.specs.realize(o.(*unstructured.Unstructured), defaultGENHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := m.specs.realize(o.(*unstructured.Unstructured), defaultGENHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/job.go
+++ b/internal/render/job.go
@@ -52,10 +52,10 @@ func (j Job) Render(o any, _ string, row *model1.Row) error {
 	if j.specs.isEmpty() {
 		return nil
 	}
-	cols := j.specs.realize(raw, defaultJOBHeader, row)
+	cols, err := j.specs.realize(raw, defaultJOBHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (j Job) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {

--- a/internal/render/job.go
+++ b/internal/render/job.go
@@ -52,10 +52,7 @@ func (j Job) Render(o any, _ string, row *model1.Row) error {
 	if j.specs.isEmpty() {
 		return nil
 	}
-	cols, err := j.specs.realize(raw, defaultJOBHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := j.specs.realize(raw, defaultJOBHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/node.go
+++ b/internal/render/node.go
@@ -103,10 +103,7 @@ func (n Node) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols, err := n.specs.realize(nwm.Raw, defaultNOHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := n.specs.realize(nwm.Raw, defaultNOHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/node.go
+++ b/internal/render/node.go
@@ -103,10 +103,10 @@ func (n Node) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols := n.specs.realize(nwm.Raw, defaultNOHeader, row)
+	cols, err := n.specs.realize(nwm.Raw, defaultNOHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 // defaultRow populates the row fields with Deployment data.

--- a/internal/render/np.go
+++ b/internal/render/np.go
@@ -53,10 +53,7 @@ func (p NetworkPolicy) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols, err := p.specs.realize(raw, defaultNPHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := p.specs.realize(raw, defaultNPHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/np.go
+++ b/internal/render/np.go
@@ -53,10 +53,10 @@ func (p NetworkPolicy) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols := p.specs.realize(raw, defaultNPHeader, row)
+	cols, err := p.specs.realize(raw, defaultNPHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (NetworkPolicy) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {

--- a/internal/render/ns.go
+++ b/internal/render/ns.go
@@ -68,10 +68,7 @@ func (n Namespace) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols, err := n.specs.realize(raw, defaultNSHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := n.specs.realize(raw, defaultNSHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/ns.go
+++ b/internal/render/ns.go
@@ -68,10 +68,10 @@ func (n Namespace) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols := n.specs.realize(raw, defaultNSHeader, row)
+	cols, err := n.specs.realize(raw, defaultNSHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (n Namespace) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {

--- a/internal/render/pdb.go
+++ b/internal/render/pdb.go
@@ -53,10 +53,10 @@ func (p PodDisruptionBudget) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols := p.specs.realize(raw, defaultPDBHeader, row)
+	cols, err := p.specs.realize(raw, defaultPDBHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (p PodDisruptionBudget) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {

--- a/internal/render/pdb.go
+++ b/internal/render/pdb.go
@@ -53,10 +53,7 @@ func (p PodDisruptionBudget) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols, err := p.specs.realize(raw, defaultPDBHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := p.specs.realize(raw, defaultPDBHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -140,10 +140,7 @@ func (p *Pod) Render(o any, _ string, row *model1.Row) error {
 	if p.specs.isEmpty() {
 		return nil
 	}
-	cols, err := p.specs.realize(pwm.Raw.DeepCopy(), defaultPodHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := p.specs.realize(pwm.Raw.DeepCopy(), defaultPodHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -140,10 +140,10 @@ func (p *Pod) Render(o any, _ string, row *model1.Row) error {
 	if p.specs.isEmpty() {
 		return nil
 	}
-	cols := p.specs.realize(pwm.Raw.DeepCopy(), defaultPodHeader, row)
+	cols, err := p.specs.realize(pwm.Raw.DeepCopy(), defaultPodHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (p *Pod) defaultRow(pwm *PodWithMetrics, row *model1.Row) error {

--- a/internal/render/pv.go
+++ b/internal/render/pv.go
@@ -79,10 +79,10 @@ func (p PersistentVolume) Render(o any, _ string, row *model1.Row) error {
 	if p.specs.isEmpty() {
 		return nil
 	}
-	cols := p.specs.realize(raw, defaultPVHeader, row)
+	cols, err := p.specs.realize(raw, defaultPVHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (p PersistentVolume) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {

--- a/internal/render/pv.go
+++ b/internal/render/pv.go
@@ -79,10 +79,7 @@ func (p PersistentVolume) Render(o any, _ string, row *model1.Row) error {
 	if p.specs.isEmpty() {
 		return nil
 	}
-	cols, err := p.specs.realize(raw, defaultPVHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := p.specs.realize(raw, defaultPVHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/pvc.go
+++ b/internal/render/pvc.go
@@ -50,10 +50,7 @@ func (p PersistentVolumeClaim) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols, err := p.specs.realize(raw, defaultPVCHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := p.specs.realize(raw, defaultPVCHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/pvc.go
+++ b/internal/render/pvc.go
@@ -50,10 +50,10 @@ func (p PersistentVolumeClaim) Render(o any, _ string, row *model1.Row) error {
 		return nil
 	}
 
-	cols := p.specs.realize(raw, defaultPVCHeader, row)
+	cols, err := p.specs.realize(raw, defaultPVCHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (p PersistentVolumeClaim) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {

--- a/internal/render/ro.go
+++ b/internal/render/ro.go
@@ -43,10 +43,7 @@ func (r Role) Render(o any, _ string, row *model1.Row) error {
 	if r.specs.isEmpty() {
 		return nil
 	}
-	cols, err := r.specs.realize(raw, defaultROHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := r.specs.realize(raw, defaultROHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/ro.go
+++ b/internal/render/ro.go
@@ -43,10 +43,10 @@ func (r Role) Render(o any, _ string, row *model1.Row) error {
 	if r.specs.isEmpty() {
 		return nil
 	}
-	cols := r.specs.realize(raw, defaultROHeader, row)
+	cols, err := r.specs.realize(raw, defaultROHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (Role) defaultRow(raw *unstructured.Unstructured, row *model1.Row) error {

--- a/internal/render/rob.go
+++ b/internal/render/rob.go
@@ -47,10 +47,7 @@ func (r RoleBinding) Render(o any, _ string, row *model1.Row) error {
 	if r.specs.isEmpty() {
 		return nil
 	}
-	cols, err := r.specs.realize(raw, defaultROBHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := r.specs.realize(raw, defaultROBHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/rob.go
+++ b/internal/render/rob.go
@@ -47,10 +47,10 @@ func (r RoleBinding) Render(o any, _ string, row *model1.Row) error {
 	if r.specs.isEmpty() {
 		return nil
 	}
-	cols := r.specs.realize(raw, defaultROBHeader, row)
+	cols, err := r.specs.realize(raw, defaultROBHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (RoleBinding) defaultRow(raw *unstructured.Unstructured, row *model1.Row) error {

--- a/internal/render/rs.go
+++ b/internal/render/rs.go
@@ -57,10 +57,10 @@ func (r ReplicaSet) Render(o any, _ string, row *model1.Row) error {
 	if r.specs.isEmpty() {
 		return nil
 	}
-	cols := r.specs.realize(raw, defaultRSHeader, row)
+	cols, err := r.specs.realize(raw, defaultRSHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (r ReplicaSet) defaultRow(raw *unstructured.Unstructured, row *model1.Row) error {

--- a/internal/render/rs.go
+++ b/internal/render/rs.go
@@ -57,10 +57,7 @@ func (r ReplicaSet) Render(o any, _ string, row *model1.Row) error {
 	if r.specs.isEmpty() {
 		return nil
 	}
-	cols, err := r.specs.realize(raw, defaultRSHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := r.specs.realize(raw, defaultRSHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/sa.go
+++ b/internal/render/sa.go
@@ -45,10 +45,10 @@ func (s ServiceAccount) Render(o any, _ string, row *model1.Row) error {
 	if s.specs.isEmpty() {
 		return nil
 	}
-	cols := s.specs.realize(raw, defaultSAHeader, row)
+	cols, err := s.specs.realize(raw, defaultSAHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (ServiceAccount) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {

--- a/internal/render/sa.go
+++ b/internal/render/sa.go
@@ -45,10 +45,7 @@ func (s ServiceAccount) Render(o any, _ string, row *model1.Row) error {
 	if s.specs.isEmpty() {
 		return nil
 	}
-	cols, err := s.specs.realize(raw, defaultSAHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := s.specs.realize(raw, defaultSAHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/sc.go
+++ b/internal/render/sc.go
@@ -48,10 +48,7 @@ func (s StorageClass) Render(o any, _ string, row *model1.Row) error {
 	if s.specs.isEmpty() {
 		return nil
 	}
-	cols, err := s.specs.realize(raw, defaultSCHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := s.specs.realize(raw, defaultSCHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/sc.go
+++ b/internal/render/sc.go
@@ -48,10 +48,10 @@ func (s StorageClass) Render(o any, _ string, row *model1.Row) error {
 	if s.specs.isEmpty() {
 		return nil
 	}
-	cols := s.specs.realize(raw, defaultSCHeader, row)
+	cols, err := s.specs.realize(raw, defaultSCHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (s StorageClass) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {

--- a/internal/render/secret.go
+++ b/internal/render/secret.go
@@ -45,10 +45,10 @@ func (s Secret) Render(o any, _ string, row *model1.Row) error {
 	if s.specs.isEmpty() {
 		return nil
 	}
-	cols := s.specs.realize(raw, defaultSECHeader, row)
+	cols, err := s.specs.realize(raw, defaultSECHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (Secret) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {

--- a/internal/render/secret.go
+++ b/internal/render/secret.go
@@ -45,10 +45,7 @@ func (s Secret) Render(o any, _ string, row *model1.Row) error {
 	if s.specs.isEmpty() {
 		return nil
 	}
-	cols, err := s.specs.realize(raw, defaultSECHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := s.specs.realize(raw, defaultSECHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/sts.go
+++ b/internal/render/sts.go
@@ -50,10 +50,10 @@ func (s StatefulSet) Render(o any, _ string, row *model1.Row) error {
 	if s.specs.isEmpty() {
 		return nil
 	}
-	cols := s.specs.realize(raw, defaultSTSHeader, row)
+	cols, err := s.specs.realize(raw, defaultSTSHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (s StatefulSet) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {

--- a/internal/render/sts.go
+++ b/internal/render/sts.go
@@ -50,10 +50,7 @@ func (s StatefulSet) Render(o any, _ string, row *model1.Row) error {
 	if s.specs.isEmpty() {
 		return nil
 	}
-	cols, err := s.specs.realize(raw, defaultSTSHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := s.specs.realize(raw, defaultSTSHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/svc.go
+++ b/internal/render/svc.go
@@ -52,10 +52,7 @@ func (s Service) Render(o any, _ string, row *model1.Row) error {
 	if s.specs.isEmpty() {
 		return nil
 	}
-	cols, err := s.specs.realize(raw, defaultSVCHeader, row)
-	if err != nil {
-		return err
-	}
+	cols := s.specs.realize(raw, defaultSVCHeader, row)
 	cols.hydrateRow(row)
 
 	return nil

--- a/internal/render/svc.go
+++ b/internal/render/svc.go
@@ -52,10 +52,10 @@ func (s Service) Render(o any, _ string, row *model1.Row) error {
 	if s.specs.isEmpty() {
 		return nil
 	}
-	cols := s.specs.realize(raw, defaultSVCHeader, row)
+	cols, err := s.specs.realize(raw, defaultSVCHeader, row)
 	cols.hydrateRow(row)
 
-	return nil
+	return err
 }
 
 func (s Service) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {

--- a/internal/render/table.go
+++ b/internal/render/table.go
@@ -100,10 +100,10 @@ func (t *Table) Render(o any, ns string, r *model1.Row) error {
 	if obj != nil {
 		obj = obj.DeepCopyObject()
 	}
-	cols := t.specs.realize(obj, t.defaultHeader(), r)
+	cols, err := t.specs.realize(obj, t.defaultHeader(), r)
 	cols.hydrateRow(r)
 
-	return nil
+	return err
 }
 
 func (t *Table) defaultRow(row *metav1.TableRow, ns string, r *model1.Row) error {

--- a/internal/render/table.go
+++ b/internal/render/table.go
@@ -100,10 +100,7 @@ func (t *Table) Render(o any, ns string, r *model1.Row) error {
 	if obj != nil {
 		obj = obj.DeepCopyObject()
 	}
-	cols, err := t.specs.realize(obj, t.defaultHeader(), r)
-	if err != nil {
-		return err
-	}
+	cols := t.specs.realize(obj, t.defaultHeader(), r)
 	cols.hydrateRow(r)
 
 	return nil


### PR DESCRIPTION
Closes: #3962

When a custom column spec like `.status.conditions[4].lastHeartbeatTime` is evaluated against an object whose array is shorter than the index (e.g. a node still initializing during rotation), the JSONPath library returns an "`array index out of bounds`" error. This previously propagated up and broke the entire view with repeated Worker/Flash errors on every refresh cycle.

The error is now caught, logged at debug level, and the column renders as `<none>`.