### PR TITLE
fix: add panic recovery to table refresh and render cycle

### DIFF
--- a/internal/model/table.go
+++ b/internal/model/table.go
@@ -119,7 +119,8 @@ func (t *Table) RemoveListener(l TableListener) {
 
 // Watch initiates model updates.
 func (t *Table) Watch(ctx context.Context) error {
-	if err := t.refresh(ctx); err != nil {
+	err := t.silentRefresh(ctx)
+	if err != nil {
 		return err
 	}
 	go t.updater(ctx)
@@ -129,7 +130,7 @@ func (t *Table) Watch(ctx context.Context) error {
 
 // Refresh updates the table content.
 func (t *Table) Refresh(ctx context.Context) error {
-	return t.refresh(ctx)
+	return t.safeRefresh(ctx)
 }
 
 // Get returns a resource instance if found, else an error.
@@ -201,6 +202,15 @@ func (t *Table) Peek() *model1.TableData {
 }
 
 func (t *Table) updater(ctx context.Context) {
+	defer func() {
+		if e := recover(); e != nil {
+			slog.Error("Reconciler panic recovered",
+				slogs.GVR, t.gvr,
+				slogs.Error, e,
+			)
+			t.fireTableLoadFailed(fmt.Errorf("internal error during refresh"))
+		}
+	}()
 	bf := backoff.NewExponentialBackOff()
 	bf.InitialInterval, bf.MaxElapsedTime = initRefreshRate, maxReaderRetryInterval
 	rate := initRefreshRate
@@ -210,7 +220,16 @@ func (t *Table) updater(ctx context.Context) {
 			return
 		case <-time.After(rate):
 			rate = t.refreshRate
-			err := backoff.Retry(func() error {
+			err := backoff.Retry(func() (perr error) {
+				defer func() {
+					if e := recover(); e != nil {
+						slog.Error("Refresh panic recovered",
+							slogs.GVR, t.gvr,
+							slogs.Error, e,
+						)
+						perr = fmt.Errorf("refresh panic: %v", e)
+					}
+				}()
 				if err := t.refresh(ctx); err != nil {
 					slog.Error("Refresh failed", slogs.GVR, t.gvr)
 					return err
@@ -244,6 +263,44 @@ func (t *Table) refresh(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (t *Table) safeRefresh(ctx context.Context) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			slog.Error("Refresh panic recovered",
+				slogs.GVR, t.gvr,
+				slogs.Error, e,
+			)
+			err = fmt.Errorf("refresh panic: %v", e)
+		}
+	}()
+
+	return t.refresh(ctx)
+}
+
+// silentRefresh loads data via reconcile without firing UI events.
+// This is used by Watch to avoid deadlocking the event loop when
+// QueueUpdateDraw is called from within the event handler.
+// The updater goroutine handles firing events on its first tick.
+func (t *Table) silentRefresh(ctx context.Context) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			slog.Error("Silent refresh panic recovered",
+				slogs.GVR, t.gvr,
+				slogs.Error, e,
+			)
+			err = fmt.Errorf("refresh panic: %v", e)
+		}
+	}()
+
+	if !atomic.CompareAndSwapInt32(&t.inUpdate, 0, 1) {
+		slog.Debug("Dropping update...")
+		return nil
+	}
+	defer atomic.StoreInt32(&t.inUpdate, 0)
+
+	return t.reconcile(ctx)
 }
 
 func (t *Table) list(ctx context.Context, a dao.Accessor) ([]runtime.Object, error) {
@@ -283,6 +340,9 @@ func (t *Table) reconcile(ctx context.Context) error {
 	}
 	if err != nil {
 		return err
+	}
+	if len(oo) == 0 || oo[0] == nil {
+		return fmt.Errorf("no data found for resource %s", t.gvr)
 	}
 	r := meta.Renderer
 	r.SetViewSetting(t.vs)

--- a/internal/model1/helpers.go
+++ b/internal/model1/helpers.go
@@ -43,6 +43,13 @@ func parallelRender(n int, fn func(i int) error) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer func() {
+				if e := recover(); e != nil {
+					errOnce.Do(func() {
+						firstErr = fmt.Errorf("render panic: %v", e)
+					})
+				}
+			}()
 			for i := lo; i < hi; i++ {
 				if err := fn(i); err != nil {
 					errOnce.Do(func() { firstErr = err })

--- a/internal/model1/table_data.go
+++ b/internal/model1/table_data.go
@@ -257,6 +257,9 @@ func (t *TableData) Render(_ context.Context, r Renderer, oo []runtime.Object) e
 			if !ok {
 				return fmt.Errorf("expecting a meta table but got %T", oo[0])
 			}
+			if table == nil {
+				return fmt.Errorf("received nil table for resource %s", t.gvr)
+			}
 			rows = make(Rows, len(table.Rows))
 			if err := GenericHydrate(t.namespace, table, rows, r); err != nil {
 				return err


### PR DESCRIPTION
## Summary

Prevents hard k9s crashes caused by unrecovered panics in the table refresh/render cycle. Currently, a panic in any renderer's `Render` method crashes the entire process because:

1. **`parallelRender` worker goroutines** have no `recover()` — a single panicking row kills k9s
2. **`updater` goroutine** has no `recover()` — panics during background refresh crash k9s
3. **`QueueUpdateDraw` deadlock** — when `Watch` fires UI events during synchronous event-loop navigation (e.g., pressing Enter to drill into a resource), the blocking `QueueUpdateDraw` deadlocks the event loop

## Changes

### `internal/model1/helpers.go`
- Add `defer recover()` to `parallelRender` worker goroutines, converting panics to errors

### `internal/model/table.go`
- `Watch()` now uses `silentRefresh()` — loads data without firing UI events, preventing the event-loop deadlock. The `updater` goroutine fires events on its first tick (~300ms) from a separate goroutine
- `updater()` goroutine gets outer `defer recover()` as last-resort safety net
- `backoff.Retry` callback gets inner `defer recover()` — catches panics per-refresh for graceful retry
- `safeRefresh()` / `silentRefresh()` wrappers convert panics to errors
- `reconcile()` nil check for `Get()` returning nil object

### `internal/model1/table_data.go`
- Nil guard in `Render()` for typed-nil `*metav1.Table` that passes type assertion but panics on `.Rows`

## Test Plan

- [x] `go vet ./...` passes clean
- [x] `go test ./...` all pass
- [x] Manual testing: navigating resources, YAML view, describe — no regressions

## Notes

This is a prerequisite for #PR_NUMBER (Gateway API dashboard) which exercises these code paths with custom renderers.