### PR TITLE
fix(view): sanitize tview escapes when saving YAML from the details view (#4042)

### DIFF
--- a/internal/view/details.go
+++ b/internal/view/details.go
@@ -307,7 +307,7 @@ func (d *Details) resetCmd(evt *tcell.EventKey) *tcell.EventKey {
 }
 
 func (d *Details) saveCmd(*tcell.EventKey) *tcell.EventKey {
-	if path, err := saveYAML(d.app.Config.K9s.ContextScreenDumpDir(), d.title, d.text.GetText(true)); err != nil {
+	if path, err := saveYAML(d.app.Config.K9s.ContextScreenDumpDir(), d.title, sanitizeEsc(d.text.GetText(true))); err != nil {
 		d.app.Flash().Err(err)
 	} else {
 		d.app.Flash().Infof("Log %s saved successfully!", path)

--- a/internal/view/details_test.go
+++ b/internal/view/details_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/config/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetailsSaveSanitize(t *testing.T) {
+	// colorizeYAML runs the content through tview.Escape, turning each `[X]` into
+	// `[X[]`. saveCmd must reverse that with sanitizeEsc, otherwise the file
+	// written to disk keeps the escaped brackets (e.g. `[[:space:[]]`) and is no
+	// longer valid for the sed/grep consumers the YAML came from. A line with
+	// several POSIX bracket classes is the reproducer from #4042.
+	s := `apiVersion: v1
+data:
+  script: sed -E 's/^([[:space:]]*count:[[:space:]]*)[0-9]+/x/'
+`
+
+	app := NewApp(mock.NewMockConfig(t))
+	app.Config.K9s.ScreenDumpDir = t.TempDir()
+
+	d := NewDetails(app, "fred", "subject", "yaml", false)
+	require.NoError(t, d.Init(context.Background()))
+	d.text.SetText(colorizeYAML(config.Yaml{}, s))
+
+	require.Nil(t, d.saveCmd(nil))
+
+	dir := app.Config.K9s.ContextScreenDumpDir()
+	files, err := filepath.Glob(filepath.Join(dir, "*.yaml"))
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	got, err := os.ReadFile(files[0])
+	require.NoError(t, err)
+	assert.Equal(t, s, string(got))
+}


### PR DESCRIPTION
## Description

Fixes #4042 (the remaining half).

#4043 already landed the `bracketRX` greediness fix, so `sanitizeEsc` now reverses every escaped bracket on a line. This PR covers the second issue from #4042 that #4043 did not touch: **`Details.saveCmd` writes the buffer to disk without `sanitizeEsc`.**

When the YAML/details view is colorized, the document is run through `tview.Escape` (`internal/view/yaml.go`), which rewrites `[[:space:]]` to `[[:space:[]]` in the buffer so literal brackets aren't parsed as tags. The copy path (`helpers.go`) and the live view save path (`live_view.go`) reverse this with `sanitizeEsc` before writing — but `Details.saveCmd` (`details.go`) did not, so saving YAML from the details view (Ctrl-S) persisted the escaped form to disk, e.g.

```
s/^([[:space:[]]*count:[[:space:[]]*)[0-9[]+/x/
```

which is no longer valid for the sed/grep consumers the YAML came from.

## Changes

- Route `Details.saveCmd` through `sanitizeEsc`, matching `LiveView.saveCmd`.
- Add `TestDetailsSaveSanitize`: saves a YAML payload with several POSIX bracket classes through the real `saveCmd` and asserts the written file equals the original (fails on the pre-fix `saveCmd`).

## How tested

- `go test ./internal/view/` passes (incl. the new `TestDetailsSaveSanitize`); the test fails against the pre-fix `saveCmd`.
- `gofmt`/`go vet` clean.

_Disclosure: prepared with AI assistance; all code references and the repro were verified against `master`._