### PR TITLE
feat: auto theme switching based on OS dark/light mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ cov.out
 execs
 /k9s
 /k8s
+k9s-dev
 dist
 notes
 vendor

--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -41,6 +41,8 @@
             "noIcons": {"type": "boolean"},
             "reactive": {"type": "boolean"},
             "skin": {"type": "string"},
+            "darkSkin": {"type": "string"},
+            "lightSkin": {"type": "string"},
             "defaultsToFullScreen": {"type": "boolean"},
             "useFullGVRTitle": {"type": "boolean"},
             "invert": {"type": "boolean"}

--- a/internal/config/theme_detect.go
+++ b/internal/config/theme_detect.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -16,14 +17,33 @@ func IsDarkMode() bool {
 		out, err := exec.Command("defaults", "read", "-g", "AppleInterfaceStyle").Output()
 		return err == nil && strings.TrimSpace(string(out)) == "Dark"
 	case "linux":
+		if isWSL() {
+			// WSL has no OS-level appearance of its own; it inherits the Windows host's.
+			return windowsRegDarkMode("reg.exe")
+		}
 		// ponytail: GNOME only via gsettings; add KDE/xdg-desktop-portal support when needed
 		out, err := exec.Command("gsettings", "get", "org.gnome.desktop.interface", "color-scheme").Output()
 		return err == nil && strings.Contains(string(out), "dark")
 	case "windows":
-		out, err := exec.Command("reg", "query",
-			`HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize`,
-			"/v", "AppsUseLightTheme").Output()
-		return err == nil && strings.Contains(string(out), "0x0")
+		return windowsRegDarkMode("reg")
 	}
 	return false
+}
+
+// isWSL reports whether we're running inside Windows Subsystem for Linux.
+func isWSL() bool {
+	if os.Getenv("WSL_DISTRO_NAME") != "" {
+		return true
+	}
+	b, err := os.ReadFile("/proc/version")
+	return err == nil && strings.Contains(strings.ToLower(string(b)), "microsoft")
+}
+
+// windowsRegDarkMode queries the Windows dark-mode registry key via bin,
+// which is "reg" natively on Windows or "reg.exe" reached through WSL interop.
+func windowsRegDarkMode(bin string) bool {
+	out, err := exec.Command(bin, "query",
+		`HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize`,
+		"/v", "AppsUseLightTheme").Output()
+	return err == nil && strings.Contains(string(out), "0x0")
 }

--- a/internal/config/theme_detect.go
+++ b/internal/config/theme_detect.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package config
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// IsDarkMode reports whether the OS is currently in dark mode.
+func IsDarkMode() bool {
+	switch runtime.GOOS {
+	case "darwin":
+		out, err := exec.Command("defaults", "read", "-g", "AppleInterfaceStyle").Output()
+		return err == nil && strings.TrimSpace(string(out)) == "Dark"
+	case "linux":
+		// ponytail: GNOME only via gsettings; add KDE/xdg-desktop-portal support when needed
+		out, err := exec.Command("gsettings", "get", "org.gnome.desktop.interface", "color-scheme").Output()
+		return err == nil && strings.Contains(string(out), "dark")
+	case "windows":
+		out, err := exec.Command("reg", "query",
+			`HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize`,
+			"/v", "AppsUseLightTheme").Output()
+		return err == nil && strings.Contains(string(out), "0x0")
+	}
+	return false
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -44,6 +44,14 @@ type UI struct {
 	// Can be overridden per context.
 	Skin string `json:"skin" yaml:"skin,omitempty"`
 
+	// DarkSkin is the skin to use when the OS is in dark mode.
+	// Takes priority over Skin and context skins when set.
+	DarkSkin string `json:"darkSkin" yaml:"darkSkin,omitempty"`
+
+	// LightSkin is the skin to use when the OS is in light mode.
+	// Takes priority over Skin and context skins when set.
+	LightSkin string `json:"lightSkin" yaml:"lightSkin,omitempty"`
+
 	// DefaultsToFullScreen toggles fullscreen on views like logs, yaml, details.
 	DefaultsToFullScreen bool `json:"defaultsToFullScreen" yaml:"defaultsToFullScreen"`
 

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/derailed/k9s/internal/config"
 	"github.com/derailed/k9s/internal/model"
@@ -259,6 +260,19 @@ func (c *Configurator) activeSkin() (string, bool) {
 		}
 	}
 
+	if c.Config.K9s.UI.DarkSkin != "" || c.Config.K9s.UI.LightSkin != "" {
+		skin = c.Config.K9s.UI.LightSkin
+		if config.IsDarkMode() {
+			skin = c.Config.K9s.UI.DarkSkin
+		}
+		if skin != "" {
+			if _, err := os.Stat(config.SkinFileFromName(skin)); err == nil {
+				slog.Debug("Loading auto-theme skin", slogs.Skin, skin)
+				return skin, true
+			}
+		}
+	}
+
 	if ct, err := c.Config.K9s.ActiveContext(); err == nil && ct.Skin != "" {
 		if _, err := os.Stat(config.SkinFileFromName(ct.Skin)); err == nil {
 			skin = ct.Skin
@@ -351,6 +365,31 @@ func (c *Configurator) loadSkinFile(synchronizer) {
 	} else {
 		c.updateStyles(skinFile, invert)
 	}
+}
+
+// ThemeWatcher polls the OS dark/light mode every 5s and reloads the skin on change.
+// No-op if neither DarkSkin nor LightSkin is configured.
+func (c *Configurator) ThemeWatcher(ctx context.Context, s synchronizer) {
+	if c.Config.K9s.UI.DarkSkin == "" && c.Config.K9s.UI.LightSkin == "" {
+		return
+	}
+	// ponytail: 2s poll; switch to OS notification API (e.g. dbus/NSDistributedNotificationCenter) if latency matters
+	go func() {
+		last := config.IsDarkMode()
+		t := time.NewTicker(2 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				if dark := config.IsDarkMode(); dark != last {
+					last = dark
+					s.QueueUpdateDraw(func() { c.RefreshStyles(s) })
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 }
 
 func (c *Configurator) updateStyles(f string, invert bool) {

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -344,6 +344,7 @@ func (a *App) Resume() {
 	ctx, a.cancelFn = context.WithCancel(context.Background())
 
 	go a.clusterUpdater(ctx)
+	a.ThemeWatcher(ctx, a)
 
 	if a.Config.K9s.UI.Reactive {
 		if err := a.ConfigWatcher(ctx, a); err != nil {


### PR DESCRIPTION
## Summary

Fixes #4102 — adds automatic skin switching when the OS toggles between dark and light mode.

- Adds `darkSkin` and `lightSkin` fields to the `UI` config section
- At startup, k9s detects the current OS appearance and loads the appropriate skin
- A background poller (2s interval) watches for OS-level changes and reloads the skin on the fly — no restart needed

### Config example

```yaml
# ~/.config/k9s/config.yaml
k9s:
  ui:
    darkSkin: my-dark-theme
    lightSkin: my-light-theme
```

### Platform support

| OS | Detection method |
|----|-----------------|
| macOS | `defaults read -g AppleInterfaceStyle` |
| Linux (GNOME) | `gsettings get org.gnome.desktop.interface color-scheme` |
| Windows | `HKCU\...\Themes\Personalize` → `AppsUseLightTheme` registry key |

### Notes

- When neither `darkSkin` nor `lightSkin` is set, behaviour is identical to today — zero overhead
- The poller only starts when at least one of the fields is configured
- Linux detection is GNOME-only for now; KDE/xdg-desktop-portal can be added in a follow-up
- Tested on macOS; Linux and Windows paths follow the same OS query patterns used by other tools

## Test plan

- [ ] Set `darkSkin` / `lightSkin` in config, toggle OS appearance, confirm skin swaps within ~2s
- [ ] Leave both fields unset, confirm no behaviour change
- [ ] Set only `darkSkin`, confirm it loads in dark mode and falls back to `skin` / context skin in light mode
- [ ] Set only `lightSkin`, confirm symmetric behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)