### PR TITLE
fix(render): CRD LABELS column always renders empty

### DIFF
--- a/internal/render/crd.go
+++ b/internal/render/crd.go
@@ -91,7 +91,7 @@ func (c CustomResourceDefinition) defaultRow(raw *unstructured.Unstructured, r *
 		naStrings(versions),
 		string(crd.Spec.Scope),
 		naStrings(crd.Spec.Names.ShortNames),
-		mapToIfc(crd.GetLabels()),
+		mapToStr(crd.GetLabels()),
 		AsStatus(c.diagnose(crd.Name, crd.Spec.Versions)),
 		ToAge(crd.GetCreationTimestamp()),
 	}

--- a/internal/render/crd_test.go
+++ b/internal/render/crd_test.go
@@ -20,4 +20,10 @@ func TestCustomResourceDefinitionRender(t *testing.T) {
 	assert.Equal(t, "-/adapters.config.istio.io", r.ID)
 	assert.Equal(t, "adapters", r.Fields[0])
 	assert.Equal(t, "config.istio.io", r.Fields[1])
+	// LABELS column (index 6) must render the CRD labels, not be empty.
+	assert.Equal(
+		t,
+		"addonmanager.kubernetes.io/mode=Reconcile,app=mixer,istio=mixer-adapter,k8s-app=istio,package=adapter",
+		r.Fields[6],
+	)
 }

--- a/internal/render/helpers.go
+++ b/internal/render/helpers.go
@@ -233,39 +233,6 @@ func mapToStr(m map[string]string) string {
 	return string(bb)
 }
 
-func mapToIfc(m any) (s string) {
-	if m == nil {
-		return ""
-	}
-
-	mm, ok := m.(map[string]any)
-	if !ok {
-		return ""
-	}
-	if len(mm) == 0 {
-		return ""
-	}
-
-	kk := make([]string, 0, len(mm))
-	for k := range mm {
-		kk = append(kk, k)
-	}
-	sort.Strings(kk)
-
-	for i, k := range kk {
-		str, ok := mm[k].(string)
-		if !ok {
-			continue
-		}
-		s += k + "=" + str
-		if i < len(kk)-1 {
-			s += " "
-		}
-	}
-
-	return
-}
-
 func toMu(v int64) string {
 	if v == 0 {
 		return NAValue


### PR DESCRIPTION
## Description

In the CRD view, the **LABELS** column is always blank, no matter what labels a CRD has.

`internal/render/crd.go` builds the field with `mapToIfc(crd.GetLabels())`. But `ObjectMeta.GetLabels()` returns a `map[string]string`, while `mapToIfc` starts with a type assertion to `map[string]any`:

```go
mm, ok := m.(map[string]any)
if !ok { return "" }   // map[string]string never satisfies this -> always ""
```

A `map[string]string` can never satisfy `map[string]any` in Go, so the assertion always fails and the function returns `""`. Every other renderer (cr, crb, ds, dp, ns, node, pod, pv, svc, sts, …) uses `mapToStr` for labels — `crd.go` was the lone outlier, and it was `mapToIfc`'s only caller.

## Fix

Use `mapToStr(crd.GetLabels())` like the sibling renderers (sorted, comma-separated) and remove the now-unused `mapToIfc` helper.

## Test

Extended `TestCustomResourceDefinitionRender` to assert the LABELS column from the existing `testdata/crd.json` fixture. Before: `actual: ""`; after: the 5 labels render. `go test ./internal/render/...` is green.