### PR TITLE
Add Modus theme skins

### DIFF
--- a/skins/modus-operandi-deuteranopia.yaml
+++ b/skins/modus-operandi-deuteranopia.yaml
@@ -1,0 +1,128 @@
+# -----------------------------------------------------------------------------
+# Modus Operandi Deuteranopia skin for k9s
+#
+# Light theme tuned for red-green color deficiency (blue/yellow axis).
+# Theme by Protesilaos Stavrou: https://protesilaos.com/emacs/modus-themes
+# Colors taken from the official modus-themes palette.
+# -----------------------------------------------------------------------------
+
+# Palette (semantic roles)...
+foreground: &foreground "#000000"
+background: &background "#ffffff"
+panel: &panel "#f2f2f2"
+subtle: &subtle "#e0e0e0"
+faint: &faint "#595959"
+border: &border "#9f9f9f"
+accent: &accent "#0031a9"
+key: &key "#0000b0"
+string: &string "#3548cf"
+builtin: &builtin "#721045"
+logo: &logo "#0000b0"
+cursor: &cursor "#0000ff"
+addColor: &add "#0031a9"
+newColor: &new "#005e8b"
+modifyColor: &modify "#695500"
+errorColor: &error "#a60000"
+warnColor: &warn "#973300"
+killColor: &kill "#721045"
+
+# Skin...
+k9s:
+  body:
+    fgColor: *foreground
+    bgColor: *background
+    logoColor: *logo
+  prompt:
+    fgColor: *foreground
+    bgColor: *panel
+    suggestColor: *accent
+  info:
+    fgColor: *faint
+    sectionColor: *accent
+    cpuColor: *accent
+    memColor: *builtin
+  help:
+    fgColor: *foreground
+    bgColor: *panel
+    keyColor: *key
+    numKeyColor: *builtin
+    sectionColor: *accent
+  dialog:
+    fgColor: *foreground
+    bgColor: *panel
+    buttonFgColor: *background
+    buttonBgColor: *accent
+    buttonFocusFgColor: *background
+    buttonFocusBgColor: *builtin
+    labelFgColor: *warn
+    fieldFgColor: *foreground
+  frame:
+    border:
+      fgColor: *border
+      focusColor: *accent
+    menu:
+      fgColor: *foreground
+      keyColor: *key
+      numKeyColor: *builtin
+    crumbs:
+      fgColor: *background
+      bgColor: *accent
+      activeColor: *warn
+    status:
+      newColor: *new
+      modifyColor: *modify
+      addColor: *add
+      errorColor: *error
+      pendingColor: *warn
+      highlightColor: *accent
+      killColor: *kill
+      completedColor: *faint
+    title:
+      fgColor: *accent
+      bgColor: *panel
+      highlightColor: *builtin
+      counterColor: *foreground
+      filterColor: *key
+  views:
+    charts:
+      bgColor: *background
+      defaultDialColors:
+        - *accent
+        - *error
+      defaultChartColors:
+        - *accent
+        - *error
+    table:
+      fgColor: *foreground
+      bgColor: *background
+      cursorFgColor: *background
+      cursorBgColor: *cursor
+      markColor: *warn
+      header:
+        fgColor: *faint
+        bgColor: *background
+        sorterColor: *accent
+    xray:
+      fgColor: *foreground
+      bgColor: *background
+      cursorColor: *cursor
+      cursorTextColor: *background
+      graphicColor: *builtin
+      showIcons: false
+    yaml:
+      keyColor: *key
+      colonColor: *faint
+      valueColor: *foreground
+    logs:
+      fgColor: *foreground
+      bgColor: *background
+      indicator:
+        fgColor: *background
+        bgColor: *accent
+        toggleOnColor: *add
+        toggleOffColor: *faint
+    help:
+      fgColor: *foreground
+      bgColor: *panel
+      indicator:
+        fgColor: *accent

--- a/skins/modus-operandi-tinted.yaml
+++ b/skins/modus-operandi-tinted.yaml
@@ -1,0 +1,128 @@
+# -----------------------------------------------------------------------------
+# Modus Operandi Tinted skin for k9s
+#
+# Light theme with warm, subtly tinted backgrounds.
+# Theme by Protesilaos Stavrou: https://protesilaos.com/emacs/modus-themes
+# Colors taken from the official modus-themes palette.
+# -----------------------------------------------------------------------------
+
+# Palette (semantic roles)...
+foreground: &foreground "#000000"
+background: &background "#fbf7f0"
+panel: &panel "#efe9dd"
+subtle: &subtle "#dfd5cf"
+faint: &faint "#595959"
+border: &border "#9f9690"
+accent: &accent "#006300"
+key: &key "#0000b0"
+string: &string "#00598b"
+builtin: &builtin "#721045"
+logo: &logo "#721045"
+cursor: &cursor "#d00000"
+addColor: &add "#006300"
+newColor: &new "#00598b"
+modifyColor: &modify "#6d5000"
+errorColor: &error "#a60000"
+warnColor: &warn "#894000"
+killColor: &kill "#721045"
+
+# Skin...
+k9s:
+  body:
+    fgColor: *foreground
+    bgColor: *background
+    logoColor: *logo
+  prompt:
+    fgColor: *foreground
+    bgColor: *panel
+    suggestColor: *accent
+  info:
+    fgColor: *faint
+    sectionColor: *accent
+    cpuColor: *accent
+    memColor: *builtin
+  help:
+    fgColor: *foreground
+    bgColor: *panel
+    keyColor: *key
+    numKeyColor: *builtin
+    sectionColor: *accent
+  dialog:
+    fgColor: *foreground
+    bgColor: *panel
+    buttonFgColor: *background
+    buttonBgColor: *accent
+    buttonFocusFgColor: *background
+    buttonFocusBgColor: *builtin
+    labelFgColor: *warn
+    fieldFgColor: *foreground
+  frame:
+    border:
+      fgColor: *border
+      focusColor: *accent
+    menu:
+      fgColor: *foreground
+      keyColor: *key
+      numKeyColor: *builtin
+    crumbs:
+      fgColor: *background
+      bgColor: *accent
+      activeColor: *warn
+    status:
+      newColor: *new
+      modifyColor: *modify
+      addColor: *add
+      errorColor: *error
+      pendingColor: *warn
+      highlightColor: *accent
+      killColor: *kill
+      completedColor: *faint
+    title:
+      fgColor: *accent
+      bgColor: *panel
+      highlightColor: *builtin
+      counterColor: *foreground
+      filterColor: *key
+  views:
+    charts:
+      bgColor: *background
+      defaultDialColors:
+        - *accent
+        - *error
+      defaultChartColors:
+        - *accent
+        - *error
+    table:
+      fgColor: *foreground
+      bgColor: *background
+      cursorFgColor: *background
+      cursorBgColor: *cursor
+      markColor: *warn
+      header:
+        fgColor: *faint
+        bgColor: *background
+        sorterColor: *accent
+    xray:
+      fgColor: *foreground
+      bgColor: *background
+      cursorColor: *cursor
+      cursorTextColor: *background
+      graphicColor: *builtin
+      showIcons: false
+    yaml:
+      keyColor: *key
+      colonColor: *faint
+      valueColor: *foreground
+    logs:
+      fgColor: *foreground
+      bgColor: *background
+      indicator:
+        fgColor: *background
+        bgColor: *accent
+        toggleOnColor: *add
+        toggleOffColor: *faint
+    help:
+      fgColor: *foreground
+      bgColor: *panel
+      indicator:
+        fgColor: *accent

--- a/skins/modus-operandi-tritanopia.yaml
+++ b/skins/modus-operandi-tritanopia.yaml
@@ -1,0 +1,128 @@
+# -----------------------------------------------------------------------------
+# Modus Operandi Tritanopia skin for k9s
+#
+# Light theme tuned for blue-yellow color deficiency (red/cyan axis).
+# Theme by Protesilaos Stavrou: https://protesilaos.com/emacs/modus-themes
+# Colors taken from the official modus-themes palette.
+# -----------------------------------------------------------------------------
+
+# Palette (semantic roles)...
+foreground: &foreground "#000000"
+background: &background "#ffffff"
+panel: &panel "#f2f2f2"
+subtle: &subtle "#e0e0e0"
+faint: &faint "#595959"
+border: &border "#9f9f9f"
+accent: &accent "#005e8b"
+key: &key "#005e8b"
+string: &string "#005e8b"
+builtin: &builtin "#721045"
+logo: &logo "#005e8b"
+cursor: &cursor "#d00000"
+addColor: &add "#006800"
+newColor: &new "#005e8b"
+modifyColor: &modify "#721045"
+errorColor: &error "#b21100"
+warnColor: &warn "#a0132f"
+killColor: &kill "#531ab6"
+
+# Skin...
+k9s:
+  body:
+    fgColor: *foreground
+    bgColor: *background
+    logoColor: *logo
+  prompt:
+    fgColor: *foreground
+    bgColor: *panel
+    suggestColor: *accent
+  info:
+    fgColor: *faint
+    sectionColor: *accent
+    cpuColor: *accent
+    memColor: *builtin
+  help:
+    fgColor: *foreground
+    bgColor: *panel
+    keyColor: *key
+    numKeyColor: *builtin
+    sectionColor: *accent
+  dialog:
+    fgColor: *foreground
+    bgColor: *panel
+    buttonFgColor: *background
+    buttonBgColor: *accent
+    buttonFocusFgColor: *background
+    buttonFocusBgColor: *builtin
+    labelFgColor: *warn
+    fieldFgColor: *foreground
+  frame:
+    border:
+      fgColor: *border
+      focusColor: *accent
+    menu:
+      fgColor: *foreground
+      keyColor: *key
+      numKeyColor: *builtin
+    crumbs:
+      fgColor: *background
+      bgColor: *accent
+      activeColor: *warn
+    status:
+      newColor: *new
+      modifyColor: *modify
+      addColor: *add
+      errorColor: *error
+      pendingColor: *warn
+      highlightColor: *accent
+      killColor: *kill
+      completedColor: *faint
+    title:
+      fgColor: *accent
+      bgColor: *panel
+      highlightColor: *builtin
+      counterColor: *foreground
+      filterColor: *key
+  views:
+    charts:
+      bgColor: *background
+      defaultDialColors:
+        - *accent
+        - *error
+      defaultChartColors:
+        - *accent
+        - *error
+    table:
+      fgColor: *foreground
+      bgColor: *background
+      cursorFgColor: *background
+      cursorBgColor: *cursor
+      markColor: *warn
+      header:
+        fgColor: *faint
+        bgColor: *background
+        sorterColor: *accent
+    xray:
+      fgColor: *foreground
+      bgColor: *background
+      cursorColor: *cursor
+      cursorTextColor: *background
+      graphicColor: *builtin
+      showIcons: false
+    yaml:
+      keyColor: *key
+      colonColor: *faint
+      valueColor: *foreground
+    logs:
+      fgColor: *foreground
+      bgColor: *background
+      indicator:
+        fgColor: *background
+        bgColor: *accent
+        toggleOnColor: *add
+        toggleOffColor: *faint
+    help:
+      fgColor: *foreground
+      bgColor: *panel
+      indicator:
+        fgColor: *accent

--- a/skins/modus-operandi.yaml
+++ b/skins/modus-operandi.yaml
@@ -1,0 +1,128 @@
+# -----------------------------------------------------------------------------
+# Modus Operandi skin for k9s
+#
+# Protesilaos Stavrou's main light theme (WCAG AAA contrast).
+# Theme by Protesilaos Stavrou: https://protesilaos.com/emacs/modus-themes
+# Colors taken from the official modus-themes palette.
+# -----------------------------------------------------------------------------
+
+# Palette (semantic roles)...
+foreground: &foreground "#000000"
+background: &background "#ffffff"
+panel: &panel "#f2f2f2"
+subtle: &subtle "#e0e0e0"
+faint: &faint "#595959"
+border: &border "#9f9f9f"
+accent: &accent "#005f5f"
+key: &key "#0000b0"
+string: &string "#3548cf"
+builtin: &builtin "#8f0075"
+logo: &logo "#8f0075"
+cursor: &cursor "#005f5f"
+addColor: &add "#006800"
+newColor: &new "#005e8b"
+modifyColor: &modify "#6f5500"
+errorColor: &error "#a60000"
+warnColor: &warn "#884900"
+killColor: &kill "#721045"
+
+# Skin...
+k9s:
+  body:
+    fgColor: *foreground
+    bgColor: *background
+    logoColor: *logo
+  prompt:
+    fgColor: *foreground
+    bgColor: *panel
+    suggestColor: *accent
+  info:
+    fgColor: *faint
+    sectionColor: *accent
+    cpuColor: *accent
+    memColor: *builtin
+  help:
+    fgColor: *foreground
+    bgColor: *panel
+    keyColor: *key
+    numKeyColor: *builtin
+    sectionColor: *accent
+  dialog:
+    fgColor: *foreground
+    bgColor: *panel
+    buttonFgColor: *background
+    buttonBgColor: *accent
+    buttonFocusFgColor: *background
+    buttonFocusBgColor: *builtin
+    labelFgColor: *warn
+    fieldFgColor: *foreground
+  frame:
+    border:
+      fgColor: *border
+      focusColor: *accent
+    menu:
+      fgColor: *foreground
+      keyColor: *key
+      numKeyColor: *builtin
+    crumbs:
+      fgColor: *background
+      bgColor: *accent
+      activeColor: *warn
+    status:
+      newColor: *new
+      modifyColor: *modify
+      addColor: *add
+      errorColor: *error
+      pendingColor: *warn
+      highlightColor: *accent
+      killColor: *kill
+      completedColor: *faint
+    title:
+      fgColor: *accent
+      bgColor: *panel
+      highlightColor: *builtin
+      counterColor: *foreground
+      filterColor: *key
+  views:
+    charts:
+      bgColor: *background
+      defaultDialColors:
+        - *accent
+        - *error
+      defaultChartColors:
+        - *accent
+        - *error
+    table:
+      fgColor: *foreground
+      bgColor: *background
+      cursorFgColor: *background
+      cursorBgColor: *cursor
+      markColor: *warn
+      header:
+        fgColor: *faint
+        bgColor: *background
+        sorterColor: *accent
+    xray:
+      fgColor: *foreground
+      bgColor: *background
+      cursorColor: *cursor
+      cursorTextColor: *background
+      graphicColor: *builtin
+      showIcons: false
+    yaml:
+      keyColor: *key
+      colonColor: *faint
+      valueColor: *foreground
+    logs:
+      fgColor: *foreground
+      bgColor: *background
+      indicator:
+        fgColor: *background
+        bgColor: *accent
+        toggleOnColor: *add
+        toggleOffColor: *faint
+    help:
+      fgColor: *foreground
+      bgColor: *panel
+      indicator:
+        fgColor: *accent

--- a/skins/modus-vivendi-deuteranopia.yaml
+++ b/skins/modus-vivendi-deuteranopia.yaml
@@ -1,0 +1,128 @@
+# -----------------------------------------------------------------------------
+# Modus Vivendi Deuteranopia skin for k9s
+#
+# Dark theme tuned for red-green color deficiency (blue/yellow axis).
+# Theme by Protesilaos Stavrou: https://protesilaos.com/emacs/modus-themes
+# Colors taken from the official modus-themes palette.
+# -----------------------------------------------------------------------------
+
+# Palette (semantic roles)...
+foreground: &foreground "#ffffff"
+background: &background "#000000"
+panel: &panel "#1e1e1e"
+subtle: &subtle "#303030"
+faint: &faint "#989898"
+border: &border "#646464"
+accent: &accent "#2fafff"
+key: &key "#00bcff"
+string: &string "#79a8ff"
+builtin: &builtin "#feacd0"
+logo: &logo "#79a8ff"
+cursor: &cursor "#efef00"
+addColor: &add "#2fafff"
+newColor: &new "#00d3d0"
+modifyColor: &modify "#cabf00"
+errorColor: &error "#ff5f59"
+warnColor: &warn "#ffa00f"
+killColor: &kill "#b6a0ff"
+
+# Skin...
+k9s:
+  body:
+    fgColor: *foreground
+    bgColor: *background
+    logoColor: *logo
+  prompt:
+    fgColor: *foreground
+    bgColor: *panel
+    suggestColor: *accent
+  info:
+    fgColor: *faint
+    sectionColor: *accent
+    cpuColor: *accent
+    memColor: *builtin
+  help:
+    fgColor: *foreground
+    bgColor: *panel
+    keyColor: *key
+    numKeyColor: *builtin
+    sectionColor: *accent
+  dialog:
+    fgColor: *foreground
+    bgColor: *panel
+    buttonFgColor: *background
+    buttonBgColor: *accent
+    buttonFocusFgColor: *background
+    buttonFocusBgColor: *builtin
+    labelFgColor: *warn
+    fieldFgColor: *foreground
+  frame:
+    border:
+      fgColor: *border
+      focusColor: *accent
+    menu:
+      fgColor: *foreground
+      keyColor: *key
+      numKeyColor: *builtin
+    crumbs:
+      fgColor: *background
+      bgColor: *accent
+      activeColor: *warn
+    status:
+      newColor: *new
+      modifyColor: *modify
+      addColor: *add
+      errorColor: *error
+      pendingColor: *warn
+      highlightColor: *accent
+      killColor: *kill
+      completedColor: *faint
+    title:
+      fgColor: *accent
+      bgColor: *panel
+      highlightColor: *builtin
+      counterColor: *foreground
+      filterColor: *key
+  views:
+    charts:
+      bgColor: *background
+      defaultDialColors:
+        - *accent
+        - *error
+      defaultChartColors:
+        - *accent
+        - *error
+    table:
+      fgColor: *foreground
+      bgColor: *background
+      cursorFgColor: *background
+      cursorBgColor: *cursor
+      markColor: *warn
+      header:
+        fgColor: *faint
+        bgColor: *background
+        sorterColor: *accent
+    xray:
+      fgColor: *foreground
+      bgColor: *background
+      cursorColor: *cursor
+      cursorTextColor: *background
+      graphicColor: *builtin
+      showIcons: false
+    yaml:
+      keyColor: *key
+      colonColor: *faint
+      valueColor: *foreground
+    logs:
+      fgColor: *foreground
+      bgColor: *background
+      indicator:
+        fgColor: *background
+        bgColor: *accent
+        toggleOnColor: *add
+        toggleOffColor: *faint
+    help:
+      fgColor: *foreground
+      bgColor: *panel
+      indicator:
+        fgColor: *accent

--- a/skins/modus-vivendi-tinted.yaml
+++ b/skins/modus-vivendi-tinted.yaml
@@ -1,0 +1,128 @@
+# -----------------------------------------------------------------------------
+# Modus Vivendi Tinted skin for k9s
+#
+# Dark theme with slightly warmer, tinted backgrounds.
+# Theme by Protesilaos Stavrou: https://protesilaos.com/emacs/modus-themes
+# Colors taken from the official modus-themes palette.
+# -----------------------------------------------------------------------------
+
+# Palette (semantic roles)...
+foreground: &foreground "#ffffff"
+background: &background "#0d0e1c"
+panel: &panel "#1d2235"
+subtle: &subtle "#2b3045"
+faint: &faint "#989898"
+border: &border "#61647a"
+accent: &accent "#11c777"
+key: &key "#00bcff"
+string: &string "#2fafff"
+builtin: &builtin "#feacd0"
+logo: &logo "#feacd0"
+cursor: &cursor "#ff66ff"
+addColor: &add "#44bc44"
+newColor: &new "#00d3d0"
+modifyColor: &modify "#d0bc00"
+errorColor: &error "#ff5f59"
+warnColor: &warn "#fec43f"
+killColor: &kill "#b6a0ff"
+
+# Skin...
+k9s:
+  body:
+    fgColor: *foreground
+    bgColor: *background
+    logoColor: *logo
+  prompt:
+    fgColor: *foreground
+    bgColor: *panel
+    suggestColor: *accent
+  info:
+    fgColor: *faint
+    sectionColor: *accent
+    cpuColor: *accent
+    memColor: *builtin
+  help:
+    fgColor: *foreground
+    bgColor: *panel
+    keyColor: *key
+    numKeyColor: *builtin
+    sectionColor: *accent
+  dialog:
+    fgColor: *foreground
+    bgColor: *panel
+    buttonFgColor: *background
+    buttonBgColor: *accent
+    buttonFocusFgColor: *background
+    buttonFocusBgColor: *builtin
+    labelFgColor: *warn
+    fieldFgColor: *foreground
+  frame:
+    border:
+      fgColor: *border
+      focusColor: *accent
+    menu:
+      fgColor: *foreground
+      keyColor: *key
+      numKeyColor: *builtin
+    crumbs:
+      fgColor: *background
+      bgColor: *accent
+      activeColor: *warn
+    status:
+      newColor: *new
+      modifyColor: *modify
+      addColor: *add
+      errorColor: *error
+      pendingColor: *warn
+      highlightColor: *accent
+      killColor: *kill
+      completedColor: *faint
+    title:
+      fgColor: *accent
+      bgColor: *panel
+      highlightColor: *builtin
+      counterColor: *foreground
+      filterColor: *key
+  views:
+    charts:
+      bgColor: *background
+      defaultDialColors:
+        - *accent
+        - *error
+      defaultChartColors:
+        - *accent
+        - *error
+    table:
+      fgColor: *foreground
+      bgColor: *background
+      cursorFgColor: *background
+      cursorBgColor: *cursor
+      markColor: *warn
+      header:
+        fgColor: *faint
+        bgColor: *background
+        sorterColor: *accent
+    xray:
+      fgColor: *foreground
+      bgColor: *background
+      cursorColor: *cursor
+      cursorTextColor: *background
+      graphicColor: *builtin
+      showIcons: false
+    yaml:
+      keyColor: *key
+      colonColor: *faint
+      valueColor: *foreground
+    logs:
+      fgColor: *foreground
+      bgColor: *background
+      indicator:
+        fgColor: *background
+        bgColor: *accent
+        toggleOnColor: *add
+        toggleOffColor: *faint
+    help:
+      fgColor: *foreground
+      bgColor: *panel
+      indicator:
+        fgColor: *accent

--- a/skins/modus-vivendi-tritanopia.yaml
+++ b/skins/modus-vivendi-tritanopia.yaml
@@ -1,0 +1,128 @@
+# -----------------------------------------------------------------------------
+# Modus Vivendi Tritanopia skin for k9s
+#
+# Dark theme tuned for blue-yellow color deficiency (red/cyan axis).
+# Theme by Protesilaos Stavrou: https://protesilaos.com/emacs/modus-themes
+# Colors taken from the official modus-themes palette.
+# -----------------------------------------------------------------------------
+
+# Palette (semantic roles)...
+foreground: &foreground "#ffffff"
+background: &background "#000000"
+panel: &panel "#1e1e1e"
+subtle: &subtle "#303030"
+faint: &faint "#989898"
+border: &border "#646464"
+accent: &accent "#00d3d0"
+key: &key "#00d3d0"
+string: &string "#00d3d0"
+builtin: &builtin "#feacd0"
+logo: &logo "#00d3d0"
+cursor: &cursor "#ff5f5f"
+addColor: &add "#44bc44"
+newColor: &new "#00d3d0"
+modifyColor: &modify "#feacd0"
+errorColor: &error "#ff6740"
+warnColor: &warn "#ff7f86"
+killColor: &kill "#b6a0ff"
+
+# Skin...
+k9s:
+  body:
+    fgColor: *foreground
+    bgColor: *background
+    logoColor: *logo
+  prompt:
+    fgColor: *foreground
+    bgColor: *panel
+    suggestColor: *accent
+  info:
+    fgColor: *faint
+    sectionColor: *accent
+    cpuColor: *accent
+    memColor: *builtin
+  help:
+    fgColor: *foreground
+    bgColor: *panel
+    keyColor: *key
+    numKeyColor: *builtin
+    sectionColor: *accent
+  dialog:
+    fgColor: *foreground
+    bgColor: *panel
+    buttonFgColor: *background
+    buttonBgColor: *accent
+    buttonFocusFgColor: *background
+    buttonFocusBgColor: *builtin
+    labelFgColor: *warn
+    fieldFgColor: *foreground
+  frame:
+    border:
+      fgColor: *border
+      focusColor: *accent
+    menu:
+      fgColor: *foreground
+      keyColor: *key
+      numKeyColor: *builtin
+    crumbs:
+      fgColor: *background
+      bgColor: *accent
+      activeColor: *warn
+    status:
+      newColor: *new
+      modifyColor: *modify
+      addColor: *add
+      errorColor: *error
+      pendingColor: *warn
+      highlightColor: *accent
+      killColor: *kill
+      completedColor: *faint
+    title:
+      fgColor: *accent
+      bgColor: *panel
+      highlightColor: *builtin
+      counterColor: *foreground
+      filterColor: *key
+  views:
+    charts:
+      bgColor: *background
+      defaultDialColors:
+        - *accent
+        - *error
+      defaultChartColors:
+        - *accent
+        - *error
+    table:
+      fgColor: *foreground
+      bgColor: *background
+      cursorFgColor: *background
+      cursorBgColor: *cursor
+      markColor: *warn
+      header:
+        fgColor: *faint
+        bgColor: *background
+        sorterColor: *accent
+    xray:
+      fgColor: *foreground
+      bgColor: *background
+      cursorColor: *cursor
+      cursorTextColor: *background
+      graphicColor: *builtin
+      showIcons: false
+    yaml:
+      keyColor: *key
+      colonColor: *faint
+      valueColor: *foreground
+    logs:
+      fgColor: *foreground
+      bgColor: *background
+      indicator:
+        fgColor: *background
+        bgColor: *accent
+        toggleOnColor: *add
+        toggleOffColor: *faint
+    help:
+      fgColor: *foreground
+      bgColor: *panel
+      indicator:
+        fgColor: *accent

--- a/skins/modus-vivendi.yaml
+++ b/skins/modus-vivendi.yaml
@@ -1,0 +1,128 @@
+# -----------------------------------------------------------------------------
+# Modus Vivendi skin for k9s
+#
+# Protesilaos Stavrou's main dark theme (WCAG AAA contrast).
+# Theme by Protesilaos Stavrou: https://protesilaos.com/emacs/modus-themes
+# Colors taken from the official modus-themes palette.
+# -----------------------------------------------------------------------------
+
+# Palette (semantic roles)...
+foreground: &foreground "#ffffff"
+background: &background "#000000"
+panel: &panel "#1e1e1e"
+subtle: &subtle "#303030"
+faint: &faint "#989898"
+border: &border "#646464"
+accent: &accent "#6ae4b9"
+key: &key "#00bcff"
+string: &string "#79a8ff"
+builtin: &builtin "#f78fe7"
+logo: &logo "#f78fe7"
+cursor: &cursor "#00eff0"
+addColor: &add "#44bc44"
+newColor: &new "#00d3d0"
+modifyColor: &modify "#d0bc00"
+errorColor: &error "#ff5f59"
+warnColor: &warn "#fec43f"
+killColor: &kill "#b6a0ff"
+
+# Skin...
+k9s:
+  body:
+    fgColor: *foreground
+    bgColor: *background
+    logoColor: *logo
+  prompt:
+    fgColor: *foreground
+    bgColor: *panel
+    suggestColor: *accent
+  info:
+    fgColor: *faint
+    sectionColor: *accent
+    cpuColor: *accent
+    memColor: *builtin
+  help:
+    fgColor: *foreground
+    bgColor: *panel
+    keyColor: *key
+    numKeyColor: *builtin
+    sectionColor: *accent
+  dialog:
+    fgColor: *foreground
+    bgColor: *panel
+    buttonFgColor: *background
+    buttonBgColor: *accent
+    buttonFocusFgColor: *background
+    buttonFocusBgColor: *builtin
+    labelFgColor: *warn
+    fieldFgColor: *foreground
+  frame:
+    border:
+      fgColor: *border
+      focusColor: *accent
+    menu:
+      fgColor: *foreground
+      keyColor: *key
+      numKeyColor: *builtin
+    crumbs:
+      fgColor: *background
+      bgColor: *accent
+      activeColor: *warn
+    status:
+      newColor: *new
+      modifyColor: *modify
+      addColor: *add
+      errorColor: *error
+      pendingColor: *warn
+      highlightColor: *accent
+      killColor: *kill
+      completedColor: *faint
+    title:
+      fgColor: *accent
+      bgColor: *panel
+      highlightColor: *builtin
+      counterColor: *foreground
+      filterColor: *key
+  views:
+    charts:
+      bgColor: *background
+      defaultDialColors:
+        - *accent
+        - *error
+      defaultChartColors:
+        - *accent
+        - *error
+    table:
+      fgColor: *foreground
+      bgColor: *background
+      cursorFgColor: *background
+      cursorBgColor: *cursor
+      markColor: *warn
+      header:
+        fgColor: *faint
+        bgColor: *background
+        sorterColor: *accent
+    xray:
+      fgColor: *foreground
+      bgColor: *background
+      cursorColor: *cursor
+      cursorTextColor: *background
+      graphicColor: *builtin
+      showIcons: false
+    yaml:
+      keyColor: *key
+      colonColor: *faint
+      valueColor: *foreground
+    logs:
+      fgColor: *foreground
+      bgColor: *background
+      indicator:
+        fgColor: *background
+        bgColor: *accent
+        toggleOnColor: *add
+        toggleOffColor: *faint
+    help:
+      fgColor: *foreground
+      bgColor: *panel
+      indicator:
+        fgColor: *accent


### PR DESCRIPTION
## What this adds

Eight new skins for [Protesilaos Stavrou's Modus themes](https://protesilaos.com/emacs/modus-themes), a family of accessibility-focused themes that conform to the highest WCAG contrast standard (7:1). The set covers the two main themes and their variants:

| Skin | Theme |
|------|-------|
| `modus-operandi` | Main light |
| `modus-vivendi` | Main dark |
| `modus-operandi-tinted` | Light, warm-tinted backgrounds |
| `modus-vivendi-tinted` | Dark, tinted backgrounds |
| `modus-operandi-deuteranopia` | Light, tuned for red–green color deficiency |
| `modus-vivendi-deuteranopia` | Dark, tuned for red–green color deficiency |
| `modus-operandi-tritanopia` | Light, tuned for blue–yellow color deficiency |
| `modus-vivendi-tritanopia` | Dark, tuned for blue–yellow color deficiency |

All color values are taken from the official `modus-themes` palette.

### Accessibility

The colorblind variants are not just recolored — they follow the upstream palette's own semantic mappings so status signals stay distinguishable:

- **Deuteranopia** (red–green deficiency): the safe axis is blue/yellow, so the "added / healthy" signal is mapped to **blue** rather than green, and error stays red. No status distinction ever rests on a red-versus-green pair.
- **Tritanopia** (blue–yellow deficiency): the safe axis is red/cyan, so info shifts to **cyan** and warnings to **magenta**, avoiding any blue-versus-yellow contrast.

## Screenshots

Captured against a local `kind` cluster with sample workloads, so the status colors reflect real resource states. Each grid pairs the light (Operandi) and dark (Vivendi) variant of a flavor side by side, one flavor per row: default, tinted, deuteranopia, tritanopia.

### Pod list — error and warning status colors
<img width="1464" height="1942" alt="grid-1-broken-pods" src="https://github.com/user-attachments/assets/b3ccb83c-2a34-4cb6-a8b3-fc72da9f8eda" />


### Pod list — healthy workloads (running / completed)
<img width="1464" height="1942" alt="grid-2-healthy-pods" src="https://github.com/user-attachments/assets/b19d99f5-5b42-40ae-a9c0-2291fb99142c" />

### Resource YAML — syntax palette
<img width="1464" height="1942" alt="grid-3-yaml" src="https://github.com/user-attachments/assets/51d6dd05-9022-45e8-a02c-172d8c1d41fe" />


### Logs view
<img width="1464" height="1942" alt="grid-4-logs" src="https://github.com/user-attachments/assets/735076ee-b2ce-4f9e-af08-e52021c802e3" />

## Notes

Each skin intentionally sets `body.bgColor` to the theme's exact Modus background so the look matches the upstream themes / WCAG guidelines. Users who prefer terminal transparency can change `bgColor` to `default`.