### PR TITLE
feat: use EndpointSlices for svc->pod

### DIFF
--- a/internal/dao/ds.go
+++ b/internal/dao/ds.go
@@ -87,20 +87,30 @@ func podLogs(ctx context.Context, sel map[string]string, opts *LogOptions) ([]Lo
 	if err != nil {
 		return nil, err
 	}
-	opts.MultiPods = true
 
-	var po Pod
-	po.Init(f, client.PodGVR)
-
-	outs := make([]LogChan, 0, len(oo))
+	fqns := make([]string, 0, len(oo))
 	for _, o := range oo {
 		u, ok := o.(*unstructured.Unstructured)
 		if !ok {
 			return nil, fmt.Errorf("expected unstructured got %t", o)
 		}
-		opts = opts.Clone()
-		opts.Path = client.FQN(u.GetNamespace(), u.GetName())
-		cc, err := po.TailLogs(ctx, opts)
+		fqns = append(fqns, client.FQN(u.GetNamespace(), u.GetName()))
+	}
+
+	return tailPodsLogs(ctx, f, fqns, opts)
+}
+
+func tailPodsLogs(ctx context.Context, f Factory, fqns []string, opts *LogOptions) ([]LogChan, error) {
+	opts.MultiPods = true
+
+	var po Pod
+	po.Init(f, client.PodGVR)
+
+	outs := make([]LogChan, 0, len(fqns))
+	for _, fqn := range fqns {
+		o := opts.Clone()
+		o.Path = fqn
+		cc, err := po.TailLogs(ctx, o)
 		if err != nil {
 			return nil, err
 		}
@@ -108,6 +118,25 @@ func podLogs(ctx context.Context, sel map[string]string, opts *LogOptions) ([]Lo
 	}
 
 	return outs, nil
+}
+
+func podFromSelector(f Factory, ns string, sel map[string]string) (string, error) {
+	oo, err := f.List(client.PodGVR, ns, true, labels.Set(sel).AsSelector())
+	if err != nil {
+		return "", err
+	}
+
+	if len(oo) == 0 {
+		return "", fmt.Errorf("no matching pods for %v", sel)
+	}
+
+	var pod v1.Pod
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(oo[0].(*unstructured.Unstructured).Object, &pod)
+	if err != nil {
+		return "", err
+	}
+
+	return client.FQN(pod.Namespace, pod.Name), nil
 }
 
 // Pod returns a pod victim by name.

--- a/internal/dao/eps.go
+++ b/internal/dao/eps.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+import (
+	"log/slog"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/slogs"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// podsForService resolves the pods backing a service via its EndpointSlices
+func podsForService(f Factory, ns, svcName string) (sets.Set[string], error) {
+	pods, err := podsFromEndpointSlices(f, ns, svcName)
+	if err != nil {
+		slog.Warn("Endpointslice lookup failed; falling back to service selector",
+			slogs.Namespace, ns,
+			slogs.ResName, svcName,
+			slogs.Error, err,
+		)
+	}
+	if pods.Len() > 0 {
+		return pods, nil
+	}
+
+	return podsFromServiceSelector(f, ns, svcName)
+}
+
+// podsFromEndpointSlices collects the FQNs of pods referenced by a service's
+// EndpointSlices through their endpoint targetRefs.
+func podsFromEndpointSlices(f Factory, ns, svcName string) (sets.Set[string], error) {
+	sel := labels.Set{discoveryv1.LabelServiceName: svcName}.AsSelector()
+	oo, err := f.List(client.EpsGVR, ns, true, sel)
+	if err != nil {
+		return nil, err
+	}
+
+	pods := sets.New[string]()
+	for _, o := range oo {
+		var eps discoveryv1.EndpointSlice
+		u, ok := o.(*unstructured.Unstructured)
+		if !ok {
+			continue
+		}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &eps); err != nil {
+			return nil, err
+		}
+		pods.Insert(endpointSlicePodFQNs(&eps, ns)...)
+	}
+
+	return pods, nil
+}
+
+// endpointSlicePodFQNs returns the FQNs of pods referenced by an EndpointSlice,
+// defaulting the namespace to the slice's own when a targetRef omits it.
+func endpointSlicePodFQNs(eps *discoveryv1.EndpointSlice, defaultNS string) []string {
+	fqns := make([]string, 0, len(eps.Endpoints))
+	for i := range eps.Endpoints {
+		ref := eps.Endpoints[i].TargetRef
+		if ref == nil || ref.Kind != "Pod" {
+			continue
+		}
+		refNS := ref.Namespace
+		if refNS == "" {
+			refNS = defaultNS
+		}
+		fqns = append(fqns, client.FQN(refNS, ref.Name))
+	}
+
+	return fqns
+}
+
+// podsFromServiceSelector collects the FQNs of pods matching a service's
+// selector, if no pods are resolved by EndpointSlices (eg, no RBAC)
+func podsFromServiceSelector(f Factory, ns, svcName string) (sets.Set[string], error) {
+	var svc Service
+	svc.Init(f, client.SvcGVR)
+	instance, err := svc.GetInstance(client.FQN(ns, svcName))
+	if err != nil {
+		return nil, err
+	}
+
+	pods := sets.New[string]()
+	if len(instance.Spec.Selector) == 0 {
+		return pods, nil
+	}
+
+	oo, err := f.List(client.PodGVR, ns, true, labels.Set(instance.Spec.Selector).AsSelector())
+	if err != nil {
+		return nil, err
+	}
+	for _, o := range oo {
+		u, ok := o.(*unstructured.Unstructured)
+		if !ok {
+			continue
+		}
+		pods.Insert(client.FQN(u.GetNamespace(), u.GetName()))
+	}
+
+	return pods, nil
+}

--- a/internal/dao/eps_test.go
+++ b/internal/dao/eps_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+)
+
+const epsTestNS = "default"
+
+func TestEndpointSlicePodFQNs(t *testing.T) {
+	uu := map[string]struct {
+		eps *discoveryv1.EndpointSlice
+		e   []string
+	}{
+		"pod_refs": {
+			eps: makeEPS(podRef(epsTestNS, "pod-a"), podRef(epsTestNS, "pod-b")),
+			e:   []string{"default/pod-a", "default/pod-b"},
+		},
+		"defaults_namespace": {
+			eps: makeEPS(podRef("", "pod-defaulted")),
+			e:   []string{"default/pod-defaulted"},
+		},
+		"cross_namespace": {
+			eps: makeEPS(podRef("other", "pod-cross")),
+			e:   []string{"other/pod-cross"},
+		},
+		"skips_non_pod_and_nil_refs": {
+			eps: makeEPS(
+				podRef(epsTestNS, "pod-kept"),
+				&v1.ObjectReference{Kind: "Node", Name: "node-a"},
+				nil,
+			),
+			e: []string{"default/pod-kept"},
+		},
+		"no_endpoints": {
+			eps: makeEPS(),
+			e:   []string{},
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, endpointSlicePodFQNs(u.eps, epsTestNS))
+		})
+	}
+}
+
+func podRef(ns, name string) *v1.ObjectReference {
+	return &v1.ObjectReference{Kind: "Pod", Namespace: ns, Name: name}
+}
+
+func makeEPS(refs ...*v1.ObjectReference) *discoveryv1.EndpointSlice {
+	eps := discoveryv1.EndpointSlice{
+		Endpoints: make([]discoveryv1.Endpoint, 0, len(refs)),
+	}
+	for _, ref := range refs {
+		eps.Endpoints = append(eps.Endpoints, discoveryv1.Endpoint{TargetRef: ref})
+	}
+
+	return &eps
+}

--- a/internal/dao/pod.go
+++ b/internal/dao/pod.go
@@ -124,6 +124,13 @@ func (p *Pod) List(ctx context.Context, ns string) ([]runtime.Object, error) {
 	}
 	nodeName := fsel["spec.nodeName"]
 
+	var svcPods sets.Set[string]
+	if svcName, ok := ctx.Value(internal.KeyServiceName).(string); ok && svcName != "" {
+		if svcPods, err = podsForService(p.getFactory(), ns, svcName); err != nil {
+			return nil, err
+		}
+	}
+
 	res := make([]runtime.Object, 0, len(oo))
 	for _, o := range oo {
 		u, ok := o.(*unstructured.Unstructured)
@@ -131,6 +138,9 @@ func (p *Pod) List(ctx context.Context, ns string) ([]runtime.Object, error) {
 			return res, fmt.Errorf("expecting *unstructured.Unstructured but got `%T", o)
 		}
 		fqn := extractFQN(o)
+		if svcPods != nil && !svcPods.Has(fqn) {
+			continue
+		}
 		if nodeName == "" {
 			res = append(res, &render.PodWithMetrics{Raw: u, MX: pmx[fqn]})
 			continue

--- a/internal/dao/svc.go
+++ b/internal/dao/svc.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var (
@@ -28,25 +29,30 @@ type Service struct {
 
 // TailLogs tail logs for all pods represented by this Service.
 func (s *Service) TailLogs(ctx context.Context, opts *LogOptions) ([]LogChan, error) {
-	svc, err := s.GetInstance(opts.Path)
+	ns, n := client.Namespaced(opts.Path)
+	pods, err := podsForService(s.Factory, ns, n)
 	if err != nil {
 		return nil, err
 	}
-	if len(svc.Spec.Selector) == 0 {
-		return nil, fmt.Errorf("no valid selector found on Service %s", opts.Path)
+	if pods.Len() == 0 {
+		return nil, fmt.Errorf("no pods backing Service %s", opts.Path)
 	}
 
-	return podLogs(ctx, svc.Spec.Selector, opts)
+	return tailPodsLogs(ctx, s.Factory, sets.List(pods), opts)
 }
 
 // Pod returns a pod victim by name.
 func (s *Service) Pod(fqn string) (string, error) {
-	svc, err := s.GetInstance(fqn)
+	ns, n := client.Namespaced(fqn)
+	pods, err := podsForService(s.Factory, ns, n)
 	if err != nil {
 		return "", err
 	}
+	if pods.Len() == 0 {
+		return "", fmt.Errorf("no matching pods for Service %s", fqn)
+	}
 
-	return podFromSelector(s.Factory, svc.Namespace, svc.Spec.Selector)
+	return sets.List(pods)[0], nil
 }
 
 // GetInstance returns a service instance.
@@ -63,26 +69,4 @@ func (s *Service) GetInstance(fqn string) (*v1.Service, error) {
 	}
 
 	return &svc, nil
-}
-
-// ----------------------------------------------------------------------------
-// Helpers...
-
-func podFromSelector(f Factory, ns string, sel map[string]string) (string, error) {
-	oo, err := f.List(client.PodGVR, ns, true, labels.Set(sel).AsSelector())
-	if err != nil {
-		return "", err
-	}
-
-	if len(oo) == 0 {
-		return "", fmt.Errorf("no matching pods for %v", sel)
-	}
-
-	var pod v1.Pod
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(oo[0].(*unstructured.Unstructured).Object, &pod)
-	if err != nil {
-		return "", err
-	}
-
-	return client.FQN(pod.Namespace, pod.Name), nil
 }

--- a/internal/keys.go
+++ b/internal/keys.go
@@ -11,6 +11,7 @@ const (
 	KeyFactory       ContextKey = "factory"
 	KeyLabels        ContextKey = "labels"
 	KeyFields        ContextKey = "fields"
+	KeyServiceName   ContextKey = "serviceName"
 	KeyTable         ContextKey = "table"
 	KeyDir           ContextKey = "dir"
 	KeyPath          ContextKey = "path"

--- a/internal/view/helpers.go
+++ b/internal/view/helpers.go
@@ -168,6 +168,26 @@ func podCtx(_ *App, path, fieldSel string) ContextFunc {
 	}
 }
 
+func showPodsForService(app *App, path string) {
+	v := NewPod(client.PodGVR)
+	ns, svcName := client.Namespaced(path)
+	v.SetContextFn(servicePodCtx(path, svcName))
+
+	if err := app.Config.SetActiveNamespace(ns); err != nil {
+		slog.Error("Unable to set active namespace during show pods", slogs.Error, err)
+	}
+	if err := app.inject(v, false); err != nil {
+		app.Flash().Err(err)
+	}
+}
+
+func servicePodCtx(path, svcName string) ContextFunc {
+	return func(ctx context.Context) context.Context {
+		ctx = context.WithValue(ctx, internal.KeyPath, path)
+		return context.WithValue(ctx, internal.KeyServiceName, svcName)
+	}
+}
+
 func extractApp(ctx context.Context) (*App, error) {
 	app, ok := ctx.Value(internal.KeyApp).(*App)
 	if !ok {

--- a/internal/view/svc.go
+++ b/internal/view/svc.go
@@ -68,12 +68,8 @@ func (s *Service) showPods(a *App, _ ui.Tabular, _ *client.GVR, path string) {
 		a.Flash().Warnf("No matching pods. Service %s is an external service.", path)
 		return
 	}
-	if svc.Spec.Selector == nil {
-		a.Flash().Warnf("No matching pods. Service %s does not provide any selectors", path)
-		return
-	}
 
-	showPods(a, path, labels.SelectorFromSet(svc.Spec.Selector), "")
+	showPodsForService(a, path)
 }
 
 func (*Service) checkSvc(svc *v1.Service) error {


### PR DESCRIPTION
Not all applications rely on the apiserver's endpoint and endpointslice controllers to manage service to pod mapping via label selectors. Instead of relying on the labelSelector field on a service, use the corresponding kubernetes.io/service-name label applied to EndpointSlices to identify slices associated with a service, and enumerate targetRefs to identify the pods.  Use this enumeration when switching to the pod view, or launching the log viewer.

Fixes #4082