### PR TITLE
feat(cmd): add `k9s watch` wizard to build the workload aggregation view

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,9 +61,9 @@ func init() {
 		return flagError{err: err}
 	})
 
-	rootCmd.AddCommand(versionCmd(), infoCmd())
 	initK9sFlags()
 	initK8sFlags()
+	rootCmd.AddCommand(versionCmd(), infoCmd(), watchCmd())
 }
 
 // Execute root command.

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/config/data"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// nativeWorkloadGVRs lists the common native workload resources, in display
+// order, that the wizard suggests when present in the target cluster.
+var nativeWorkloadGVRs = []string{
+	"v1/pods",
+	"v1/services",
+	"apps/v1/deployments",
+	"apps/v1/statefulsets",
+	"apps/v1/daemonsets",
+	"apps/v1/replicasets",
+	"batch/v1/jobs",
+	"batch/v1/cronjobs",
+}
+
+// standardGroups mirrors the built-in k8s api groups so the wizard can tell
+// native resources apart from CRDs.
+var standardGroups = map[string]struct{}{
+	"apps/v1":            {},
+	"autoscaling/v1":     {},
+	"autoscaling/v2":     {},
+	"batch/v1":           {},
+	"batch/v1beta1":      {},
+	"extensions/v1beta1": {},
+	"policy/v1":          {},
+	"policy/v1beta1":     {},
+	"v1":                 {},
+}
+
+// resourceEntry represents a discoverable cluster resource the wizard can add
+// to the workload aggregation view.
+type resourceEntry struct {
+	gvr   string
+	kind  string
+	isCRD bool
+}
+
+func watchCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "watch",
+		Short: "Interactive wizard to build a workload (:wk) aggregation view",
+		Long:  "Interactively pick cluster resources and namespaces, then write them to the workload (:wk) aggregation view in views.yaml.",
+		RunE:  runWatch,
+	}
+	// Reuse the same connection flags as the main command (context, kubeconfig,
+	// insecure-skip-tls-verify, ...) so the wizard can target any cluster.
+	k8sFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func runWatch(*cobra.Command, []string) error {
+	if err := config.InitLocs(); err != nil {
+		return err
+	}
+
+	k8sCfg := client.NewConfig(k8sFlags)
+	conn, err := client.InitConnection(k8sCfg, slog.Default())
+	if err != nil {
+		return fmt.Errorf("k8s connection failed: %w", err)
+	}
+	if !conn.CheckConnectivity() {
+		return fmt.Errorf("unable to connect to the cluster, check your kubeconfig/context")
+	}
+
+	resources, err := discoverResources(conn)
+	if err != nil {
+		return err
+	}
+	if len(resources) == 0 {
+		return fmt.Errorf("no resources discovered in the cluster")
+	}
+	namespaces := discoverNamespaces(conn)
+
+	entries, err := runWatchWizard(os.Stdin, out, resources, namespaces)
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(out, "No resources selected, nothing written.")
+		return nil
+	}
+
+	if err := writeWorkloadsView(config.AppViewsFile, entries); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "\n✅ Wrote %s, run `k9s` then `:wk` to view.\n", config.AppViewsFile)
+
+	return nil
+}
+
+// discoverResources lists the native workloads present in the cluster plus all
+// discovered CRDs.
+func discoverResources(conn client.Connection) ([]resourceEntry, error) {
+	dial, err := conn.CachedDiscovery()
+	if err != nil {
+		return nil, err
+	}
+	rr, err := dial.ServerPreferredResources()
+	if err != nil {
+		// Partial discovery results are still useful (e.g. a flaky aggregated
+		// api group), so only fail when nothing came back at all.
+		slog.Warn("Partial resource discovery", "error", err)
+		if len(rr) == 0 {
+			return nil, fmt.Errorf("resource discovery failed: %w", err)
+		}
+	}
+
+	known := make(map[string]resourceEntry)
+	var crds []resourceEntry
+	for _, r := range rr {
+		for i := range r.APIResources {
+			res := r.APIResources[i]
+			if strings.Contains(res.Name, "/") || !slices.Contains(res.Verbs, "list") {
+				continue
+			}
+			gvr := client.FromGVAndR(r.GroupVersion, res.Name).String()
+			entry := resourceEntry{gvr: gvr, kind: res.Kind, isCRD: !isStandardGroup(r.GroupVersion)}
+			known[gvr] = entry
+			if entry.isCRD {
+				crds = append(crds, entry)
+			}
+		}
+	}
+
+	out := make([]resourceEntry, 0, len(nativeWorkloadGVRs)+len(crds))
+	for _, g := range nativeWorkloadGVRs {
+		if e, ok := known[g]; ok {
+			out = append(out, e)
+		}
+	}
+	slices.SortFunc(crds, func(a, b resourceEntry) int { return strings.Compare(a.gvr, b.gvr) })
+	out = append(out, crds...)
+
+	return out, nil
+}
+
+func isStandardGroup(gv string) bool {
+	if _, ok := standardGroups[gv]; ok {
+		return true
+	}
+	return strings.Contains(gv, ".k8s.io")
+}
+
+// discoverNamespaces returns sorted namespace names, best-effort. An empty
+// result simply means the namespace prompt falls back to free-form input.
+func discoverNamespaces(conn client.Connection) []string {
+	nn, err := conn.ValidNamespaceNames()
+	if err != nil {
+		slog.Warn("Unable to list namespaces", "error", err)
+		return nil
+	}
+	nss := make([]string, 0, len(nn))
+	for ns := range nn {
+		nss = append(nss, ns)
+	}
+	slices.Sort(nss)
+
+	return nss
+}
+
+// runWatchWizard drives the interactive prompt and returns the assembled
+// workload entries ("<gvr>" or "<gvr> <namespace>").
+func runWatchWizard(in io.Reader, w io.Writer, resources []resourceEntry, namespaces []string) ([]string, error) {
+	scanner := bufio.NewScanner(in)
+
+	fmt.Fprintln(w, "Discovered resources:")
+	var lastNative, lastCRD bool
+	for i, r := range resources {
+		if !r.isCRD && !lastNative {
+			fmt.Fprintln(w, "\n  Native workloads:")
+			lastNative = true
+		}
+		if r.isCRD && !lastCRD {
+			fmt.Fprintln(w, "\n  Custom resources (CRDs):")
+			lastCRD = true
+		}
+		fmt.Fprintf(w, "    %d) %s\n", i+1, r.gvr)
+	}
+
+	fmt.Fprint(w, "\nSelect resources to aggregate (enter numbers, comma-separated, e.g. 1,3,5): ")
+	if !scanner.Scan() {
+		return nil, scanner.Err()
+	}
+	indices, err := parseSelection(scanner.Text(), len(resources))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(namespaces) > 0 {
+		fmt.Fprintln(w, "\nCluster namespaces:")
+		for i, ns := range namespaces {
+			fmt.Fprintf(w, "    %d) %s\n", i+1, ns)
+		}
+	}
+
+	entries := make([]string, 0, len(indices))
+	for _, idx := range indices {
+		r := resources[idx]
+		fmt.Fprintf(w, "\nNamespace for %q? (number or name, enter = follow view/all): ", r.gvr)
+		if !scanner.Scan() {
+			return nil, scanner.Err()
+		}
+		ns := resolveNamespace(scanner.Text(), namespaces)
+		entries = append(entries, workloadEntry(r.gvr, ns))
+	}
+
+	return entries, nil
+}
+
+// resolveNamespace turns a namespace answer (a list number or a raw name) into
+// a namespace string. An empty answer follows the view's active namespace.
+func resolveNamespace(answer string, namespaces []string) string {
+	answer = strings.TrimSpace(answer)
+	if answer == "" {
+		return ""
+	}
+	if n, err := strconv.Atoi(answer); err == nil && n >= 1 && n <= len(namespaces) {
+		return namespaces[n-1]
+	}
+
+	return answer
+}
+
+// parseSelection parses a comma-separated 1-based selection (e.g. "1,3,5")
+// into deduplicated 0-based indices, validating against the count n.
+func parseSelection(input string, n int) ([]int, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil, nil
+	}
+
+	seen := make(map[int]struct{})
+	indices := make([]int, 0)
+	for _, tok := range strings.Split(input, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		num, err := strconv.Atoi(tok)
+		if err != nil {
+			return nil, fmt.Errorf("invalid selection %q: not a number", tok)
+		}
+		if num < 1 || num > n {
+			return nil, fmt.Errorf("selection %d out of range (1-%d)", num, n)
+		}
+		idx := num - 1
+		if _, ok := seen[idx]; ok {
+			continue
+		}
+		seen[idx] = struct{}{}
+		indices = append(indices, idx)
+	}
+
+	return indices, nil
+}
+
+// workloadEntry assembles a workload list entry. An empty namespace yields just
+// the gvr (follow the view's active namespace); otherwise "<gvr> <namespace>".
+func workloadEntry(gvr, ns string) string {
+	gvr = strings.TrimSpace(gvr)
+	ns = strings.TrimSpace(ns)
+	if ns == "" || ns == client.NamespaceAll {
+		return gvr
+	}
+
+	return gvr + " " + ns
+}
+
+// writeWorkloadsView merges the selected entries into the workloads.default
+// list of the views.yaml at path, preserving any existing content.
+func writeWorkloadsView(path string, entries []string) error {
+	var existing []byte
+	if path != "" {
+		if bb, err := os.ReadFile(path); err == nil {
+			existing = bb
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	merged, err := mergeWorkloads(existing, entries)
+	if err != nil {
+		return err
+	}
+	if err := data.EnsureDirPath(path, data.DefaultDirMod); err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, merged, data.DefaultFileMod)
+}
+
+// mergeWorkloads sets workloads.default to entries inside an existing views.yaml
+// document, preserving the views section and any other workload sets.
+func mergeWorkloads(existing []byte, entries []string) ([]byte, error) {
+	doc := map[string]any{}
+	if len(existing) > 0 {
+		if err := yaml.Unmarshal(existing, &doc); err != nil {
+			return nil, fmt.Errorf("parse existing views config: %w", err)
+		}
+		if doc == nil {
+			doc = map[string]any{}
+		}
+	}
+
+	workloads, _ := doc["workloads"].(map[string]any)
+	if workloads == nil {
+		workloads = map[string]any{}
+	}
+	workloads[config.DefaultWorkloadGVRs] = entries
+	doc["workloads"] = workloads
+
+	return yaml.Marshal(doc)
+}

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestParseSelection(t *testing.T) {
+	tests := map[string]struct {
+		input   string
+		n       int
+		want    []int
+		wantErr bool
+	}{
+		"simple":        {input: "1,3,5", n: 5, want: []int{0, 2, 4}},
+		"spaces":        {input: " 1 , 2 ", n: 5, want: []int{0, 1}},
+		"single":        {input: "2", n: 5, want: []int{1}},
+		"dedupe":        {input: "1,1,2", n: 5, want: []int{0, 1}},
+		"emptyTokens":   {input: "1,,3", n: 5, want: []int{0, 2}},
+		"empty":         {input: "", n: 5, want: nil},
+		"blank":         {input: "   ", n: 5, want: nil},
+		"notANumber":    {input: "1,x", n: 5, wantErr: true},
+		"zero":          {input: "0", n: 5, wantErr: true},
+		"outOfRange":    {input: "6", n: 5, wantErr: true},
+		"negative":      {input: "-1", n: 5, wantErr: true},
+		"orderPreserve": {input: "3,1", n: 5, want: []int{2, 0}},
+	}
+
+	for k := range tests {
+		u := tests[k]
+		t.Run(k, func(t *testing.T) {
+			got, err := parseSelection(u.input, u.n)
+			if u.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, u.want, got)
+		})
+	}
+}
+
+func TestWorkloadEntry(t *testing.T) {
+	tests := map[string]struct {
+		gvr  string
+		ns   string
+		want string
+	}{
+		"noNamespace":     {gvr: "v1/pods", ns: "", want: "v1/pods"},
+		"withNamespace":   {gvr: "apps/v1/deployments", ns: "kube-system", want: "apps/v1/deployments kube-system"},
+		"allFollowsView":  {gvr: "v1/pods", ns: "all", want: "v1/pods"},
+		"trimsWhitespace": {gvr: " v1/pods ", ns: " demo ", want: "v1/pods demo"},
+	}
+
+	for k := range tests {
+		u := tests[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.want, workloadEntry(u.gvr, u.ns))
+		})
+	}
+}
+
+func TestResolveNamespace(t *testing.T) {
+	nss := []string{"default", "demo", "kube-system"}
+
+	assert.Equal(t, "", resolveNamespace("", nss))
+	assert.Equal(t, "default", resolveNamespace("1", nss))
+	assert.Equal(t, "kube-system", resolveNamespace("3", nss))
+	assert.Equal(t, "custom", resolveNamespace("custom", nss))
+	// Out of range number falls through to a literal name.
+	assert.Equal(t, "9", resolveNamespace("9", nss))
+}
+
+func TestMergeWorkloadsFresh(t *testing.T) {
+	out, err := mergeWorkloads(nil, []string{"v1/pods", "apps/v1/deployments demo"})
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(out, &doc))
+	wl, ok := doc["workloads"].(map[string]any)
+	require.True(t, ok)
+	def, ok := wl["default"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"v1/pods", "apps/v1/deployments demo"}, def)
+}
+
+func TestMergeWorkloadsPreservesViews(t *testing.T) {
+	existing := []byte(`views:
+  v1/pods:
+    columns:
+      - NAME
+      - STATUS
+workloads:
+  default:
+    - v1/services
+  other:
+    - v1/pods
+`)
+
+	out, err := mergeWorkloads(existing, []string{"v1/pods", "batch/v1/jobs default"})
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(out, &doc))
+
+	// views section preserved.
+	views, ok := doc["views"].(map[string]any)
+	require.True(t, ok, "views section must be preserved")
+	_, ok = views["v1/pods"]
+	assert.True(t, ok, "view entry must be preserved")
+
+	wl, ok := doc["workloads"].(map[string]any)
+	require.True(t, ok)
+	// default replaced.
+	assert.Equal(t, []any{"v1/pods", "batch/v1/jobs default"}, wl["default"])
+	// other workload set preserved.
+	assert.Equal(t, []any{"v1/pods"}, wl["other"])
+}
+
+func TestIsStandardGroup(t *testing.T) {
+	assert.True(t, isStandardGroup("v1"))
+	assert.True(t, isStandardGroup("apps/v1"))
+	assert.True(t, isStandardGroup("batch/v1"))
+	assert.True(t, isStandardGroup("networking.k8s.io/v1"))
+	assert.False(t, isStandardGroup("examples.demo.io/v1"))
+	assert.False(t, isStandardGroup("monitoring.coreos.com/v1"))
+}

--- a/internal/config/json/schemas/views.json
+++ b/internal/config/json/schemas/views.json
@@ -18,7 +18,13 @@
         },
         "required": ["columns"]
       }
+    },
+    "workloads": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
     }
-  },
-  "required": ["views"]
+  }
 }

--- a/internal/config/testdata/views/workloads.yaml
+++ b/internal/config/testdata/views/workloads.yaml
@@ -1,0 +1,15 @@
+views:
+  v1/pods:
+    columns:
+      - NAME
+      - AGE
+
+workloads:
+  default:
+    - apps/v1/deployments
+    - v1/pods
+    - examples.demo.io/v1/foos
+  rks:
+    - rks.io/v1/rksinstances
+    - rks.io/v1/workerinstances
+    - v1/pods

--- a/internal/config/views.go
+++ b/internal/config/views.go
@@ -73,9 +73,17 @@ func (v *ViewSetting) Equals(vs *ViewSetting) bool {
 	return cmp.Compare(v.SortColumn, vs.SortColumn) == 0
 }
 
+// DefaultWorkloadGVRs is the name of the workload GVR set used by the
+// built-in workload (:wk) view.
+const DefaultWorkloadGVRs = "default"
+
 // CustomView represents a collection of view customization.
 type CustomView struct {
-	Views     map[string]ViewSetting `yaml:"views"`
+	Views map[string]ViewSetting `yaml:"views"`
+	// Workloads maps a named aggregation to a list of GVRs that the workload
+	// view should display. The "default" entry overrides the built-in
+	// workload resource set. When unset, the built-in defaults are used.
+	Workloads map[string][]string `yaml:"workloads,omitempty"`
 	listeners map[string]ViewConfigListener
 }
 
@@ -83,6 +91,7 @@ type CustomView struct {
 func NewCustomView() *CustomView {
 	return &CustomView{
 		Views:     make(map[string]ViewSetting),
+		Workloads: make(map[string][]string),
 		listeners: make(map[string]ViewConfigListener),
 	}
 }
@@ -92,6 +101,28 @@ func (v *CustomView) Reset() {
 	for k := range v.Views {
 		delete(v.Views, k)
 	}
+	for k := range v.Workloads {
+		delete(v.Workloads, k)
+	}
+}
+
+// WorkloadGVRs returns the list of GVRs configured for the given workload
+// aggregation name. The second return value reports whether a non-empty
+// configuration was found. When false, callers should fall back to the
+// built-in defaults to preserve backward compatibility.
+func (v *CustomView) WorkloadGVRs(name string) ([]string, bool) {
+	if v == nil || len(v.Workloads) == 0 {
+		return nil, false
+	}
+	if name == "" {
+		name = DefaultWorkloadGVRs
+	}
+	gvrs, ok := v.Workloads[name]
+	if !ok || len(gvrs) == 0 {
+		return nil, false
+	}
+
+	return gvrs, true
 }
 
 // Load loads view configurations.
@@ -114,6 +145,7 @@ func (v *CustomView) Load(path string) error {
 		return err
 	}
 	v.Views = in.Views
+	v.Workloads = in.Workloads
 	v.fireConfigChanged()
 
 	return nil

--- a/internal/config/views_test.go
+++ b/internal/config/views_test.go
@@ -49,6 +49,71 @@ func TestCustomViewLoad(t *testing.T) {
 	}
 }
 
+func TestWorkloadGVRsLoad(t *testing.T) {
+	cfg := config.NewCustomView()
+	require.NoError(t, cfg.Load("testdata/views/workloads.yaml"))
+
+	gvrs, ok := cfg.WorkloadGVRs(config.DefaultWorkloadGVRs)
+	require.True(t, ok)
+	assert.Equal(t, []string{"apps/v1/deployments", "v1/pods", "examples.demo.io/v1/foos"}, gvrs)
+
+	rks, ok := cfg.WorkloadGVRs("rks")
+	require.True(t, ok)
+	assert.Equal(t, []string{"rks.io/v1/rksinstances", "rks.io/v1/workerinstances", "v1/pods"}, rks)
+}
+
+func TestWorkloadGVRs(t *testing.T) {
+	uu := map[string]struct {
+		cv   *config.CustomView
+		name string
+		e    []string
+		ok   bool
+	}{
+		"nil": {
+			cv: nil,
+		},
+		"empty": {
+			cv: config.NewCustomView(),
+		},
+		"default-fallback-on-blank-name": {
+			cv: func() *config.CustomView {
+				cv := config.NewCustomView()
+				cv.Workloads[config.DefaultWorkloadGVRs] = []string{"v1/pods"}
+				return cv
+			}(),
+			name: "",
+			e:    []string{"v1/pods"},
+			ok:   true,
+		},
+		"named": {
+			cv: func() *config.CustomView {
+				cv := config.NewCustomView()
+				cv.Workloads["rks"] = []string{"rks.io/v1/rksinstances"}
+				return cv
+			}(),
+			name: "rks",
+			e:    []string{"rks.io/v1/rksinstances"},
+			ok:   true,
+		},
+		"unknown-name": {
+			cv: func() *config.CustomView {
+				cv := config.NewCustomView()
+				cv.Workloads[config.DefaultWorkloadGVRs] = []string{"v1/pods"}
+				return cv
+			}(),
+			name: "nope",
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			gvrs, ok := u.cv.WorkloadGVRs(u.name)
+			assert.Equal(t, u.ok, ok)
+			assert.Equal(t, u.e, gvrs)
+		})
+	}
+}
+
 func TestViewSettingEquals(t *testing.T) {
 	uu := map[string]struct {
 		v1, v2 *config.ViewSetting

--- a/internal/dao/workload.go
+++ b/internal/dao/workload.go
@@ -230,6 +230,12 @@ func readiness(gvr *client.GVR, r *metav1.TableRow, h []metav1.TableColumnDefini
 		}
 	case client.SvcGVR:
 		return ""
+	default:
+		// CRDs may expose their own "Ready" printer column; surface it when
+		// present instead of defaulting to N/A.
+		if v := cellAt(r, h, "Ready"); v != nil {
+			return fmt.Sprintf("%v", v)
+		}
 	}
 
 	return render.NAValue

--- a/internal/dao/workload.go
+++ b/internal/dao/workload.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/derailed/k9s/internal"
 	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/render"
 	"github.com/derailed/k9s/internal/slogs"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -92,10 +93,32 @@ func (a *Workload) fetch(ctx context.Context, gvr *client.GVR, ns string) (*meta
 	return tt, nil
 }
 
+// workloadGVRs resolves the set of GVRs the workload view should aggregate.
+// It prefers a user-configured set (via the view config carried in the
+// context) and falls back to the built-in defaults for backward
+// compatibility.
+func workloadGVRs(ctx context.Context) []*client.GVR {
+	cv, ok := ctx.Value(internal.KeyViewConfig).(*config.CustomView)
+	if !ok || cv == nil {
+		return resList
+	}
+	names, ok := cv.WorkloadGVRs(config.DefaultWorkloadGVRs)
+	if !ok {
+		return resList
+	}
+
+	gvrs := make([]*client.GVR, 0, len(names))
+	for _, n := range names {
+		gvrs = append(gvrs, client.NewGVR(n))
+	}
+
+	return gvrs
+}
+
 // List fetch workloads.
 func (a *Workload) List(ctx context.Context, ns string) ([]runtime.Object, error) {
 	oo := make([]runtime.Object, 0, 100)
-	for _, gvr := range resList {
+	for _, gvr := range workloadGVRs(ctx) {
 		table, err := a.fetch(ctx, gvr, ns)
 		if err != nil {
 			return nil, err
@@ -116,10 +139,14 @@ func (a *Workload) List(ctx context.Context, ns string) ([]runtime.Object, error
 				}
 			}
 			stat := status(gvr, &r, table.ColumnDefinitions)
+			name := cellAt(&r, table.ColumnDefinitions, "Name")
+			if name == nil {
+				name = render.MissingValue
+			}
 			oo = append(oo, &render.WorkloadRes{Row: metav1.TableRow{Cells: []any{
 				gvr.String(),
 				ns,
-				r.Cells[indexOf("Name", table.ColumnDefinitions)],
+				name,
 				stat,
 				readiness(gvr, &r, table.ColumnDefinitions),
 				validity(stat),
@@ -136,11 +163,15 @@ func (a *Workload) List(ctx context.Context, ns string) ([]runtime.Object, error
 func readiness(gvr *client.GVR, r *metav1.TableRow, h []metav1.TableColumnDefinition) string {
 	switch gvr {
 	case client.PodGVR, client.DpGVR, client.StsGVR:
-		return r.Cells[indexOf("Ready", h)].(string)
+		if s, ok := cellAt(r, h, "Ready").(string); ok {
+			return s
+		}
 	case client.RsGVR, client.DsGVR:
-		c := r.Cells[indexOf("Ready", h)].(int64)
-		d := r.Cells[indexOf("Desired", h)].(int64)
-		return fmt.Sprintf("%d/%d", c, d)
+		c, ok1 := cellAt(r, h, "Ready").(int64)
+		d, ok2 := cellAt(r, h, "Desired").(int64)
+		if ok1 && ok2 {
+			return fmt.Sprintf("%d/%d", c, d)
+		}
 	case client.SvcGVR:
 		return ""
 	}
@@ -151,26 +182,28 @@ func readiness(gvr *client.GVR, r *metav1.TableRow, h []metav1.TableColumnDefini
 func status(gvr *client.GVR, r *metav1.TableRow, h []metav1.TableColumnDefinition) string {
 	switch gvr {
 	case client.PodGVR:
-		if status := r.Cells[indexOf("Status", h)]; status == render.PhaseCompleted {
+		ready, _ := cellAt(r, h, "Ready").(string)
+		if status := cellAt(r, h, "Status"); status == render.PhaseCompleted {
 			return StatusOK
-		} else if !isReady(r.Cells[indexOf("Ready", h)].(string)) || status != render.PhaseRunning {
+		} else if !isReady(ready) || status != render.PhaseRunning {
 			return DegradedStatus
 		}
 	case client.DpGVR, client.StsGVR:
-		if !isReady(r.Cells[indexOf("Ready", h)].(string)) {
+		ready, _ := cellAt(r, h, "Ready").(string)
+		if !isReady(ready) {
 			return DegradedStatus
 		}
 	case client.RsGVR, client.DsGVR:
-		rd, ok1 := r.Cells[indexOf("Ready", h)].(int64)
-		de, ok2 := r.Cells[indexOf("Desired", h)].(int64)
+		rd, ok1 := cellAt(r, h, "Ready").(int64)
+		de, ok2 := cellAt(r, h, "Desired").(int64)
 		if ok1 && ok2 {
 			if !isReady(fmt.Sprintf("%d/%d", rd, de)) {
 				return DegradedStatus
 			}
 			break
 		}
-		rds, oks1 := r.Cells[indexOf("Ready", h)].(string)
-		des, oks2 := r.Cells[indexOf("Desired", h)].(string)
+		rds, oks1 := cellAt(r, h, "Ready").(string)
+		des, oks2 := cellAt(r, h, "Desired").(string)
 		if oks1 && oks2 {
 			if !isReady(fmt.Sprintf("%s/%s", rds, des)) {
 				return DegradedStatus
@@ -228,4 +261,16 @@ func indexOf(n string, defs []metav1.TableColumnDefinition) int {
 	}
 
 	return -1
+}
+
+// cellAt safely returns the cell value for the named column or nil when the
+// column is absent or out of range. This guards against resources (notably
+// CRDs) whose printer columns differ from the native workload resources.
+func cellAt(r *metav1.TableRow, defs []metav1.TableColumnDefinition, col string) any {
+	idx := indexOf(col, defs)
+	if idx < 0 || idx >= len(r.Cells) {
+		return nil
+	}
+
+	return r.Cells[idx]
 }

--- a/internal/dao/workload.go
+++ b/internal/dao/workload.go
@@ -93,33 +93,66 @@ func (a *Workload) fetch(ctx context.Context, gvr *client.GVR, ns string) (*meta
 	return tt, nil
 }
 
+// workloadGVR pairs a GVR with an optional namespace override. When ns is
+// empty, the aggregated view's active namespace is used for that resource.
+type workloadGVR struct {
+	gvr *client.GVR
+	ns  string
+}
+
 // workloadGVRs resolves the set of GVRs the workload view should aggregate.
 // It prefers a user-configured set (via the view config carried in the
 // context) and falls back to the built-in defaults for backward
-// compatibility.
-func workloadGVRs(ctx context.Context) []*client.GVR {
+// compatibility. Each configured entry is "<gvr>" or "<gvr> <namespace>"
+// (k9s prompt style), so a resource can be pinned to a specific namespace
+// independent of the view's active namespace.
+func workloadGVRs(ctx context.Context) []workloadGVR {
 	cv, ok := ctx.Value(internal.KeyViewConfig).(*config.CustomView)
 	if !ok || cv == nil {
-		return resList
+		return defaultWorkloadGVRs()
 	}
 	names, ok := cv.WorkloadGVRs(config.DefaultWorkloadGVRs)
 	if !ok {
-		return resList
+		return defaultWorkloadGVRs()
 	}
 
-	gvrs := make([]*client.GVR, 0, len(names))
+	ww := make([]workloadGVR, 0, len(names))
 	for _, n := range names {
-		gvrs = append(gvrs, client.NewGVR(n))
+		fields := strings.Fields(n)
+		if len(fields) == 0 {
+			continue
+		}
+		w := workloadGVR{gvr: client.NewGVR(fields[0])}
+		if len(fields) > 1 {
+			w.ns = fields[1]
+		}
+		ww = append(ww, w)
 	}
 
-	return gvrs
+	return ww
+}
+
+// defaultWorkloadGVRs wraps the built-in resource list as workloadGVRs with no
+// namespace override.
+func defaultWorkloadGVRs() []workloadGVR {
+	ww := make([]workloadGVR, 0, len(resList))
+	for _, g := range resList {
+		ww = append(ww, workloadGVR{gvr: g})
+	}
+
+	return ww
 }
 
 // List fetch workloads.
 func (a *Workload) List(ctx context.Context, ns string) ([]runtime.Object, error) {
 	oo := make([]runtime.Object, 0, 100)
-	for _, gvr := range workloadGVRs(ctx) {
-		table, err := a.fetch(ctx, gvr, ns)
+	for _, w := range workloadGVRs(ctx) {
+		gvr := w.gvr
+		fetchNS := ns
+		if w.ns != "" {
+			fetchNS = w.ns
+		}
+		table, err := a.fetch(ctx, gvr, fetchNS)
 		if err != nil {
 			// A configured GVR may be absent in this cluster (e.g. CRD not
 			// installed) or transiently unavailable. Skip it rather than

--- a/internal/dao/workload.go
+++ b/internal/dao/workload.go
@@ -78,19 +78,36 @@ func (w *Workload) Delete(ctx context.Context, path string, propagation *metav1.
 
 func (a *Workload) fetch(ctx context.Context, gvr *client.GVR, ns string) (*metav1.Table, error) {
 	a.gvr = gvr
-	oo, err := a.Table.List(ctx, ns)
-	if err != nil {
-		return nil, err
+	// ns may be a comma-separated list of namespaces (e.g. "ns1,ns2"); fetch
+	// each and merge their rows so one resource can span several namespaces.
+	// A namespace that fails (typo, no access) is skipped, not fatal.
+	var out *metav1.Table
+	for _, n := range strings.Split(ns, ",") {
+		n = strings.TrimSpace(n)
+		oo, err := a.Table.List(ctx, n)
+		if err != nil {
+			slog.Warn("Skipping namespace for workload resource",
+				"gvr", gvr.String(), "namespace", n, slogs.Error, err)
+			continue
+		}
+		if len(oo) == 0 {
+			continue
+		}
+		tt, ok := oo[0].(*metav1.Table)
+		if !ok {
+			return nil, errors.New("not a metav1.Table")
+		}
+		if out == nil {
+			out = tt
+		} else {
+			out.Rows = append(out.Rows, tt.Rows...)
+		}
 	}
-	if len(oo) == 0 {
+	if out == nil {
 		return nil, fmt.Errorf("no table found for gvr: %s", gvr)
 	}
-	tt, ok := oo[0].(*metav1.Table)
-	if !ok {
-		return nil, errors.New("not a metav1.Table")
-	}
 
-	return tt, nil
+	return out, nil
 }
 
 // workloadGVR pairs a GVR with an optional namespace override. When ns is

--- a/internal/dao/workload.go
+++ b/internal/dao/workload.go
@@ -121,7 +121,13 @@ func (a *Workload) List(ctx context.Context, ns string) ([]runtime.Object, error
 	for _, gvr := range workloadGVRs(ctx) {
 		table, err := a.fetch(ctx, gvr, ns)
 		if err != nil {
-			return nil, err
+			// A configured GVR may be absent in this cluster (e.g. CRD not
+			// installed) or transiently unavailable. Skip it rather than
+			// failing the whole aggregated view, so the resources that DO
+			// exist still render.
+			slog.Warn("Skipping unavailable workload resource",
+				"gvr", gvr.String(), slogs.Error, err)
+			continue
 		}
 		var (
 			ns string

--- a/internal/dao/workload_test.go
+++ b/internal/dao/workload_test.go
@@ -158,15 +158,15 @@ func TestWorkloadReadiness(t *testing.T) {
 func TestWorkloadGVRs(t *testing.T) {
 	uu := map[string]struct {
 		ctx context.Context
-		e   []*client.GVR
+		e   []workloadGVR
 	}{
 		"no-config-uses-defaults": {
 			ctx: context.Background(),
-			e:   resList,
+			e:   defaultWorkloadGVRs(),
 		},
 		"empty-config-uses-defaults": {
 			ctx: context.WithValue(context.Background(), internal.KeyViewConfig, config.NewCustomView()),
-			e:   resList,
+			e:   defaultWorkloadGVRs(),
 		},
 		"override": {
 			ctx: func() context.Context {
@@ -177,9 +177,23 @@ func TestWorkloadGVRs(t *testing.T) {
 				}
 				return context.WithValue(context.Background(), internal.KeyViewConfig, cv)
 			}(),
-			e: []*client.GVR{
-				client.PodGVR,
-				client.NewGVR("examples.demo.io/v1/foos"),
+			e: []workloadGVR{
+				{gvr: client.PodGVR},
+				{gvr: client.NewGVR("examples.demo.io/v1/foos")},
+			},
+		},
+		"per-namespace-override": {
+			ctx: func() context.Context {
+				cv := config.NewCustomView()
+				cv.Workloads[config.DefaultWorkloadGVRs] = []string{
+					"v1/pods kube-system",
+					"examples.demo.io/v1/foos",
+				}
+				return context.WithValue(context.Background(), internal.KeyViewConfig, cv)
+			}(),
+			e: []workloadGVR{
+				{gvr: client.PodGVR, ns: "kube-system"},
+				{gvr: client.NewGVR("examples.demo.io/v1/foos")},
 			},
 		},
 	}

--- a/internal/dao/workload_test.go
+++ b/internal/dao/workload_test.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+import (
+	"context"
+	"testing"
+
+	"github.com/derailed/k9s/internal"
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/render"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func cols(names ...string) []metav1.TableColumnDefinition {
+	dd := make([]metav1.TableColumnDefinition, 0, len(names))
+	for _, n := range names {
+		dd = append(dd, metav1.TableColumnDefinition{Name: n})
+	}
+	return dd
+}
+
+func TestCellAt(t *testing.T) {
+	defs := cols("Name", "Ready", "Status")
+	r := &metav1.TableRow{Cells: []any{"p1", "1/1", "Running"}}
+
+	uu := map[string]struct {
+		col string
+		e   any
+	}{
+		"present":     {col: "Name", e: "p1"},
+		"present-mid": {col: "Ready", e: "1/1"},
+		"missing":     {col: "Nope", e: nil},
+	}
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, cellAt(r, defs, u.col))
+		})
+	}
+}
+
+func TestCellAtShortRow(t *testing.T) {
+	// Column exists in defs but the row has fewer cells.
+	defs := cols("Name", "Ready", "Desired")
+	r := &metav1.TableRow{Cells: []any{"p1"}}
+	assert.Nil(t, cellAt(r, defs, "Desired"))
+}
+
+func TestWorkloadStatus(t *testing.T) {
+	uu := map[string]struct {
+		gvr  *client.GVR
+		defs []metav1.TableColumnDefinition
+		row  *metav1.TableRow
+		e    string
+	}{
+		"pod-running-ok": {
+			gvr:  client.PodGVR,
+			defs: cols("Name", "Ready", "Status"),
+			row:  &metav1.TableRow{Cells: []any{"p1", "1/1", render.PhaseRunning}},
+			e:    StatusOK,
+		},
+		"pod-completed-ok": {
+			gvr:  client.PodGVR,
+			defs: cols("Name", "Ready", "Status"),
+			row:  &metav1.TableRow{Cells: []any{"p1", "0/1", render.PhaseCompleted}},
+			e:    StatusOK,
+		},
+		"pod-not-ready-degraded": {
+			gvr:  client.PodGVR,
+			defs: cols("Name", "Ready", "Status"),
+			row:  &metav1.TableRow{Cells: []any{"p1", "0/1", render.PhaseRunning}},
+			e:    DegradedStatus,
+		},
+		"dp-ready-ok": {
+			gvr:  client.DpGVR,
+			defs: cols("Name", "Ready"),
+			row:  &metav1.TableRow{Cells: []any{"d1", "2/2"}},
+			e:    StatusOK,
+		},
+		"rs-degraded": {
+			gvr:  client.RsGVR,
+			defs: cols("Name", "Desired", "Ready"),
+			row:  &metav1.TableRow{Cells: []any{"r1", int64(3), int64(1)}},
+			e:    DegradedStatus,
+		},
+		// CRD with non-native printer columns must not panic and degrades to a
+		// placeholder status rather than crashing.
+		"crd-degrades-gracefully": {
+			gvr:  client.NewGVR("examples.demo.io/v1/foos"),
+			defs: cols("Name", "Phase", "Region"),
+			row:  &metav1.TableRow{Cells: []any{"foo1", "Active", "us-east"}},
+			e:    render.MissingValue,
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				assert.Equal(t, u.e, status(u.gvr, u.row, u.defs))
+			})
+		})
+	}
+}
+
+func TestWorkloadReadiness(t *testing.T) {
+	uu := map[string]struct {
+		gvr  *client.GVR
+		defs []metav1.TableColumnDefinition
+		row  *metav1.TableRow
+		e    string
+	}{
+		"pod": {
+			gvr:  client.PodGVR,
+			defs: cols("Name", "Ready"),
+			row:  &metav1.TableRow{Cells: []any{"p1", "1/1"}},
+			e:    "1/1",
+		},
+		"rs": {
+			gvr:  client.RsGVR,
+			defs: cols("Name", "Desired", "Ready"),
+			row:  &metav1.TableRow{Cells: []any{"r1", int64(2), int64(2)}},
+			e:    "2/2",
+		},
+		"svc-empty": {
+			gvr:  client.SvcGVR,
+			defs: cols("Name"),
+			row:  &metav1.TableRow{Cells: []any{"s1"}},
+			e:    "",
+		},
+		// CRD has no Ready column -> N/A, no panic.
+		"crd-na": {
+			gvr:  client.NewGVR("examples.demo.io/v1/foos"),
+			defs: cols("Name", "Phase"),
+			row:  &metav1.TableRow{Cells: []any{"foo1", "Active"}},
+			e:    render.NAValue,
+		},
+		// Native GVR but printer columns missing -> N/A instead of panic.
+		"pod-missing-col-na": {
+			gvr:  client.PodGVR,
+			defs: cols("Name"),
+			row:  &metav1.TableRow{Cells: []any{"p1"}},
+			e:    render.NAValue,
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				assert.Equal(t, u.e, readiness(u.gvr, u.row, u.defs))
+			})
+		})
+	}
+}
+
+func TestWorkloadGVRs(t *testing.T) {
+	uu := map[string]struct {
+		ctx context.Context
+		e   []*client.GVR
+	}{
+		"no-config-uses-defaults": {
+			ctx: context.Background(),
+			e:   resList,
+		},
+		"empty-config-uses-defaults": {
+			ctx: context.WithValue(context.Background(), internal.KeyViewConfig, config.NewCustomView()),
+			e:   resList,
+		},
+		"override": {
+			ctx: func() context.Context {
+				cv := config.NewCustomView()
+				cv.Workloads[config.DefaultWorkloadGVRs] = []string{
+					"v1/pods",
+					"examples.demo.io/v1/foos",
+				}
+				return context.WithValue(context.Background(), internal.KeyViewConfig, cv)
+			}(),
+			e: []*client.GVR{
+				client.PodGVR,
+				client.NewGVR("examples.demo.io/v1/foos"),
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, workloadGVRs(u.ctx))
+		})
+	}
+}

--- a/internal/render/workload.go
+++ b/internal/render/workload.go
@@ -5,6 +5,7 @@ package render
 
 import (
 	"fmt"
+	"hash/fnv"
 	"strings"
 
 	"github.com/derailed/k9s/internal/model1"
@@ -29,21 +30,37 @@ type Workload struct {
 	Base
 }
 
-// ColorerFunc colors a resource row.
+// wkKindColors tints workload rows by KIND so different resource types are
+// visually grouped: rows sharing a KIND share a color. Red is intentionally
+// omitted to avoid clashing with the DEGRADED warning color.
+var wkKindColors = []tcell.Color{
+	tcell.ColorTeal,
+	tcell.ColorNavy,
+	tcell.ColorOlive,
+	tcell.ColorPurple,
+	tcell.ColorGreen,
+	tcell.ColorBlue,
+	tcell.ColorFuchsia,
+	tcell.ColorAqua,
+}
+
+// ColorerFunc colors a resource row. DEGRADED status takes precedence;
+// otherwise each row is tinted by its KIND to visually separate the different
+// resource types aggregated in the workload view.
 func (Workload) ColorerFunc() model1.ColorerFunc {
 	return func(ns string, h model1.Header, re *model1.RowEvent) tcell.Color {
-		c := model1.DefaultColorer(ns, h, re)
-
-		idx, ok := h.IndexOf("STATUS", true)
-		if !ok {
-			return c
+		if idx, ok := h.IndexOf("STATUS", true); ok {
+			if strings.TrimSpace(re.Row.Fields[idx]) == "DEGRADED" {
+				return model1.PendingColor
+			}
 		}
-		status := strings.TrimSpace(re.Row.Fields[idx])
-		if status == "DEGRADED" {
-			c = model1.PendingColor
+		if idx, ok := h.IndexOf("KIND", true); ok {
+			hsh := fnv.New32a()
+			_, _ = hsh.Write([]byte(re.Row.Fields[idx]))
+			return wkKindColors[hsh.Sum32()%uint32(len(wkKindColors))]
 		}
 
-		return c
+		return model1.DefaultColorer(ns, h, re)
 	}
 }
 

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -639,6 +639,7 @@ func (b *Browser) defaultContext() context.Context {
 	}
 	ctx = context.WithValue(ctx, internal.KeyNamespace, client.CleanseNamespace(b.App().Config.ActiveNamespace()))
 	ctx = context.WithValue(ctx, internal.KeyWithMetrics, b.app.factory.Client().HasMetrics())
+	ctx = context.WithValue(ctx, internal.KeyViewConfig, b.app.CustomView())
 
 	return ctx
 }


### PR DESCRIPTION
## What

Adds an interactive `k9s watch` subcommand: connect to the cluster, discover native workloads and CRDs, let the user pick resources and a namespace for each, and write the selection into the workload (`:wk`) aggregation view in `views.yaml` — so users don't have to hand-edit the config.

## Depends on #4090

This is **stacked on #4090** (configurable workload view) — `k9s watch` writes the `workloads` config that #4090 introduces, so it can't stand alone. The diff here therefore includes #4090's commits; **the new work in this PR is `cmd/watch.go`, `cmd/watch_test.go`, and the `watchCmd()` registration in `cmd/root.go`.** Once #4090 merges, this rebases cleanly onto master.

## How

- `cmd/watch.go`: connects via the shared kube flags, discovers resources (native workloads + CRDs via discovery) and namespaces, runs a stdin Q&A wizard, then merges the selection into `views.yaml` while preserving existing content (the `views:` section and other workload sets).
- Each selected resource can be pinned to one or more namespaces (comma-joined), matching the per-resource namespace support in the workload view.
- Pure logic (selection parsing, entry assembly, yaml merge) is unit-tested in `cmd/watch_test.go`; the interactive/network parts are factored out behind `io.Reader`/`io.Writer` and a discovery interface.

## Example

```
$ k9s watch --context my-cluster
Discovered resources:
  Native workloads:
    1) v1/pods   2) apps/v1/deployments   ...
  Custom resources (CRDs):
    9) examples.demo.io/v1/foos
Select resources to aggregate (enter numbers, comma-separated): 1,9
Cluster namespaces:  1) default  4) kube-system ...
Namespace for "v1/pods"? (number or name, enter = follow view/all): kube-system
✅ Wrote .../views.yaml, run `k9s` then `:wk` to view.
```
