### PR TITLE
version in user agent instead of placeholder

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,8 @@ type flagError struct{ err error }
 func (e flagError) Error() string { return e.err.Error() }
 
 func init() {
+	client.Version = version
+
 	if err := config.InitLogLoc(); err != nil {
 		fmt.Printf("Fail to init k9s logs location %s\n", err)
 	}

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -28,6 +29,17 @@ const (
 	defaultQPS   float32 = 50
 	defaultBurst         = 100
 )
+
+// Version is the k9s build version. It is wired up from the cmd package at
+// startup and reported to the API server through the client User-Agent header
+// so k9s traffic is identifiable in API server logs, audit events and metrics.
+var Version = "dev"
+
+// userAgent returns the User-Agent k9s reports to the API server, e.g.
+// "k9s/v0.40.0 (linux/amd64)".
+func userAgent() string {
+	return fmt.Sprintf("k9s/%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
+}
 
 // Config tracks a kubernetes configuration.
 type Config struct {
@@ -60,6 +72,9 @@ func (c *Config) RESTConfig() (*restclient.Config, error) {
 	cfg, err := c.clientConfig().ClientConfig()
 	if err != nil {
 		return nil, err
+	}
+	if cfg.UserAgent == "" {
+		cfg.UserAgent = userAgent()
 	}
 	if c.proxy != nil {
 		cfg.Proxy = c.proxy

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -295,8 +295,8 @@ func TestConfigRestConfigUserAgent(t *testing.T) {
 		e       string
 	}{
 		"release": {
-			version: "v0.51.0",
-			e:       fmt.Sprintf("k9s/v0.51.0 (%s/%s)", runtime.GOOS, runtime.GOARCH),
+			version: "v1.2.3-test",
+			e:       fmt.Sprintf("k9s/v1.2.3-test (%s/%s)", runtime.GOOS, runtime.GOARCH),
 		},
 		"dev": {
 			version: "dev",

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -5,8 +5,10 @@ package client_test
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -282,6 +284,39 @@ func TestConfigRestConfig(t *testing.T) {
 	rc, err := cfg.RESTConfig()
 	require.NoError(t, err)
 	assert.Equal(t, "https://localhost:3002", rc.Host)
+}
+
+func TestConfigRestConfigUserAgent(t *testing.T) {
+	defaultVersion := client.Version
+	defer func() { client.Version = defaultVersion }()
+
+	uu := map[string]struct {
+		version string
+		e       string
+	}{
+		"release": {
+			version: "v0.51.0",
+			e:       fmt.Sprintf("k9s/v0.51.0 (%s/%s)", runtime.GOOS, runtime.GOARCH),
+		},
+		"dev": {
+			version: "dev",
+			e:       fmt.Sprintf("k9s/dev (%s/%s)", runtime.GOOS, runtime.GOARCH),
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			client.Version = u.version
+			flags := genericclioptions.ConfigFlags{
+				KubeConfig: &kubeConfig,
+			}
+			cfg := client.NewConfig(&flags)
+			rc, err := cfg.RESTConfig()
+			require.NoError(t, err)
+			assert.Equal(t, u.e, rc.UserAgent)
+		})
+	}
 }
 
 func TestConfigBadConfig(t *testing.T) {


### PR DESCRIPTION
user agent version segment is always the go placeholder of `v0.0.0`

update it to report k9s version