### PR TITLE
fix(watch): namespace YAML/describe views come up empty

### DIFF
--- a/internal/watch/factory.go
+++ b/internal/watch/factory.go
@@ -244,6 +244,11 @@ func (f *Factory) CanForInstance(fqn string, gvr *client.GVR, verbs []string) (i
 		return nil, fmt.Errorf("%v access denied on resource %q:%q", verbs, authNs, gvr)
 	}
 
+	// Namespaces are cluster-scoped; always use cluster scope for the informer.
+	if gvr == client.NsGVR {
+		ns = client.ClusterScope
+	}
+
 	return f.ForResource(ns, gvr)
 }
 


### PR DESCRIPTION
## Problem

Viewing a Namespace's YAML (`y`) or running describe shows an empty view, even
though the namespace exists and is selectable in the list. This is a regression
introduced in v0.51.0 by #4001.

## Root cause

`Factory.CanForInstance` was updated in #4001 to use the resource name as the
namespace for the RBAC check (correct), but it kept passing the original
(usually empty) namespace to `f.ForResource(ns, gvr)`. For cluster-scoped
resources like Namespaces this registers the informer in a per-namespace
factory rather than the cluster-scope one.

Consequently `Factory.Get` takes the `ByNamespace(ns).Get(n)` branch (because
`IsClusterScoped(ns)` is false for `ns == ""`) and returns NotFound, so the
YAML/describe model receives nothing to render.

`CanForResource` in the same commit already forces cluster scope for `NsGVR`
before calling `ForResource`; `CanForInstance` was missing the same step.

## Fix

Force cluster scope for `NsGVR` in `CanForInstance` before `ForResource`,
mirroring the existing logic in `CanForResource`.

## Verification

- `go build ./...` ✓
- `go vet ./internal/watch/...` ✓
- `go test ./internal/watch/... ./internal/dao/...` ✓
- `gofmt -l internal/watch/factory.go` clean ✓
- Manual: `y` on a Namespace row now renders the YAML.

## Checklist

- [x] Exported items are commented
- [x] All commits signed off (DCO)