### PR TITLE
feat(cli): expose --server and --tls-server-name flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -305,6 +305,13 @@ func initK8sFlags() {
 	)
 
 	rootCmd.Flags().StringVar(
+		k8sFlags.APIServer,
+		"server",
+		"",
+		"The address and port of the Kubernetes API server",
+	)
+
+	rootCmd.Flags().StringVar(
 		k8sFlags.AuthInfoName,
 		"user",
 		"",
@@ -346,6 +353,13 @@ func initCertFlags() {
 		"insecure-skip-tls-verify",
 		false,
 		"If true, the server's caCertFile will not be checked for validity",
+	)
+
+	rootCmd.Flags().StringVar(
+		k8sFlags.TLSServerName,
+		"tls-server-name",
+		"",
+		"Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used",
 	)
 
 	rootCmd.Flags().StringVar(


### PR DESCRIPTION
## What

Exposes kubectl's standard `--server` and `--tls-server-name` flags, which k9s already wires via `genericclioptions.ConfigFlags` but never registered on the command line.

## Why

`initK8sFlags`/`initCertFlags` register only a subset of the standard kubeconfig flags. Without `--server`, the API server endpoint cannot be overridden on the command line — users whose kubeconfig points at an unreachable or rotated server address had to edit the file just to connect. `--server` (and `--tls-server-name`) match kubectl and allow overriding without touching kubeconfig.

## How

Registers `k8sFlags.APIServer` as `--server` and `k8sFlags.TLSServerName` as `--tls-server-name`. The fields already exist on the embedded `ConfigFlags`; only the flag registration was missing — so this is purely additive and backward compatible.

```
k9s --server https://10.0.0.5:6443 --insecure-skip-tls-verify
```
