### PR TITLE
build: modernize snap packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,15 @@ Binaries for Linux, Windows and Mac are available as tarballs in the [release pa
 
 * Via [snap](https://snapcraft.io/k9s) for Linux
 
-  ```shell
-  snap install k9s --devmode
-  ```
+> [!WARNING]
+> The published snap is out of date and has several bugs.
+> If you want to use this method, clone the repository and build the snap locally:
+
+   ```shell
+   snap install snapcraft --classic
+   snapcraft pack
+   snap install ./k9s*.snap --classic --dangerous
+   ```
 
 * On Arch Linux
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,6 +20,7 @@ platforms:
 apps:
   k9s:
     command: bin/k9s
+    completer: k9s-completion.bash
 
 parts:
   k9s:
@@ -33,6 +34,7 @@ parts:
       make test
       make build
       install $SNAPCRAFT_PART_BUILD/execs/k9s -D $SNAPCRAFT_PART_INSTALL/bin/k9s
+      "${CRAFT_PART_INSTALL}/bin/k9s" completion bash > "${CRAFT_PART_INSTALL}/k9s-completion.bash"
     build-packages:
       - build-essential
     build-snaps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,29 +1,34 @@
 name: k9s
-base: core22
-version: 'v0.50.18'
+base: core26
 summary: K9s is a CLI to view and manage your Kubernetes clusters.
 description: |
   K9s is a CLI to view and manage your Kubernetes clusters. By leveraging a terminal UI, you can easily traverse Kubernetes resources and view the state of your clusters in a single powerful session.
+website: https://k9scli.io
+license: Apache-2.0
+source-code: https://github.com/derailed/k9s
+issues: https://github.com/derailed/k9s/issues
+adopt-info: k9s
 
 grade: stable
 confinement: classic
 
-architectures:
-  - amd64
-  - arm64
-  - armhf
-  - i386
+platforms:
+  amd64:
+  arm64:
+  armhf:
 
 apps:
   k9s:
     command: bin/k9s
 
 parts:
-  build:
+  k9s:
     plugin: go
     source: https://github.com/derailed/k9s
     source-type: git
-    source-tag: $SNAPCRAFT_PROJECT_VERSION
+    override-pull: |
+      craftctl default
+      craftctl set version=$(git describe --long --tags --always --match=v*.*.* | sed 's/v//')
     override-build: |
       make test
       make build


### PR DESCRIPTION
Hi! Big fan of K9s, I use it every day.

This PR modernizes the Snap packaging: `core26`, fetch version from git tag, add some missing metadata. I also cherry-picked @jrib's #2633.

Unfortuntely, merging this will not immediately help with the various issues that have been reported about http://snapcraft.io/k9s being out of date (#4074, #2800, #2712, #2622, #2470, #2264, #2128, #1873, #1339).

I see from https://github.com/derailed/k9s/issues/2267#issuecomment-1802535176 and https://github.com/derailed/k9s/pull/2633#issuecomment-2036886010 that the bottleneck has been the Canonical folks granting classic confinement to the snap, with the last attempt getting stale while waiting for @derailed to give some information.

Making k9s use strict confinement would be a major undertaking, and some functionality would be limited, so k9s is sadly stuck with classic confinement. To clarify the current status, I also updated the instructions in the README.

I know the process is a hassle, so if you want, I am happy to take over the snap maintenance if you trust me (we'd need to do a [transfer-ownership](https://forum.snapcraft.io/c/store-requests/transfer-ownership/30) request).

And if you are not okay with me maintaining the snap (which I would fully respect), merging this PR is beneficial anyway for folks who want to build the snap locally.

Disclaimer: I'm a Canonical employee.