### PR TITLE
feat(config): surface fatal kubeconfig load errors on the terminal

### DIFF
--- a/cmd/configerror.go
+++ b/cmd/configerror.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/derailed/k9s/internal/client"
+)
+
+// fatalConfigError flags a non-recoverable kubeconfig loading failure.
+// When the kubeconfig cannot be parsed/loaded at all, k9s cannot obtain any
+// context and entering the TUI is pointless (it would only loop on the same
+// error). Such errors must be surfaced to the user on the terminal.
+type fatalConfigError struct {
+	path string
+	err  error
+}
+
+func (e *fatalConfigError) Error() string {
+	if e.path != "" {
+		return fmt.Sprintf("kubeconfig %q could not be loaded: %v", e.path, e.err)
+	}
+
+	return fmt.Sprintf("kubeconfig could not be loaded: %v", e.err)
+}
+
+func (e *fatalConfigError) Unwrap() error { return e.err }
+
+// UserMessage returns a human friendly, multi-line description of the failure
+// suitable for direct terminal output.
+func (e *fatalConfigError) UserMessage() string {
+	var b strings.Builder
+	b.WriteString("Unable to load your Kubernetes configuration (kubeconfig).\n")
+	if e.path != "" {
+		b.WriteString(fmt.Sprintf("File: %s\n", e.path))
+	}
+	b.WriteString(fmt.Sprintf("Reason: %s\n", rootCause(e.err)))
+	b.WriteString("\nK9s cannot start until this is resolved. Please fix your kubeconfig and try again.")
+
+	return b.String()
+}
+
+// checkFatalConfigError probes whether the kubeconfig is fundamentally
+// unusable. It returns a *fatalConfigError only when the kubeconfig cannot be
+// loaded/parsed at all (e.g. malformed file, duplicate entries). It explicitly
+// does NOT treat a parseable-but-unreachable cluster as fatal so users keep the
+// ability to switch contexts from within the TUI.
+func checkFatalConfigError(cfg *client.Config) *fatalConfigError {
+	if cfg == nil {
+		return nil
+	}
+	// RawConfig is the lowest-level kubeconfig load. If it fails, no context can
+	// be resolved and the file is broken at the parse/merge level.
+	if _, err := cfg.RawConfig(); err != nil {
+		return &fatalConfigError{path: kubeconfigPath(cfg), err: err}
+	}
+
+	return nil
+}
+
+// kubeconfigPath best-effort resolves the kubeconfig file path for messaging.
+func kubeconfigPath(cfg *client.Config) string {
+	acc, err := cfg.ConfigAccess()
+	if err != nil || acc == nil {
+		return ""
+	}
+	if f := acc.GetExplicitFile(); f != "" {
+		return f
+	}
+	if pp := acc.GetLoadingPrecedence(); len(pp) > 0 {
+		return strings.Join(pp, ", ")
+	}
+
+	return ""
+}
+
+// rootCause walks the error chain and returns the deepest message, stripping
+// k9s' own wrapping so the user sees the underlying client-go cause.
+func rootCause(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	// errors.Join concatenates messages with newlines; surface the first line
+	// that mentions the config load failure when present, else the whole thing.
+	for _, line := range strings.Split(msg, "\n") {
+		if strings.Contains(line, "error loading config file") ||
+			strings.Contains(line, "duplicate") {
+			return strings.TrimSpace(line)
+		}
+	}
+
+	return strings.TrimSpace(msg)
+}

--- a/cmd/configerror_test.go
+++ b/cmd/configerror_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func newConfigForFile(path string) *client.Config {
+	flags := genericclioptions.NewConfigFlags(client.UsePersistentConfig)
+	flags.KubeConfig = &path
+
+	return client.NewConfig(flags)
+}
+
+func TestCheckFatalConfigError(t *testing.T) {
+	tests := map[string]struct {
+		kubeconfig string
+		wantFatal  bool
+	}{
+		"broken-duplicate-user": {
+			kubeconfig: "testdata/bad-kubeconfig.yaml",
+			wantFatal:  true,
+		},
+		"valid-config": {
+			kubeconfig: "testdata/good-kubeconfig.yaml",
+			wantFatal:  false,
+		},
+	}
+
+	for k := range tests {
+		u := tests[k]
+		t.Run(k, func(t *testing.T) {
+			cfg := newConfigForFile(u.kubeconfig)
+			fatal := checkFatalConfigError(cfg)
+			if u.wantFatal {
+				assert.NotNil(t, fatal)
+				assert.Equal(t, u.kubeconfig, fatal.path)
+			} else {
+				assert.Nil(t, fatal)
+			}
+		})
+	}
+}
+
+func TestCheckFatalConfigErrorNil(t *testing.T) {
+	assert.Nil(t, checkFatalConfigError(nil))
+}
+
+func TestFatalConfigErrorMessages(t *testing.T) {
+	cause := errors.New(`error loading config file "/tmp/bad.yaml": duplicate name "default" in list`)
+	e := &fatalConfigError{path: "/tmp/bad.yaml", err: cause}
+
+	assert.ErrorIs(t, e, cause)
+	assert.Contains(t, e.Error(), "/tmp/bad.yaml")
+	assert.Contains(t, e.Error(), "could not be loaded")
+
+	msg := e.UserMessage()
+	assert.Contains(t, msg, "Unable to load your Kubernetes configuration")
+	assert.Contains(t, msg, "File: /tmp/bad.yaml")
+	assert.Contains(t, msg, `duplicate name "default"`)
+	assert.Contains(t, msg, "K9s cannot start")
+}
+
+func TestFatalConfigErrorMessageNoPath(t *testing.T) {
+	e := &fatalConfigError{err: errors.New("boom")}
+	assert.Equal(t, "kubeconfig could not be loaded: boom", e.Error())
+	assert.NotContains(t, e.UserMessage(), "File:")
+}
+
+func TestRootCause(t *testing.T) {
+	tests := map[string]struct {
+		err  error
+		want string
+	}{
+		"nil": {
+			err:  nil,
+			want: "",
+		},
+		"joined-picks-config-load-line": {
+			err: errors.Join(
+				errors.New("some unrelated wrap"),
+				errors.New(`error loading config file "/tmp/x.yaml": duplicate name "default" in list`),
+			),
+			want: `error loading config file "/tmp/x.yaml": duplicate name "default" in list`,
+		},
+		"plain": {
+			err:  errors.New("cannot connect to context: foo"),
+			want: "cannot connect to context: foo",
+		},
+	}
+
+	for k := range tests {
+		u := tests[k]
+		t.Run(k, func(t *testing.T) {
+			got := rootCause(u.err)
+			assert.True(t, strings.Contains(got, u.want) || got == u.want)
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,9 +105,22 @@ func run(*cobra.Command, []string) error {
 		TimeFormat: time.RFC3339,
 	})))
 
-	cfg, err := loadConfiguration()
+	cfg, k8sCfg, err := loadConfiguration()
 	if err != nil {
-		// Only warn if there's an actual context configured
+		// A kubeconfig that cannot be parsed/loaded is fatal: no context can be
+		// resolved and the TUI would only loop on the same error. Surface it
+		// loudly on the terminal and bail out instead of entering a broken TUI.
+		if fatal := checkFatalConfigError(k8sCfg); fatal != nil {
+			fatal.err = err
+			slog.Error("Fatal kubeconfig load failure", slogs.Error, err)
+			printConfigError(fatal)
+			// We have already rendered a complete, user-facing error on the
+			// terminal. Exit directly to avoid cobra re-printing the raw error
+			// and the full usage block, which would only bury our message.
+			os.Exit(1)
+		}
+		// Otherwise the error is recoverable (e.g. unreachable cluster). Keep the
+		// existing best-effort warn so users can still switch contexts in-app.
 		if cfg != nil && cfg.K9s.ActiveContextName() != "" {
 			slog.Warn("Fail to load global/context configuration", slogs.Error, err)
 		}
@@ -130,7 +143,7 @@ func run(*cobra.Command, []string) error {
 	return nil
 }
 
-func loadConfiguration() (*config.Config, error) {
+func loadConfiguration() (*config.Config, *client.Config, error) {
 	slog.Info("🐶 K9s starting up...")
 
 	k8sCfg := client.NewConfig(k8sFlags)
@@ -174,7 +187,15 @@ func loadConfiguration() (*config.Config, error) {
 		errs = errors.Join(errs, err)
 	}
 
-	return k9sCfg, errs
+	return k9sCfg, k8sCfg, errs
+}
+
+// printConfigError renders a fatal kubeconfig error prominently on the terminal
+// so the user is not left guessing why k9s refused to start.
+func printConfigError(e *fatalConfigError) {
+	printLogo(color.Red)
+	fmt.Fprintf(out, "%s\n", color.Colorize("💥 K9s startup failed", color.Red))
+	fmt.Fprintf(out, "%s\n", color.Colorize(e.UserMessage(), color.Red))
 }
 
 func parseLevel(level string) slog.Level {

--- a/cmd/testdata/bad-kubeconfig.yaml
+++ b/cmd/testdata/bad-kubeconfig.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Config
+current-context: fake-ctx
+clusters:
+- name: fake-cluster
+  cluster:
+    server: https://127.0.0.1:6443
+    insecure-skip-tls-verify: true
+contexts:
+- name: fake-ctx
+  context:
+    cluster: fake-cluster
+    user: default
+users:
+- name: default
+  user:
+    token: aaa
+- name: default
+  user:
+    token: bbb

--- a/cmd/testdata/good-kubeconfig.yaml
+++ b/cmd/testdata/good-kubeconfig.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Config
+current-context: fake-ctx
+clusters:
+- name: fake-cluster
+  cluster:
+    server: https://127.0.0.1:6443
+    insecure-skip-tls-verify: true
+contexts:
+- name: fake-ctx
+  context:
+    cluster: fake-cluster
+    user: fake-user
+users:
+- name: fake-user
+  user:
+    token: aaa


### PR DESCRIPTION
## What

Surfaces fatal kubeconfig load failures as a clear, actionable terminal error instead of silently dropping into a broken TUI.

## Why

When a kubeconfig cannot be parsed or merged (e.g. duplicate user entries — common when `KUBECONFIG` merges multiple files that share a user name), k9s only logged a warning plus a transient flash that is immediately buried by repeating context-watcher errors. The user lands in a TUI that loops on the same failure with no visible cause, and has to dig through `k9s.log` to find out why.

## How

`checkFatalConfigError` probes `client.Config.RawConfig()` — the lowest-level kubeconfig load. If it fails, no context can be resolved and the file is broken at the parse/merge level, so `run()` prints a clear message (file path + root cause + next step) and exits, instead of entering an unusable TUI. Parseable-but-unreachable clusters are explicitly NOT treated as fatal, so users keep the ability to switch contexts from within k9s.

## Tests

Unit tests for fatal-vs-recoverable detection, user-facing message formatting, and error-chain root-cause extraction. Manually verified with a malformed kubeconfig (duplicate `default` user): k9s now prints a red, readable error and exits cleanly instead of hanging.

Example output:
```
💥 K9s startup failed
Unable to load your Kubernetes configuration (kubeconfig).
File: /path/to/kubeconfig.yaml
Reason: error loading config file ...: duplicate name "default" in list
K9s cannot start until this is resolved. Please fix your kubeconfig and try again.
```
