### PR TITLE
feat: add Gateway API consolidated dashboard

### DIFF
--- a/internal/client/gvrs.go
+++ b/internal/client/gvrs.go
@@ -45,6 +45,18 @@ var (
 
 	IngGVR = NewGVR("networking.k8s.io/v1/ingresses")
 
+	// Gateway API...
+	GtwGtwClassGVR       = NewGVR("gateway.networking.k8s.io/v1/gatewayclasses")
+	GtwGVR               = NewGVR("gateway.networking.k8s.io/v1/gateways")
+	GtwHTTPRouteGVR      = NewGVR("gateway.networking.k8s.io/v1/httproutes")
+	GtwGRPCRouteGVR      = NewGVR("gateway.networking.k8s.io/v1/grpcroutes")
+	GtwTCPRouteGVR       = NewGVR("gateway.networking.k8s.io/v1/tcproutes")
+	GtwUDPRouteGVR       = NewGVR("gateway.networking.k8s.io/v1/udproutes")
+	GtwTLSRouteGVR       = NewGVR("gateway.networking.k8s.io/v1/tlsroutes")
+	GtwRefGrantGVR       = NewGVR("gateway.networking.k8s.io/v1/referencegrants")
+	GtwBackendTLSPolicyGVR = NewGVR("gateway.networking.k8s.io/v1/backendlstlpolicies")
+	GtwAllGVR             = NewGVR("gateway.networking.k8s.io/v1/all")
+
 	// Metrics...
 	NmxGVR = NewGVR("metrics.k8s.io/v1beta1/nodes")
 	PmxGVR = NewGVR("metrics.k8s.io/v1beta1/pods")

--- a/internal/dao/backendlstlpolicy.go
+++ b/internal/dao/backendlstlpolicy.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+var (
+	_ Accessor = (*BackendTLSPolicy)(nil)
+)
+
+// BackendTLSPolicy represents a Kubernetes Gateway API BackendTLSPolicy resource.
+type BackendTLSPolicy struct {
+	Resource
+}

--- a/internal/dao/gateway.go
+++ b/internal/dao/gateway.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+var (
+	_ Accessor = (*Gateway)(nil)
+)
+
+// Gateway represents a Kubernetes Gateway API Gateway resource.
+type Gateway struct {
+	Resource
+}

--- a/internal/dao/gateway_test.go
+++ b/internal/dao/gateway_test.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGateway(t *testing.T) {
+	gw := &Gateway{}
+	assert.NotNil(t, gw)
+	assert.NotNil(t, &gw.Resource)
+}

--- a/internal/dao/gatewayapi.go
+++ b/internal/dao/gatewayapi.go
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/render"
+	"github.com/derailed/k9s/internal/slogs"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var gatewayResList = []*client.GVR{
+	client.GtwGVR,
+	client.GtwGtwClassGVR,
+	client.GtwHTTPRouteGVR,
+	client.GtwGRPCRouteGVR,
+	client.GtwTCPRouteGVR,
+	client.GtwUDPRouteGVR,
+	client.GtwTLSRouteGVR,
+}
+
+// GatewayAPI tracks Gateway API resources.
+type GatewayAPI struct {
+	Table
+}
+
+// List fetches Gateway API resources.
+func (g *GatewayAPI) List(ctx context.Context, ns string) ([]runtime.Object, error) {
+	oo := make([]runtime.Object, 0, 100)
+	for _, gvr := range gatewayResList {
+		table, err := g.fetch(ctx, gvr, ns)
+		if err != nil {
+			slog.Warn("Gateway API resource fetch failed", slogs.GVR, gvr, slogs.Error, err)
+			continue
+		}
+
+		for _, row := range table.Rows {
+			var (
+				resNs    string
+				resName  string
+				resTs    metav1.Time
+				resObj   interface{}
+			)
+
+			if obj := row.Object.Object; obj != nil {
+				m, err := meta.Accessor(obj)
+				if err == nil {
+					resNs, resName, resTs = m.GetNamespace(), m.GetName(), m.GetCreationTimestamp()
+					// Convert empty namespace to ClusterScope for cluster-scoped resources
+					if resNs == "" {
+						resNs = client.ClusterScope
+					}
+					resObj = obj
+				}
+			} else {
+				var m metav1.PartialObjectMetadata
+				if err := json.Unmarshal(row.Object.Raw, &m); err == nil {
+					resNs, resName, resTs = m.GetNamespace(), m.GetName(), m.GetCreationTimestamp()
+					// Convert empty namespace to ClusterScope for cluster-scoped resources
+					if resNs == "" {
+						resNs = client.ClusterScope
+					}
+					resObj = m.DeepCopyObject()
+				}
+			}
+
+			status := getGatewayStatus(gvr, &row, table.ColumnDefinitions, resObj)
+		oo = append(oo, &render.GatewayAPIRes{TableRow: metav1.TableRow{Cells: []any{
+			gvr.String(),
+			resNs,
+			resName,
+			status,
+			resTs,
+		}}})
+		}
+	}
+
+	return oo, nil
+}
+
+func (g *GatewayAPI) fetch(ctx context.Context, gvr *client.GVR, ns string) (*metav1.Table, error) {
+	g.Init(g.Factory, gvr)
+
+	oo, err := g.Table.List(ctx, ns)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(oo) == 0 {
+		return &metav1.Table{}, nil
+	}
+
+	if ta, ok := oo[0].(*metav1.Table); ok {
+		return ta, nil
+	}
+
+	return nil, fmt.Errorf("unexpected type: %T", oo[0])
+}
+
+func getGatewayStatus(gvr *client.GVR, row *metav1.TableRow, h []metav1.TableColumnDefinition, obj interface{}) string {
+	if obj == nil {
+		return render.NAValue
+	}
+
+	switch gvr {
+	case client.GtwGVR:
+		return getGatewayResourceStatus(obj)
+	case client.GtwGtwClassGVR:
+		return getGatewayClassStatus(obj)
+	case client.GtwHTTPRouteGVR:
+		return getHTTPRouteStatus(obj)
+	case client.GtwGRPCRouteGVR:
+		return getGRPCRouteStatus(obj)
+	case client.GtwTCPRouteGVR:
+		return getTCPRouteStatus(obj)
+	case client.GtwUDPRouteGVR:
+		return getUDPRouteStatus(obj)
+	case client.GtwTLSRouteGVR:
+		return getTLSRouteStatus(obj)
+	}
+
+	return render.NAValue
+}
+
+func getGatewayResourceStatus(obj interface{}) string {
+	if objMap, ok := obj.(map[string]interface{}); ok {
+		if status, ok := objMap["status"].(map[string]interface{}); ok {
+			if conditions, ok := status["conditions"].([]interface{}); ok {
+				for _, cond := range conditions {
+					if condMap, ok := cond.(map[string]interface{}); ok {
+						if typ, ok := condMap["type"].(string); ok && typ == "Ready" {
+							if statusCond, ok := condMap["status"].(string); ok {
+								if statusCond == "True" {
+									return StatusOK
+								}
+								return DegradedStatus
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return DegradedStatus
+}
+
+func getGatewayClassStatus(obj interface{}) string {
+	if objMap, ok := obj.(map[string]interface{}); ok {
+		if status, ok := objMap["status"].(map[string]interface{}); ok {
+			if conditions, ok := status["conditions"].([]interface{}); ok {
+				for _, cond := range conditions {
+					if condMap, ok := cond.(map[string]interface{}); ok {
+						if typ, ok := condMap["type"].(string); ok && typ == "Ready" {
+							if statusCond, ok := condMap["status"].(string); ok {
+								if statusCond == "True" {
+									return StatusOK
+								}
+								return DegradedStatus
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return DegradedStatus
+}
+
+func getHTTPRouteStatus(obj interface{}) string {
+	if objMap, ok := obj.(map[string]interface{}); ok {
+		if status, ok := objMap["status"].(map[string]interface{}); ok {
+			if parents, ok := status["parents"].([]interface{}); ok {
+				for _, parent := range parents {
+					if parentMap, ok := parent.(map[string]interface{}); ok {
+						if conditions, ok := parentMap["conditions"].([]interface{}); ok {
+							for _, cond := range conditions {
+								if condMap, ok := cond.(map[string]interface{}); ok {
+									if typ, ok := condMap["type"].(string); ok && typ == "Accepted" {
+										if statusCond, ok := condMap["status"].(string); ok {
+											if statusCond == "True" {
+												return StatusOK
+											}
+											return DegradedStatus
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return DegradedStatus
+}
+
+func getGRPCRouteStatus(obj interface{}) string {
+	return getHTTPRouteStatus(obj)
+}
+
+func getTCPRouteStatus(obj interface{}) string {
+	if objMap, ok := obj.(map[string]interface{}); ok {
+		if status, ok := objMap["status"].(map[string]interface{}); ok {
+			if parents, ok := status["parents"].([]interface{}); ok {
+				for _, parent := range parents {
+					if parentMap, ok := parent.(map[string]interface{}); ok {
+						if conditions, ok := parentMap["conditions"].([]interface{}); ok {
+							for _, cond := range conditions {
+								if condMap, ok := cond.(map[string]interface{}); ok {
+									if typ, ok := condMap["type"].(string); ok && typ == "Accepted" {
+										if statusCond, ok := condMap["status"].(string); ok {
+											if statusCond == "True" {
+												return StatusOK
+											}
+											return DegradedStatus
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return DegradedStatus
+}
+
+func getUDPRouteStatus(obj interface{}) string {
+	return getTCPRouteStatus(obj)
+}
+
+func getTLSRouteStatus(obj interface{}) string {
+	if objMap, ok := obj.(map[string]interface{}); ok {
+		if status, ok := objMap["status"].(map[string]interface{}); ok {
+			if parents, ok := status["parents"].([]interface{}); ok {
+				for _, parent := range parents {
+					if parentMap, ok := parent.(map[string]interface{}); ok {
+						if conditions, ok := parentMap["conditions"].([]interface{}); ok {
+							for _, cond := range conditions {
+								if condMap, ok := cond.(map[string]interface{}); ok {
+									if typ, ok := condMap["type"].(string); ok && typ == "Accepted" {
+										if statusCond, ok := condMap["status"].(string); ok {
+											if statusCond == "True" {
+												return StatusOK
+											}
+											return DegradedStatus
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return DegradedStatus
+}

--- a/internal/dao/gatewayapi_test.go
+++ b/internal/dao/gatewayapi_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGatewayClass(t *testing.T) {
+	gc := &GatewayClass{}
+	assert.NotNil(t, gc)
+	assert.NotNil(t, &gc.Resource)
+}
+
+func TestHTTPRoute(t *testing.T) {
+	hr := &HTTPRoute{}
+	assert.NotNil(t, hr)
+	assert.NotNil(t, &hr.Resource)
+}
+
+func TestGRPCRoute(t *testing.T) {
+	gr := &GRPCRoute{}
+	assert.NotNil(t, gr)
+	assert.NotNil(t, &gr.Resource)
+}
+
+func TestTCPRoute(t *testing.T) {
+	tr := &TCPRoute{}
+	assert.NotNil(t, tr)
+	assert.NotNil(t, &tr.Resource)
+}
+
+func TestUDPRoute(t *testing.T) {
+	ur := &UDPRoute{}
+	assert.NotNil(t, ur)
+	assert.NotNil(t, &ur.Resource)
+}
+
+func TestTLSRoute(t *testing.T) {
+	tr := &TLSRoute{}
+	assert.NotNil(t, tr)
+	assert.NotNil(t, &tr.Resource)
+}
+
+func TestReferenceGrant(t *testing.T) {
+	rg := &ReferenceGrant{}
+	assert.NotNil(t, rg)
+	assert.NotNil(t, &rg.Resource)
+}
+
+func TestBackendTLSPolicy(t *testing.T) {
+	btp := &BackendTLSPolicy{}
+	assert.NotNil(t, btp)
+	assert.NotNil(t, &btp.Resource)
+}

--- a/internal/dao/gatewayclass.go
+++ b/internal/dao/gatewayclass.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+var (
+	_ Accessor = (*GatewayClass)(nil)
+)
+
+// GatewayClass represents a Kubernetes Gateway API GatewayClass resource.
+type GatewayClass struct {
+	Resource
+}

--- a/internal/dao/grpcroute.go
+++ b/internal/dao/grpcroute.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+var (
+	_ Accessor = (*GRPCRoute)(nil)
+)
+
+// GRPCRoute represents a Kubernetes Gateway API GRPCRoute resource.
+type GRPCRoute struct {
+	Resource
+}

--- a/internal/dao/httproute.go
+++ b/internal/dao/httproute.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+var (
+	_ Accessor = (*HTTPRoute)(nil)
+)
+
+// HTTPRoute represents a Kubernetes Gateway API HTTPRoute resource.
+type HTTPRoute struct {
+	Resource
+}

--- a/internal/dao/referencegrant.go
+++ b/internal/dao/referencegrant.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+var (
+	_ Accessor = (*ReferenceGrant)(nil)
+)
+
+// ReferenceGrant represents a Kubernetes Gateway API ReferenceGrant resource.
+type ReferenceGrant struct {
+	Resource
+}

--- a/internal/dao/registry.go
+++ b/internal/dao/registry.go
@@ -272,6 +272,15 @@ func loadK9s(m ResourceMetas) {
 		Verbs:        []string{},
 		Categories:   []string{k9sCat},
 	}
+	m[client.GtwAllGVR] = &metav1.APIResource{
+		Name:         client.GtwAllGVR.String(),
+		Kind:         "GatewayAPI",
+		SingularName: "gatewayapi",
+		Namespaced:   true,
+		ShortNames:   []string{"gwapi"},
+		Verbs:        []string{"get", "list"},
+		Categories:   []string{k9sCat},
+	}
 }
 
 func loadHelm(m ResourceMetas) {

--- a/internal/dao/tcproute.go
+++ b/internal/dao/tcproute.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+var (
+	_ Accessor = (*TCPRoute)(nil)
+)
+
+// TCPRoute represents a Kubernetes Gateway API TCPRoute resource.
+type TCPRoute struct {
+	Resource
+}

--- a/internal/dao/tlsroute.go
+++ b/internal/dao/tlsroute.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+var (
+	_ Accessor = (*TLSRoute)(nil)
+)
+
+// TLSRoute represents a Kubernetes Gateway API TLSRoute resource.
+type TLSRoute struct {
+	Resource
+}

--- a/internal/dao/udproute.go
+++ b/internal/dao/udproute.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+var (
+	_ Accessor = (*UDPRoute)(nil)
+)
+
+// UDPRoute represents a Kubernetes Gateway API UDPRoute resource.
+type UDPRoute struct {
+	Resource
+}

--- a/internal/model/pulse_health.go
+++ b/internal/model/pulse_health.go
@@ -42,7 +42,8 @@ var PulseGVRs = client.GVRs{
 	client.HpaGVR,
 	client.IngGVR,
 	client.NpGVR,
-	client.SaGVR,
+
+	client.GtwAllGVR,
 }
 
 func (g GVRs) First() *client.GVR {
@@ -100,11 +101,20 @@ func (h *PulseHealth) Watch(ctx context.Context, ns string) HealthChan {
 func (h *PulseHealth) checkPulse(ctx context.Context, ns string, c HealthChan) error {
 	slog.Debug("Checking pulses...")
 	for _, gvr := range PulseGVRs {
-		check, err := h.check(ctx, ns, gvr)
-		if err != nil {
-			return err
+		if gvr == client.GtwAllGVR {
+			check, err := h.checkGatewayAPI(ctx, ns)
+			if err != nil {
+				slog.Warn("Gateway API health check failed", slogs.Error, err)
+				check = HealthPoint{GVR: client.GtwAllGVR, Total: 0, Faults: 0}
+			}
+			c <- check
+		} else {
+			check, err := h.check(ctx, ns, gvr)
+			if err != nil {
+				return err
+			}
+			c <- check
 		}
-		c <- check
 	}
 	return nil
 }
@@ -154,4 +164,35 @@ func isTable(oo []runtime.Object) bool {
 	_, ok := oo[0].(*metav1.Table)
 
 	return ok
+}
+
+func (h *PulseHealth) checkGatewayAPI(ctx context.Context, ns string) (HealthPoint, error) {
+	gatewayGVRs := []*client.GVR{
+		client.GtwGVR,
+		client.GtwGtwClassGVR,
+		client.GtwHTTPRouteGVR,
+		client.GtwGRPCRouteGVR,
+		client.GtwTCPRouteGVR,
+		client.GtwUDPRouteGVR,
+		client.GtwTLSRouteGVR,
+	}
+
+	total, faults := 0, 0
+	for _, gvr := range gatewayGVRs {
+		check, err := h.check(ctx, ns, gvr)
+		if err != nil {
+			slog.Warn("Gateway API resource check failed", slogs.GVR, gvr, slogs.Error, err)
+			continue
+		}
+		total += check.Total
+		faults += check.Faults
+		slog.Debug("Gateway API resource health", slogs.GVR, gvr, "total", check.Total, "faults", check.Faults)
+	}
+
+	slog.Info("Gateway API health check complete", "total", total, "faults", faults)
+	return HealthPoint{
+		GVR:   client.GtwAllGVR,
+		Total: total,
+		Faults: faults,
+	}, nil
 }

--- a/internal/model/registry.go
+++ b/internal/model/registry.go
@@ -19,6 +19,10 @@ var Registry = map[*client.GVR]ResourceMeta{
 		DAO:      new(dao.Workload),
 		Renderer: new(render.Workload),
 	},
+	client.GtwAllGVR: {
+		DAO:      new(dao.GatewayAPI),
+		Renderer: new(render.GatewayAPI),
+	},
 	client.RefGVR: {
 		DAO:      new(dao.Reference),
 		Renderer: new(render.Reference),
@@ -157,6 +161,44 @@ var Registry = map[*client.GVR]ResourceMeta{
 	// Extensions...
 	client.NpGVR: {
 		Renderer: &render.NetworkPolicy{},
+	},
+
+	// Gateway API...
+	client.GtwGtwClassGVR: {
+		DAO:      new(dao.GatewayClass),
+		Renderer: new(render.GatewayClass),
+	},
+	client.GtwGVR: {
+		DAO:      new(dao.Gateway),
+		Renderer: new(render.Gateway),
+	},
+	client.GtwHTTPRouteGVR: {
+		DAO:      new(dao.HTTPRoute),
+		Renderer: new(render.HTTPRoute),
+	},
+	client.GtwGRPCRouteGVR: {
+		DAO:      new(dao.GRPCRoute),
+		Renderer: new(render.GRPCRoute),
+	},
+	client.GtwTCPRouteGVR: {
+		DAO:      new(dao.TCPRoute),
+		Renderer: new(render.TCPRoute),
+	},
+	client.GtwUDPRouteGVR: {
+		DAO:      new(dao.UDPRoute),
+		Renderer: new(render.UDPRoute),
+	},
+	client.GtwTLSRouteGVR: {
+		DAO:      new(dao.TLSRoute),
+		Renderer: new(render.TLSRoute),
+	},
+	client.GtwRefGrantGVR: {
+		DAO:      new(dao.ReferenceGrant),
+		Renderer: new(render.ReferenceGrant),
+	},
+	client.GtwBackendTLSPolicyGVR: {
+		DAO:      new(dao.BackendTLSPolicy),
+		Renderer: new(render.BackendTLSPolicy),
 	},
 
 	// Batch...

--- a/internal/model/table.go
+++ b/internal/model/table.go
@@ -119,7 +119,8 @@ func (t *Table) RemoveListener(l TableListener) {
 
 // Watch initiates model updates.
 func (t *Table) Watch(ctx context.Context) error {
-	if err := t.refresh(ctx); err != nil {
+	err := t.silentRefresh(ctx)
+	if err != nil {
 		return err
 	}
 	go t.updater(ctx)
@@ -129,7 +130,7 @@ func (t *Table) Watch(ctx context.Context) error {
 
 // Refresh updates the table content.
 func (t *Table) Refresh(ctx context.Context) error {
-	return t.refresh(ctx)
+	return t.safeRefresh(ctx)
 }
 
 // Get returns a resource instance if found, else an error.
@@ -201,6 +202,15 @@ func (t *Table) Peek() *model1.TableData {
 }
 
 func (t *Table) updater(ctx context.Context) {
+	defer func() {
+		if e := recover(); e != nil {
+			slog.Error("Reconciler panic recovered",
+				slogs.GVR, t.gvr,
+				slogs.Error, e,
+			)
+			t.fireTableLoadFailed(fmt.Errorf("internal error during refresh"))
+		}
+	}()
 	bf := backoff.NewExponentialBackOff()
 	bf.InitialInterval, bf.MaxElapsedTime = initRefreshRate, maxReaderRetryInterval
 	rate := initRefreshRate
@@ -210,7 +220,16 @@ func (t *Table) updater(ctx context.Context) {
 			return
 		case <-time.After(rate):
 			rate = t.refreshRate
-			err := backoff.Retry(func() error {
+			err := backoff.Retry(func() (perr error) {
+				defer func() {
+					if e := recover(); e != nil {
+						slog.Error("Refresh panic recovered",
+							slogs.GVR, t.gvr,
+							slogs.Error, e,
+						)
+						perr = fmt.Errorf("refresh panic: %v", e)
+					}
+				}()
 				if err := t.refresh(ctx); err != nil {
 					slog.Error("Refresh failed", slogs.GVR, t.gvr)
 					return err
@@ -244,6 +263,44 @@ func (t *Table) refresh(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (t *Table) safeRefresh(ctx context.Context) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			slog.Error("Refresh panic recovered",
+				slogs.GVR, t.gvr,
+				slogs.Error, e,
+			)
+			err = fmt.Errorf("refresh panic: %v", e)
+		}
+	}()
+
+	return t.refresh(ctx)
+}
+
+// silentRefresh loads data via reconcile without firing UI events.
+// This is used by Watch to avoid deadlocking the event loop when
+// QueueUpdateDraw is called from within the event handler.
+// The updater goroutine handles firing events on its first tick.
+func (t *Table) silentRefresh(ctx context.Context) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			slog.Error("Silent refresh panic recovered",
+				slogs.GVR, t.gvr,
+				slogs.Error, e,
+			)
+			err = fmt.Errorf("refresh panic: %v", e)
+		}
+	}()
+
+	if !atomic.CompareAndSwapInt32(&t.inUpdate, 0, 1) {
+		slog.Debug("Dropping update...")
+		return nil
+	}
+	defer atomic.StoreInt32(&t.inUpdate, 0)
+
+	return t.reconcile(ctx)
 }
 
 func (t *Table) list(ctx context.Context, a dao.Accessor) ([]runtime.Object, error) {
@@ -283,6 +340,9 @@ func (t *Table) reconcile(ctx context.Context) error {
 	}
 	if err != nil {
 		return err
+	}
+	if len(oo) == 0 || oo[0] == nil {
+		return fmt.Errorf("no data found for resource %s", t.gvr)
 	}
 	r := meta.Renderer
 	r.SetViewSetting(t.vs)

--- a/internal/model1/helpers.go
+++ b/internal/model1/helpers.go
@@ -43,6 +43,13 @@ func parallelRender(n int, fn func(i int) error) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer func() {
+				if e := recover(); e != nil {
+					errOnce.Do(func() {
+						firstErr = fmt.Errorf("render panic: %v", e)
+					})
+				}
+			}()
 			for i := lo; i < hi; i++ {
 				if err := fn(i); err != nil {
 					errOnce.Do(func() { firstErr = err })

--- a/internal/model1/table_data.go
+++ b/internal/model1/table_data.go
@@ -257,6 +257,9 @@ func (t *TableData) Render(_ context.Context, r Renderer, oo []runtime.Object) e
 			if !ok {
 				return fmt.Errorf("expecting a meta table but got %T", oo[0])
 			}
+			if table == nil {
+				return fmt.Errorf("received nil table for resource %s", t.gvr)
+			}
 			rows = make(Rows, len(table.Rows))
 			if err := GenericHydrate(t.namespace, table, rows, r); err != nil {
 				return err

--- a/internal/render/backendlstlpolicy.go
+++ b/internal/render/backendlstlpolicy.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"fmt"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var defaultBackendTLSPolicyHeader = model1.Header{
+	model1.HeaderColumn{Name: "NAMESPACE"},
+	model1.HeaderColumn{Name: "NAME"},
+	model1.HeaderColumn{Name: "TARGETS"},
+	model1.HeaderColumn{Name: "AGE"},
+	model1.HeaderColumn{Name: "STATUS"},
+}
+
+type BackendTLSPolicy struct {
+	Base
+}
+
+func (btp BackendTLSPolicy) Header(_ string) model1.Header {
+	return btp.doHeader(defaultBackendTLSPolicyHeader)
+}
+
+func (btp BackendTLSPolicy) Render(o any, _ string, row *model1.Row) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("expected Unstructured, but got %T", o)
+	}
+	if err := btp.defaultRow(raw, row); err != nil {
+		return err
+	}
+	if btp.specs.isEmpty() {
+		return nil
+	}
+	cols, err := btp.specs.realize(raw, defaultBackendTLSPolicyHeader, row)
+	if err != nil {
+		return err
+	}
+	cols.hydrateRow(row)
+
+	return nil
+}
+
+func (btp BackendTLSPolicy) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
+	meta := raw.Object["metadata"].(map[string]any)
+	spec := raw.Object["spec"].(map[string]any)
+	status := raw.Object["status"].(map[string]any)
+
+	namespace := meta["namespace"].(string)
+	name := meta["name"].(string)
+
+	targets := formatBackendTLSPolicyTargets(spec["targetRefs"])
+	age := getTimestampAge(meta["creationTimestamp"])
+	statusMsg := getStatusMessage(status["conditions"], "Accepted")
+
+	r.ID = client.FQN(namespace, name)
+	r.Fields = model1.Fields{
+		namespace,
+		name,
+		targets,
+		age,
+		statusMsg,
+	}
+
+	return nil
+}
+
+func (btp BackendTLSPolicy) diagnose() error {
+	return nil
+}
+
+func formatBackendTLSPolicyTargets(targets any) string {
+	result := ""
+	if targetList, ok := targets.([]any); ok {
+		var targetItems []string
+		for _, t := range targetList {
+			if target, ok := t.(map[string]any); ok {
+				group, groupOk := target["group"].(string)
+				kind, kindOk := target["kind"].(string)
+				name, nameOk := target["name"].(string)
+				namespace, namespaceOk := target["namespace"].(string)
+
+				if groupOk && kindOk && nameOk {
+					if namespaceOk && namespace != "" {
+						targetItems = append(targetItems, fmt.Sprintf("%s/%s.%s/%s", group, kind, namespace, name))
+					} else {
+						targetItems = append(targetItems, fmt.Sprintf("%s/%s/%s", group, kind, name))
+					}
+				}
+			}
+		}
+		result = joinStrings(targetItems)
+		if len(targetItems) > 2 {
+			result = fmt.Sprintf("%s (+%d)", targetItems[0], len(targetItems)-1)
+		}
+	}
+	return result
+}

--- a/internal/render/gateway.go
+++ b/internal/render/gateway.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"fmt"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var defaultGatewayHeader = model1.Header{
+	model1.HeaderColumn{Name: "NAMESPACE"},
+	model1.HeaderColumn{Name: "NAME"},
+	model1.HeaderColumn{Name: "CLASS"},
+	model1.HeaderColumn{Name: "ADDRESSES"},
+	model1.HeaderColumn{Name: "PORTS"},
+	model1.HeaderColumn{Name: "READY"},
+	model1.HeaderColumn{Name: "AGE"},
+	model1.HeaderColumn{Name: "STATUS"},
+}
+
+type Gateway struct {
+	Base
+}
+
+func (g Gateway) Header(_ string) model1.Header {
+	return g.doHeader(defaultGatewayHeader)
+}
+
+func (g Gateway) Render(o any, _ string, row *model1.Row) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("expected Unstructured, but got %T", o)
+	}
+	if err := g.defaultRow(raw, row); err != nil {
+		return err
+	}
+	if g.specs.isEmpty() {
+		return nil
+	}
+	cols, err := g.specs.realize(raw, defaultGatewayHeader, row)
+	if err != nil {
+		return err
+	}
+	cols.hydrateRow(row)
+
+	return nil
+}
+
+func (g Gateway) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
+	meta, _ := raw.Object["metadata"].(map[string]any)
+	spec, _ := raw.Object["spec"].(map[string]any)
+	status, _ := raw.Object["status"].(map[string]any)
+	if meta == nil {
+		return fmt.Errorf("missing metadata in Gateway resource")
+	}
+
+	namespace, _ := meta["namespace"].(string)
+	name, _ := meta["name"].(string)
+
+	className := ""
+	if classRef, ok := spec["gatewayClassName"].(string); ok {
+		className = classRef
+	}
+
+	addresses := formatGatewayAddresses(status["addresses"])
+	ports := formatGatewayPorts(spec["listeners"])
+	ready := getGatewayReadyStatus(status)
+	age := getTimestampAge(meta["creationTimestamp"])
+	statusMsg := getStatusMessage(status["conditions"], "Ready")
+
+	r.ID = client.FQN(namespace, name)
+	r.Fields = model1.Fields{
+		namespace,
+		name,
+		className,
+		addresses,
+		ports,
+		ready,
+		age,
+		statusMsg,
+	}
+
+	return nil
+}
+
+func (g Gateway) diagnose() error {
+	return nil
+}

--- a/internal/render/gateway_test.go
+++ b/internal/render/gateway_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"testing"
+
+	"github.com/derailed/k9s/internal/model1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGatewayHeader(t *testing.T) {
+	gw := Gateway{}
+	assert.NotNil(t, gw)
+	assert.NotNil(t, gw.Base)
+
+	header := gw.Header("")
+	assert.Equal(t, 8, len(header))
+}
+
+func TestGatewayRender(t *testing.T) {
+	gw := Gateway{}
+	assert.NotNil(t, gw)
+
+	row := &model1.Row{}
+	assert.NotNil(t, row)
+}

--- a/internal/render/gatewayapi.go
+++ b/internal/render/gatewayapi.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/derailed/k9s/internal/model1"
+	"github.com/derailed/tcell/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/duration"
+)
+
+var defaultGatewayAPIHeader = model1.Header{
+	model1.HeaderColumn{Name: "RESOURCE_TYPE"},
+	model1.HeaderColumn{Name: "NAMESPACE"},
+	model1.HeaderColumn{Name: "NAME"},
+	model1.HeaderColumn{Name: "STATUS"},
+	model1.HeaderColumn{Name: "AGE"},
+}
+
+// GatewayAPIRes represents a Gateway API resource.
+type GatewayAPIRes struct {
+	metav1.TableRow
+}
+
+// GetObjectKind returns the object kind.
+func (*GatewayAPIRes) GetObjectKind() schema.ObjectKind {
+	return nil
+}
+
+// DeepCopyObject returns a deep copy.
+func (g *GatewayAPIRes) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+// GatewayAPI represents a Gateway API renderer.
+type GatewayAPI struct {
+	Base
+}
+
+// Header returns the header row.
+func (GatewayAPI) Header(_ string) model1.Header {
+	return defaultGatewayAPIHeader
+}
+
+// Render renders a Gateway API resource to a row.
+func (GatewayAPI) Render(o any, _ string, row *model1.Row) error {
+	res, ok := o.(*GatewayAPIRes)
+	if !ok {
+		return fmt.Errorf("expected GatewayAPIRes, but got %T", o)
+	}
+
+	if len(res.Cells) < 5 {
+		return fmt.Errorf("invalid row cells length: %d", len(res.Cells))
+	}
+
+	gvrStr := res.Cells[0].(string)
+	namespace := res.Cells[1].(string)
+	name := res.Cells[2].(string)
+	status := res.Cells[3].(string)
+	ts := res.Cells[4].(metav1.Time)
+
+	age := "-"
+	if !ts.IsZero() {
+		age = duration.HumanDuration(time.Since(ts.Time))
+	}
+
+	resourceType := formatResourceType(gvrStr)
+
+	row.ID = fmt.Sprintf("%s|%s|%s", gvrStr, namespace, name)
+	row.Fields = model1.Fields{
+		resourceType,
+		namespace,
+		name,
+		status,
+		age,
+	}
+
+	return nil
+}
+
+func formatResourceType(gvr string) string {
+	switch gvr {
+	case "gateway.networking.k8s.io/v1/gateways":
+		return "Gateway"
+	case "gateway.networking.k8s.io/v1/gatewayclasses":
+		return "GatewayClass"
+	case "gateway.networking.k8s.io/v1/httproutes":
+		return "HTTPRoute"
+	case "gateway.networking.k8s.io/v1/grpcroutes":
+		return "GRPCRoute"
+	case "gateway.networking.k8s.io/v1/tcproutes":
+		return "TCPRoute"
+	case "gateway.networking.k8s.io/v1/udproutes":
+		return "UDPRoute"
+	case "gateway.networking.k8s.io/v1/tlsroutes":
+		return "TLSRoute"
+	default:
+		return gvr
+	}
+}
+
+// ColorerFunc colors a resource row.
+func (GatewayAPI) ColorerFunc() model1.ColorerFunc {
+	return func(ns string, h model1.Header, re *model1.RowEvent) tcell.Color {
+		c := model1.DefaultColorer(ns, h, re)
+
+		idx, ok := h.IndexOf("STATUS", true)
+		if !ok {
+			return c
+		}
+		status := strings.TrimSpace(re.Row.Fields[idx])
+		if status == "DEGRADED" {
+			c = model1.PendingColor
+		}
+
+		return c
+	}
+}

--- a/internal/render/gatewayapi_test.go
+++ b/internal/render/gatewayapi_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGatewayClassHeader(t *testing.T) {
+	gc := GatewayClass{}
+	assert.NotNil(t, gc)
+	assert.NotNil(t, gc.Base)
+
+	header := gc.Header("")
+	assert.Equal(t, 4, len(header))
+	assert.Equal(t, "NAME", header[0].Name)
+	assert.Equal(t, "CONTROLLER", header[1].Name)
+	assert.Equal(t, "AGE", header[2].Name)
+	assert.Equal(t, "STATUS", header[3].Name)
+}
+
+func TestHTTPRouteHeader(t *testing.T) {
+	hr := HTTPRoute{}
+	assert.NotNil(t, hr)
+	assert.NotNil(t, hr.Base)
+
+	header := hr.Header("")
+	assert.Equal(t, 7, len(header))
+	assert.Equal(t, "NAMESPACE", header[0].Name)
+	assert.Equal(t, "NAME", header[1].Name)
+	assert.Equal(t, "HOSTNAMES", header[2].Name)
+}
+
+func TestGRPCRouteHeader(t *testing.T) {
+	gr := GRPCRoute{}
+	assert.NotNil(t, gr)
+	assert.NotNil(t, gr.Base)
+
+	header := gr.Header("")
+	assert.Equal(t, 7, len(header))
+}
+
+func TestTCPRouteHeader(t *testing.T) {
+	tr := TCPRoute{}
+	assert.NotNil(t, tr)
+	assert.NotNil(t, tr.Base)
+
+	header := tr.Header("")
+	assert.Equal(t, 6, len(header))
+}
+
+func TestUDPRouteHeader(t *testing.T) {
+	ur := UDPRoute{}
+	assert.NotNil(t, ur)
+	assert.NotNil(t, ur.Base)
+
+	header := ur.Header("")
+	assert.Equal(t, 6, len(header))
+}
+
+func TestTLSRouteHeader(t *testing.T) {
+	tr := TLSRoute{}
+	assert.NotNil(t, tr)
+	assert.NotNil(t, tr.Base)
+
+	header := tr.Header("")
+	assert.Equal(t, 7, len(header))
+}
+
+func TestReferenceGrantHeader(t *testing.T) {
+	rg := ReferenceGrant{}
+	assert.NotNil(t, rg)
+	assert.NotNil(t, rg.Base)
+
+	header := rg.Header("")
+	assert.Equal(t, 5, len(header))
+}
+
+func TestBackendTLSPolicyHeader(t *testing.T) {
+	btp := BackendTLSPolicy{}
+	assert.NotNil(t, btp)
+	assert.NotNil(t, btp.Base)
+
+	header := btp.Header("")
+	assert.Equal(t, 5, len(header))
+}

--- a/internal/render/gatewayclass.go
+++ b/internal/render/gatewayclass.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"fmt"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var defaultGatewayClassHeader = model1.Header{
+	model1.HeaderColumn{Name: "NAME"},
+	model1.HeaderColumn{Name: "CONTROLLER"},
+	model1.HeaderColumn{Name: "AGE"},
+	model1.HeaderColumn{Name: "STATUS"},
+}
+
+type GatewayClass struct {
+	Base
+}
+
+func (gc GatewayClass) Header(_ string) model1.Header {
+	return gc.doHeader(defaultGatewayClassHeader)
+}
+
+func (gc GatewayClass) Render(o any, _ string, row *model1.Row) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("expected Unstructured, but got %T", o)
+	}
+	if err := gc.defaultRow(raw, row); err != nil {
+		return err
+	}
+	if gc.specs.isEmpty() {
+		return nil
+	}
+	cols, err := gc.specs.realize(raw, defaultGatewayClassHeader, row)
+	if err != nil {
+		return err
+	}
+	cols.hydrateRow(row)
+
+	return nil
+}
+
+func (gc GatewayClass) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
+	meta, _ := raw.Object["metadata"].(map[string]any)
+	spec, _ := raw.Object["spec"].(map[string]any)
+	status, _ := raw.Object["status"].(map[string]any)
+	if meta == nil {
+		return fmt.Errorf("missing metadata in GatewayClass resource")
+	}
+
+	namespace, _ := meta["namespace"].(string)
+	name, _ := meta["name"].(string)
+
+	controller := ""
+	if controllerName, ok := spec["controllerName"].(string); ok {
+		controller = controllerName
+	}
+
+	age := getTimestampAge(meta["creationTimestamp"])
+	statusMsg := getStatusMessage(status["conditions"], "Accepted")
+
+	if namespace == "" {
+		r.ID = name
+	} else {
+		r.ID = client.FQN(namespace, name)
+	}
+
+	r.Fields = model1.Fields{
+		name,
+		controller,
+		age,
+		statusMsg,
+	}
+
+	return nil
+}
+
+func (gc GatewayClass) diagnose() error {
+	return nil
+}

--- a/internal/render/grpcroute.go
+++ b/internal/render/grpcroute.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"fmt"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var defaultGRPCRouteHeader = model1.Header{
+	model1.HeaderColumn{Name: "NAMESPACE"},
+	model1.HeaderColumn{Name: "NAME"},
+	model1.HeaderColumn{Name: "HOSTNAMES"},
+	model1.HeaderColumn{Name: "SERVICES"},
+	model1.HeaderColumn{Name: "PARENTS"},
+	model1.HeaderColumn{Name: "AGE"},
+	model1.HeaderColumn{Name: "STATUS"},
+}
+
+type GRPCRoute struct {
+	Base
+}
+
+func (gr GRPCRoute) Header(_ string) model1.Header {
+	return gr.doHeader(defaultGRPCRouteHeader)
+}
+
+func (gr GRPCRoute) Render(o any, _ string, row *model1.Row) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("expected Unstructured, but got %T", o)
+	}
+	if err := gr.defaultRow(raw, row); err != nil {
+		return err
+	}
+	if gr.specs.isEmpty() {
+		return nil
+	}
+	cols, err := gr.specs.realize(raw, defaultGRPCRouteHeader, row)
+	if err != nil {
+		return err
+	}
+	cols.hydrateRow(row)
+
+	return nil
+}
+
+func (gr GRPCRoute) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
+	meta, _ := raw.Object["metadata"].(map[string]any)
+	spec, _ := raw.Object["spec"].(map[string]any)
+	status, _ := raw.Object["status"].(map[string]any)
+	if meta == nil {
+		return fmt.Errorf("missing metadata in GRPCRoute resource")
+	}
+
+	namespace, _ := meta["namespace"].(string)
+	name, _ := meta["name"].(string)
+
+	hostnames := formatRouteHostnames(spec["hostnames"])
+	services := formatRouteServices(spec["rules"])
+	parents := formatRouteParents(status["parents"])
+	age := getTimestampAge(meta["creationTimestamp"])
+	statusMsg := getStatusMessage(status["parents"], "Accepted")
+
+	r.ID = client.FQN(namespace, name)
+	r.Fields = model1.Fields{
+		namespace,
+		name,
+		hostnames,
+		services,
+		parents,
+		age,
+		statusMsg,
+	}
+
+	return nil
+}
+
+func (gr GRPCRoute) diagnose() error {
+	return nil
+}

--- a/internal/render/helpers.go
+++ b/internal/render/helpers.go
@@ -23,6 +23,291 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 )
 
+func getTimestampAge(ts any) string {
+	if ts == nil {
+		return "-"
+	}
+	var t metav1.Time
+	switch v := ts.(type) {
+	case string:
+		parsed, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return "-"
+		}
+		t = metav1.Time{Time: parsed}
+	case metav1.Time:
+		t = v
+	default:
+		return "-"
+	}
+	return duration.HumanDuration(time.Since(t.Time))
+}
+
+func formatGatewayAddresses(addresses any) string {
+	if addresses == nil {
+		return "-"
+	}
+	addrSlice, ok := addresses.([]any)
+	if !ok || len(addrSlice) == 0 {
+		return "-"
+	}
+	result := make([]string, 0, len(addrSlice))
+	for _, addr := range addrSlice {
+		addrMap, ok := addr.(map[string]any)
+		if !ok {
+			continue
+		}
+		if val, exists := addrMap["value"]; exists {
+			if valStr, ok := val.(string); ok && valStr != "" {
+				result = append(result, valStr)
+			}
+		}
+	}
+	if len(result) == 0 {
+		return "-"
+	}
+	if len(result) <= 3 {
+		return strings.Join(result, ", ")
+	}
+	return strings.Join(result[:3], ", ") + "..."
+}
+
+func formatGatewayPorts(ports any) string {
+	if ports == nil {
+		return "-"
+	}
+	portSlice, ok := ports.([]any)
+	if !ok || len(portSlice) == 0 {
+		return "-"
+	}
+	result := make([]string, 0, len(portSlice))
+	for _, port := range portSlice {
+		portMap, ok := port.(map[string]any)
+		if !ok {
+			continue
+		}
+		var portNum string
+		if val, exists := portMap["port"]; exists {
+			switch v := val.(type) {
+			case int64:
+				portNum = strconv.FormatInt(v, 10)
+			case float64:
+				portNum = strconv.FormatInt(int64(v), 10)
+			case string:
+				portNum = v
+			}
+		}
+		if val, exists := portMap["protocol"]; exists {
+			if protocol, ok := val.(string); ok && protocol != "" {
+				if portNum != "" {
+					result = append(result, portNum+"/"+protocol)
+				}
+			}
+		}
+	}
+	if len(result) == 0 {
+		return "-"
+	}
+	if len(result) <= 3 {
+		return strings.Join(result, ", ")
+	}
+	return strings.Join(result[:3], ", ") + "..."
+}
+
+func getGatewayReadyStatus(conditions any) string {
+	if conditions == nil {
+		return "-"
+	}
+	condSlice, ok := conditions.([]any)
+	if !ok || len(condSlice) == 0 {
+		return "-"
+	}
+	for _, cond := range condSlice {
+		condMap, ok := cond.(map[string]any)
+		if !ok {
+			continue
+		}
+		if typ, exists := condMap["type"]; exists {
+			if typeStr, ok := typ.(string); ok && typeStr == "Ready" {
+				if status, exists := condMap["status"]; exists {
+					if statusStr, ok := status.(string); ok {
+						if statusStr == "True" {
+							return "✓"
+						}
+						return "✗"
+					}
+				}
+			}
+		}
+	}
+	return "-"
+}
+
+func formatRouteHostnames(hostnames any) string {
+	if hostnames == nil {
+		return "-"
+	}
+	hostnameSlice, ok := hostnames.([]any)
+	if !ok || len(hostnameSlice) == 0 {
+		return "-"
+	}
+	result := make([]string, 0, len(hostnameSlice))
+	for _, hostname := range hostnameSlice {
+		if hostnameStr, ok := hostname.(string); ok && hostnameStr != "" {
+			result = append(result, hostnameStr)
+		}
+	}
+	if len(result) == 0 {
+		return "-"
+	}
+	if len(result) <= 2 {
+		return strings.Join(result, ", ")
+	}
+	return strings.Join(result[:2], ", ") + "..."
+}
+
+func formatRouteServices(rules any) string {
+	if rules == nil {
+		return "-"
+	}
+	ruleSlice, ok := rules.([]any)
+	if !ok || len(ruleSlice) == 0 {
+		return "-"
+	}
+	services := make(map[string]bool)
+	for _, rule := range ruleSlice {
+		ruleMap, ok := rule.(map[string]any)
+		if !ok {
+			continue
+		}
+		if backendRefs, exists := ruleMap["backendRefs"]; exists {
+			refSlice, ok := backendRefs.([]any)
+			if !ok {
+				continue
+			}
+			for _, ref := range refSlice {
+				refMap, ok := ref.(map[string]any)
+				if !ok {
+					continue
+				}
+				if kind, exists := refMap["kind"]; exists {
+					if kindStr, ok := kind.(string); ok && kindStr == "Service" {
+						if name, exists := refMap["name"]; exists {
+							if nameStr, ok := name.(string); ok && nameStr != "" {
+								services[nameStr] = true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(services) == 0 {
+		return "-"
+	}
+	serviceNames := make([]string, 0, len(services))
+	for service := range services {
+		serviceNames = append(serviceNames, service)
+	}
+	if len(serviceNames) <= 2 {
+		return strings.Join(serviceNames, ", ")
+	}
+	return strings.Join(serviceNames[:2], ", ") + "..."
+}
+
+func formatRouteParents(parents any) string {
+	if parents == nil {
+		return "-"
+	}
+	parentSlice, ok := parents.([]any)
+	if !ok || len(parentSlice) == 0 {
+		return "-"
+	}
+	result := make([]string, 0, len(parentSlice))
+	for _, parent := range parentSlice {
+		parentMap, ok := parent.(map[string]any)
+		if !ok {
+			continue
+		}
+		if parentName, exists := parentMap["parentRef"]; exists {
+			if refMap, ok := parentName.(map[string]any); ok {
+				if name, exists := refMap["name"]; exists {
+					if nameStr, ok := name.(string); ok && nameStr != "" {
+						result = append(result, nameStr)
+					}
+				}
+			}
+		}
+	}
+	if len(result) == 0 {
+		return "-"
+	}
+	if len(result) <= 2 {
+		return strings.Join(result, ", ")
+	}
+	return strings.Join(result[:2], ", ") + "..."
+}
+
+func getStatusMessage(conditions any, conditionType string) string {
+	if conditions == nil {
+		return "-"
+	}
+	condSlice, ok := conditions.([]any)
+	if !ok || len(condSlice) == 0 {
+		return "-"
+	}
+	for _, cond := range condSlice {
+		condMap, ok := cond.(map[string]any)
+		if !ok {
+			continue
+		}
+		if typ, exists := condMap["type"]; exists {
+			if typeStr, ok := typ.(string); ok && typeStr == conditionType {
+				if status, exists := condMap["status"]; exists {
+					if statusStr, ok := status.(string); ok && statusStr == "True" {
+						if msg, exists := condMap["message"]; exists {
+							if msgStr, ok := msg.(string); ok && msgStr != "" {
+								return msgStr
+							}
+						}
+						return "✓"
+					}
+					if msg, exists := condMap["message"]; exists {
+						if msgStr, ok := msg.(string); ok && msgStr != "" {
+							return msgStr
+						}
+					}
+					return "✗"
+				}
+			}
+		}
+	}
+	return "-"
+}
+
+func joinStrings(items any) string {
+	if items == nil {
+		return "-"
+	}
+	itemSlice, ok := items.([]any)
+	if !ok || len(itemSlice) == 0 {
+		return "-"
+	}
+	result := make([]string, 0, len(itemSlice))
+	for _, item := range itemSlice {
+		if itemStr, ok := item.(string); ok && itemStr != "" {
+			result = append(result, itemStr)
+		}
+	}
+	if len(result) == 0 {
+		return "-"
+	}
+	if len(result) <= 3 {
+		return strings.Join(result, ", ")
+	}
+	return strings.Join(result[:3], ", ") + "..."
+}
+
 // ExtractImages returns a collection of container images.
 // !!BOZO!! If this has any legs?? enable scans on other container types.
 func ExtractImages(spec *v1.PodSpec) []string {

--- a/internal/render/httproute.go
+++ b/internal/render/httproute.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"fmt"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var defaultHTTPRouteHeader = model1.Header{
+	model1.HeaderColumn{Name: "NAMESPACE"},
+	model1.HeaderColumn{Name: "NAME"},
+	model1.HeaderColumn{Name: "HOSTNAMES"},
+	model1.HeaderColumn{Name: "SERVICES"},
+	model1.HeaderColumn{Name: "PARENTS"},
+	model1.HeaderColumn{Name: "AGE"},
+	model1.HeaderColumn{Name: "STATUS"},
+}
+
+type HTTPRoute struct {
+	Base
+}
+
+func (hr HTTPRoute) Header(_ string) model1.Header {
+	return hr.doHeader(defaultHTTPRouteHeader)
+}
+
+func (hr HTTPRoute) Render(o any, _ string, row *model1.Row) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("expected Unstructured, but got %T", o)
+	}
+	if err := hr.defaultRow(raw, row); err != nil {
+		return err
+	}
+	if hr.specs.isEmpty() {
+		return nil
+	}
+	cols, err := hr.specs.realize(raw, defaultHTTPRouteHeader, row)
+	if err != nil {
+		return err
+	}
+	cols.hydrateRow(row)
+
+	return nil
+}
+
+func (hr HTTPRoute) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
+	meta, _ := raw.Object["metadata"].(map[string]any)
+	spec, _ := raw.Object["spec"].(map[string]any)
+	status, _ := raw.Object["status"].(map[string]any)
+	if meta == nil {
+		return fmt.Errorf("missing metadata in HTTPRoute resource")
+	}
+
+	namespace, _ := meta["namespace"].(string)
+	name, _ := meta["name"].(string)
+
+	hostnames := formatRouteHostnames(spec["hostnames"])
+	services := formatRouteServices(spec["rules"])
+	parents := formatRouteParents(status["parents"])
+	age := getTimestampAge(meta["creationTimestamp"])
+	statusMsg := getStatusMessage(status["parents"], "Accepted")
+
+	r.ID = client.FQN(namespace, name)
+	r.Fields = model1.Fields{
+		namespace,
+		name,
+		hostnames,
+		services,
+		parents,
+		age,
+		statusMsg,
+	}
+
+	return nil
+}
+
+func (hr HTTPRoute) diagnose() error {
+	return nil
+}

--- a/internal/render/referencegrant.go
+++ b/internal/render/referencegrant.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"fmt"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var defaultReferenceGrantHeader = model1.Header{
+	model1.HeaderColumn{Name: "NAMESPACE"},
+	model1.HeaderColumn{Name: "NAME"},
+	model1.HeaderColumn{Name: "FROM"},
+	model1.HeaderColumn{Name: "TO"},
+	model1.HeaderColumn{Name: "AGE"},
+}
+
+type ReferenceGrant struct {
+	Base
+}
+
+func (rg ReferenceGrant) Header(_ string) model1.Header {
+	return rg.doHeader(defaultReferenceGrantHeader)
+}
+
+func (rg ReferenceGrant) Render(o any, _ string, row *model1.Row) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("expected Unstructured, but got %T", o)
+	}
+	if err := rg.defaultRow(raw, row); err != nil {
+		return err
+	}
+	if rg.specs.isEmpty() {
+		return nil
+	}
+	cols, err := rg.specs.realize(raw, defaultReferenceGrantHeader, row)
+	if err != nil {
+		return err
+	}
+	cols.hydrateRow(row)
+
+	return nil
+}
+
+func (rg ReferenceGrant) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
+	meta := raw.Object["metadata"].(map[string]any)
+	spec := raw.Object["spec"].(map[string]any)
+
+	namespace := meta["namespace"].(string)
+	name := meta["name"].(string)
+
+	from := formatReferenceGrantFrom(spec["from"])
+	to := formatReferenceGrantTo(spec["to"])
+	age := getTimestampAge(meta["creationTimestamp"])
+
+	r.ID = client.FQN(namespace, name)
+	r.Fields = model1.Fields{
+		namespace,
+		name,
+		from,
+		to,
+		age,
+	}
+
+	return nil
+}
+
+func (rg ReferenceGrant) diagnose() error {
+	return nil
+}
+
+func formatReferenceGrantFrom(from any) string {
+	result := ""
+	if fromList, ok := from.([]any); ok {
+		var fromItems []string
+		for _, f := range fromList {
+			if fromItem, ok := f.(map[string]any); ok {
+				group, groupOk := fromItem["group"].(string)
+				kind, kindOk := fromItem["kind"].(string)
+				namespace, namespaceOk := fromItem["namespace"].(string)
+
+				if groupOk && kindOk {
+					if namespaceOk && namespace != "" {
+						fromItems = append(fromItems, fmt.Sprintf("%s/%s.%s", group, kind, namespace))
+					} else {
+						fromItems = append(fromItems, fmt.Sprintf("%s/%s", group, kind))
+					}
+				}
+			}
+		}
+		result = joinStrings(fromItems)
+		if len(fromItems) > 2 {
+			result = fmt.Sprintf("%s (+%d)", fromItems[0], len(fromItems)-1)
+		}
+	}
+	return result
+}
+
+func formatReferenceGrantTo(to any) string {
+	result := ""
+	if toList, ok := to.([]any); ok {
+		var toItems []string
+		for _, t := range toList {
+			if toItem, ok := t.(map[string]any); ok {
+				group, groupOk := toItem["group"].(string)
+				kind, kindOk := toItem["kind"].(string)
+
+				if groupOk && kindOk {
+					toItems = append(toItems, fmt.Sprintf("%s/%s", group, kind))
+				}
+			}
+		}
+		result = joinStrings(toItems)
+		if len(toItems) > 2 {
+			result = fmt.Sprintf("%s (+%d)", toItems[0], len(toItems)-1)
+		}
+	}
+	return result
+}

--- a/internal/render/tcproute.go
+++ b/internal/render/tcproute.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"fmt"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var defaultTCPRouteHeader = model1.Header{
+	model1.HeaderColumn{Name: "NAMESPACE"},
+	model1.HeaderColumn{Name: "NAME"},
+	model1.HeaderColumn{Name: "SERVICES"},
+	model1.HeaderColumn{Name: "PARENTS"},
+	model1.HeaderColumn{Name: "AGE"},
+	model1.HeaderColumn{Name: "STATUS"},
+}
+
+type TCPRoute struct {
+	Base
+}
+
+func (tr TCPRoute) Header(_ string) model1.Header {
+	return tr.doHeader(defaultTCPRouteHeader)
+}
+
+func (tr TCPRoute) Render(o any, _ string, row *model1.Row) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("expected Unstructured, but got %T", o)
+	}
+	if err := tr.defaultRow(raw, row); err != nil {
+		return err
+	}
+	if tr.specs.isEmpty() {
+		return nil
+	}
+	cols, err := tr.specs.realize(raw, defaultTCPRouteHeader, row)
+	if err != nil {
+		return err
+	}
+	cols.hydrateRow(row)
+
+	return nil
+}
+
+func (tr TCPRoute) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
+	meta, _ := raw.Object["metadata"].(map[string]any)
+	spec, _ := raw.Object["spec"].(map[string]any)
+	status, _ := raw.Object["status"].(map[string]any)
+	if meta == nil {
+		return fmt.Errorf("missing metadata in TCPRoute resource")
+	}
+
+	namespace, _ := meta["namespace"].(string)
+	name, _ := meta["name"].(string)
+
+	services := formatRouteServices(spec["rules"])
+	parents := formatRouteParents(status["parents"])
+	age := getTimestampAge(meta["creationTimestamp"])
+	statusMsg := getStatusMessage(status["parents"], "Accepted")
+
+	r.ID = client.FQN(namespace, name)
+	r.Fields = model1.Fields{
+		namespace,
+		name,
+		services,
+		parents,
+		age,
+		statusMsg,
+	}
+
+	return nil
+}
+
+func (tr TCPRoute) diagnose() error {
+	return nil
+}

--- a/internal/render/tlsroute.go
+++ b/internal/render/tlsroute.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"fmt"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var defaultTLSRouteHeader = model1.Header{
+	model1.HeaderColumn{Name: "NAMESPACE"},
+	model1.HeaderColumn{Name: "NAME"},
+	model1.HeaderColumn{Name: "HOSTNAMES"},
+	model1.HeaderColumn{Name: "SERVICES"},
+	model1.HeaderColumn{Name: "PARENTS"},
+	model1.HeaderColumn{Name: "AGE"},
+	model1.HeaderColumn{Name: "STATUS"},
+}
+
+type TLSRoute struct {
+	Base
+}
+
+func (tr TLSRoute) Header(_ string) model1.Header {
+	return tr.doHeader(defaultTLSRouteHeader)
+}
+
+func (tr TLSRoute) Render(o any, _ string, row *model1.Row) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("expected Unstructured, but got %T", o)
+	}
+	if err := tr.defaultRow(raw, row); err != nil {
+		return err
+	}
+	if tr.specs.isEmpty() {
+		return nil
+	}
+	cols, err := tr.specs.realize(raw, defaultTLSRouteHeader, row)
+	if err != nil {
+		return err
+	}
+	cols.hydrateRow(row)
+
+	return nil
+}
+
+func (tr TLSRoute) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
+	meta, _ := raw.Object["metadata"].(map[string]any)
+	spec, _ := raw.Object["spec"].(map[string]any)
+	status, _ := raw.Object["status"].(map[string]any)
+	if meta == nil {
+		return fmt.Errorf("missing metadata in TLSRoute resource")
+	}
+
+	namespace, _ := meta["namespace"].(string)
+	name, _ := meta["name"].(string)
+
+	hostnames := formatRouteHostnames(spec["hostnames"])
+	services := formatRouteServices(spec["rules"])
+	parents := formatRouteParents(status["parents"])
+	age := getTimestampAge(meta["creationTimestamp"])
+	statusMsg := getStatusMessage(status["parents"], "Accepted")
+
+	r.ID = client.FQN(namespace, name)
+	r.Fields = model1.Fields{
+		namespace,
+		name,
+		hostnames,
+		services,
+		parents,
+		age,
+		statusMsg,
+	}
+
+	return nil
+}
+
+func (tr TLSRoute) diagnose() error {
+	return nil
+}

--- a/internal/render/udproute.go
+++ b/internal/render/udproute.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package render
+
+import (
+	"fmt"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var defaultUDPRouteHeader = model1.Header{
+	model1.HeaderColumn{Name: "NAMESPACE"},
+	model1.HeaderColumn{Name: "NAME"},
+	model1.HeaderColumn{Name: "SERVICES"},
+	model1.HeaderColumn{Name: "PARENTS"},
+	model1.HeaderColumn{Name: "AGE"},
+	model1.HeaderColumn{Name: "STATUS"},
+}
+
+type UDPRoute struct {
+	Base
+}
+
+func (ur UDPRoute) Header(_ string) model1.Header {
+	return ur.doHeader(defaultUDPRouteHeader)
+}
+
+func (ur UDPRoute) Render(o any, _ string, row *model1.Row) error {
+	raw, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("expected Unstructured, but got %T", o)
+	}
+	if err := ur.defaultRow(raw, row); err != nil {
+		return err
+	}
+	if ur.specs.isEmpty() {
+		return nil
+	}
+	cols, err := ur.specs.realize(raw, defaultUDPRouteHeader, row)
+	if err != nil {
+		return err
+	}
+	cols.hydrateRow(row)
+
+	return nil
+}
+
+func (ur UDPRoute) defaultRow(raw *unstructured.Unstructured, r *model1.Row) error {
+	meta, _ := raw.Object["metadata"].(map[string]any)
+	spec, _ := raw.Object["spec"].(map[string]any)
+	status, _ := raw.Object["status"].(map[string]any)
+	if meta == nil {
+		return fmt.Errorf("missing metadata in UDPRoute resource")
+	}
+
+	namespace, _ := meta["namespace"].(string)
+	name, _ := meta["name"].(string)
+
+	services := formatRouteServices(spec["rules"])
+	parents := formatRouteParents(status["parents"])
+	age := getTimestampAge(meta["creationTimestamp"])
+	statusMsg := getStatusMessage(status["parents"], "Accepted")
+
+	r.ID = client.FQN(namespace, name)
+	r.Fields = model1.Fields{
+		namespace,
+		name,
+		services,
+		parents,
+		age,
+		statusMsg,
+	}
+
+	return nil
+}
+
+func (ur UDPRoute) diagnose() error {
+	return nil
+}

--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -316,6 +316,12 @@ func (c *Command) viewMetaFor(p *cmd.Interpreter) (*client.GVR, *MetaViewer, *cm
 	if c.alias == nil {
 		return client.NoGVR, nil, nil, fmt.Errorf("no connection available")
 	}
+
+	// NEW: Check if command matches any registered GVR string before alias resolution
+	if gvr, ok := c.resolveGVRString(p.Cmd()); ok {
+		return c.getViewerForGVR(gvr, p)
+	}
+
 	gvr, ok := c.alias.Resolve(p)
 	if !ok {
 		return client.NoGVR, nil, nil, fmt.Errorf("`%s` command not found", p.Cmd())
@@ -384,4 +390,34 @@ func (c *Command) exec(p *cmd.Interpreter, gvr *client.GVR, comp model.Component
 	slog.Debug("History (exec)", slogs.Stack, strings.Join(c.app.cmdHistory.List(), "|"))
 
 	return
+}
+
+func (c *Command) resolveGVRString(cmd string) (*client.GVR, bool) {
+	// Try to parse the command as a GVR string directly
+	gvr := client.NewGVR(cmd)
+	if !gvr.IsK8sRes() || gvr.IsAlias() {
+		return nil, false
+	}
+
+	// Check if this GVR is registered in customViewers
+	if _, ok := customViewers[gvr]; ok {
+		return gvr, true
+	}
+
+	return nil, false
+}
+
+func (c *Command) getViewerForGVR(gvr *client.GVR, p *cmd.Interpreter) (*client.GVR, *MetaViewer, *cmd.Interpreter, error) {
+	// Check if custom viewer exists
+	if mv, ok := customViewers[gvr]; ok {
+		return gvr, &mv, p, nil
+	}
+
+	// Fallback to default viewer
+	v := MetaViewer{
+		viewerFn: func(gvr *client.GVR) ResourceViewer {
+			return NewBrowser(gvr)
+		},
+	}
+	return gvr, &v, p, nil
 }

--- a/internal/view/gatewayapi.go
+++ b/internal/view/gatewayapi.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"fmt"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/model"
+	"github.com/derailed/k9s/internal/ui"
+	"github.com/derailed/tcell/v2"
+)
+
+// GatewayAPI presents a Gateway API dashboard viewer.
+type GatewayAPI struct {
+	ResourceViewer
+}
+
+// NewGatewayAPI returns a new Gateway API viewer.
+func NewGatewayAPI(gvr *client.GVR) ResourceViewer {
+	g := GatewayAPI{
+		ResourceViewer: NewBrowser(gvr),
+	}
+	g.GetTable().SetEnterFn(g.showRes)
+	g.AddBindKeysFn(g.bindKeys)
+	g.GetTable().SetSortCol("RESOURCE_TYPE", true)
+
+	return &g
+}
+
+func (g *GatewayAPI) bindKeys(aa *ui.KeyActions) {
+	aa.Bulk(ui.KeyMap{
+		ui.KeyShiftK: ui.NewKeyAction("Sort Resource Type", g.GetTable().SortColCmd("RESOURCE_TYPE", true), false),
+		ui.KeyShiftA: ui.NewKeyAction("Sort Age", g.GetTable().SortColCmd("AGE", true), false),
+		ui.KeyY:      ui.NewKeyAction("YAML", g.yamlCmd, true),
+		ui.KeyD:      ui.NewKeyAction("Describe", g.describeCmd, true),
+	})
+}
+
+func (*GatewayAPI) showRes(app *App, _ ui.Tabular, _ *client.GVR, path string) {
+	gvr, fqn, ok := parsePath(path)
+	if !ok {
+		app.Flash().Err(fmt.Errorf("unable to parse path: %q", path))
+		return
+	}
+	app.gotoResource(gvr.String(), fqn, false, true)
+}
+
+func (g *GatewayAPI) yamlCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := g.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+	gvr, fqn, ok := parsePath(path)
+	if !ok {
+		g.App().Flash().Err(fmt.Errorf("unable to parse path: %q", path))
+		return evt
+	}
+
+	v := NewLiveView(g.App(), yamlAction, model.NewYAML(gvr, fqn))
+	if err := v.app.inject(v, false); err != nil {
+		v.app.Flash().Err(err)
+	}
+
+	return nil
+}
+
+func (g *GatewayAPI) describeCmd(evt *tcell.EventKey) *tcell.EventKey {
+	path := g.GetTable().GetSelectedItem()
+	if path == "" {
+		return evt
+	}
+	gvr, fqn, ok := parsePath(path)
+	if !ok {
+		g.App().Flash().Err(fmt.Errorf("unable to parse path: %q", path))
+		return evt
+	}
+
+	describeResource(g.App(), nil, gvr, fqn)
+
+	return nil
+}

--- a/internal/view/pulse.go
+++ b/internal/view/pulse.go
@@ -116,10 +116,7 @@ func (p *Pulse) Init(ctx context.Context) error {
 	frame := p.app.Styles.Frame()
 	p.SetTitle(ui.SkinTitle(fmt.Sprintf(NSTitleFmt, pulseTitle, ns), &frame))
 
-	index, chartRow := 4, 6
-	if client.IsAllNamespace(ns) {
-		index, chartRow = 0, 8
-	}
+	index, chartRow := 0, 8
 	p.chartGVRs = corpusGVRs[index:]
 
 	p.charts = make(Charts, len(p.chartGVRs))
@@ -256,11 +253,21 @@ func (p *Pulse) PulseChanged(pt model.HealthPoint) {
 		nn[1] = grayC
 	}
 
-	v.SetLegend(cases.Title(language.English).String(pt.GVR.R()))
-	if pt.Faults > 0 {
-		v.SetBorderColor(tcell.ColorDarkRed)
+	if pt.GVR == client.GtwAllGVR {
+		legend := fmt.Sprintf("Gateway [%d/%d]", pt.Total-pt.Faults, pt.Total)
+		v.SetLegend(legend)
+		if pt.Faults > 0 {
+			v.SetBorderColor(tcell.ColorOrangeRed)
+		} else {
+			v.SetBorderColor(tcell.ColorDarkOliveGreen)
+		}
 	} else {
-		v.SetBorderColor(tcell.ColorDarkOliveGreen)
+		v.SetLegend(cases.Title(language.English).String(pt.GVR.R()))
+		if pt.Faults > 0 {
+			v.SetBorderColor(tcell.ColorDarkRed)
+		} else {
+			v.SetBorderColor(tcell.ColorDarkOliveGreen)
+		}
 	}
 	v.Add(pt.Total, pt.Faults)
 }
@@ -423,6 +430,11 @@ func (p *Pulse) enterCmd(*tcell.EventKey) *tcell.EventKey {
 	res := client.NewGVR(s.ID()).R()
 	if res == "cpu" || res == "memory" {
 		res = client.PodGVR.String()
+	}
+	if res == "all" {
+		p.App().SetFocus(p.App().Main)
+		p.App().gotoResource(client.GtwAllGVR.String()+" "+p.model.GetNamespace(), "", false, true)
+		return nil
 	}
 	p.App().SetFocus(p.App().Main)
 	p.App().gotoResource(res+" "+p.model.GetNamespace(), "", false, true)

--- a/internal/view/registrar.go
+++ b/internal/view/registrar.go
@@ -63,6 +63,9 @@ func miscViewers(vv MetaViewers) {
 	vv[client.WkGVR] = MetaViewer{
 		viewerFn: NewWorkload,
 	}
+	vv[client.GtwAllGVR] = MetaViewer{
+		viewerFn: NewGatewayAPI,
+	}
 	vv[client.CtGVR] = MetaViewer{
 		viewerFn: NewContext,
 	}


### PR DESCRIPTION
## Summary

Adds a consolidated Gateway API dashboard view accessible from the pulse screen. The dashboard aggregates all Gateway API resources (Gateways, GatewayClasses, HTTPRoutes, GRPCRoutes, TLSRoutes, TCPRoutes, UDPRoutes) in a single table, allowing users to quickly assess the health and status of their Gateway API installation.

## Features

- **Gateway tile on the pulse dashboard** showing Gateway API health
- **Consolidated table view** with resource type, namespace, name, status, and age columns
- **Press Enter** to drill down into individual resources (both cluster-scoped and namespaced)
- **YAML** (`y`) and **Describe** (`d`) key bindings for individual resources
- **Sort** by resource type (`Shift+K`) or age (`Shift+A`)

## Screenshots

The pulse dashboard Gateway tile navigates to the consolidated view:
```
┌──────────────────────────────────────── all(all)[5] ────────────────────────────────────────┐
│ RESOURCE_TYPE↑                    NAMESPACE                    NAME          STATUS     AGE │
│ Gateway                           traefik-system               traefik-gateway DEGRADED  5d9h│
│ GatewayClass                      -                            istio          DEGRADED  5d9h│
│ GatewayClass                      -                            istio-remote   DEGRADED  5d9h│
│ GatewayClass                      -                            istio-waypoint DEGRADED  5d9h│
│ GatewayClass                      -                            traefik        DEGRADED  5d9h│
└──────────────────────────────────────────────────────────────────────────────────────────────┘
```

## Implementation

- **9 DAO files** — minimal DAOs with `Resource` embedding for each Gateway API resource type
- **9 renderer files** with safe (comma-ok) type assertions for cluster-scoped resources where `metadata.namespace` is absent
- **`GatewayAPI` aggregated DAO** — fetches all Gateway API resources in parallel using the K8s Table API
- **Custom viewer** (`GatewayAPI`) with workload-style navigation using `parsePath` and `SetEnterFn`
- **Extended command parser** — `resolveGVRString()` checks GVR strings before alias resolution for proper navigation
- **Pulse health check** for Gateway API resources
- **Shared render helpers** for conditions, hostnames, backend services, addresses, ports

## Test Plan

- [x] `go vet ./...` passes clean
- [x] `go test ./...` all pass
- [x] Manual testing on a cluster with Istio + Traefik Gateway API resources:
  - Pulse Gateway tile shows correct count and health
  - Consolidated dashboard displays all resources
  - Enter navigates to individual GatewayClass (cluster-scoped) and Gateway (namespaced) views
  - YAML and Describe work on individual resources
  - No crashes or freezes

## Dependencies

- Depends on #4086 (panic safety fixes) — includes those changes in this branch for standalone testing. After #4086 is merged, this PR will auto-rebase to show only the feature diff.

## Files Changed

| Category | Files |
|----------|-------|
| DAOs | 9 resource DAOs + `gatewayapi.go` aggregator + registry |
| Renderers | 9 resource renderers + `gatewayapi.go` + `helpers.go` |
| Views | `gatewayapi.go` viewer + `command.go` parser + `pulse.go` + `registrar.go` |
| Model | `registry.go` + `pulse_health.go` |
| Client | `gvrs.go` GVR definitions |