### PR TITLE
Refactor crossplane resource trace commands

### DIFF
--- a/plugins/crossplane.yaml
+++ b/plugins/crossplane.yaml
@@ -12,7 +12,6 @@ plugins:
     args:
       - -c
       - 'NS="$NAMESPACE"; if [ "$NS" = "-" ] || [ -z "$NS" ]; then crossplane resource trace -c "$CONTEXT" "${RESOURCE_NAME}.${RESOURCE_GROUP}" "$NAME" -o wide | less -K; else crossplane resource trace -c "$CONTEXT" -n "$NS" "${RESOURCE_NAME}.${RESOURCE_GROUP}" "$NAME" -o wide | less -K; fi'
-  # crossplane-watch requires 'crossplane' cli and 'viddy' binaries installed
   crossplane-watch:
     shortCut: w
     confirm: false
@@ -22,6 +21,6 @@ plugins:
     command: sh
     background: false
     args:
-      - -c
-      - 'NS="$NAMESPACE"; if [ "$NS" = "-" ] || [ -z "$NS" ]; then crossplane resource trace -c "$CONTEXT" "${RESOURCE_NAME}.${RESOURCE_GROUP}" "$NAME" -o wide -w; else crossplane resource trace -c "$CONTEXT" -n "$NS" "${RESOURCE_NAME}.${RESOURCE_GROUP}" "$NAME" -o wide -w; fi'
-
+        - -c
+        - |
+          NS="$NAMESPACE"; if [ "$NS" = "-" ] || [ -z "$NS" ]; then viddy -- crossplane resource trace -c "$CONTEXT" "${RESOURCE_NAME}.${RESOURCE_GROUP}" "$NAME" -o wide; else viddy -- crossplane resource trace -c "$CONTEXT" -n "$NS" "${RESOURCE_NAME}.${RESOURCE_GROUP}" "$NAME" -o wide; fi


### PR DESCRIPTION
Updated crossplane resource trace commands to use 'viddy' for output, because watch default lot of problems