### PR TITLE
feat: navigate from Prometheus Operator CRDs to selected resources

### DIFF
--- a/internal/client/gvrs.go
+++ b/internal/client/gvrs.go
@@ -33,6 +33,11 @@ var (
 	CjGVR  = NewGVR("batch/v1/cronjobs")
 	JobGVR = NewGVR("batch/v1/jobs")
 
+	// Monitoring (Prometheus Operator)...
+	SmonGVR = NewGVR("monitoring.coreos.com/v1/servicemonitors")
+	PmonGVR = NewGVR("monitoring.coreos.com/v1/podmonitors")
+	PrbGVR  = NewGVR("monitoring.coreos.com/v1/probes")
+
 	// Misc...
 	CrdGVR = NewGVR("apiextensions.k8s.io/v1/customresourcedefinitions")
 	PcGVR  = NewGVR("scheduling.k8s.io/v1/priorityclasses")

--- a/internal/dao/accessor.go
+++ b/internal/dao/accessor.go
@@ -36,6 +36,10 @@ var accessors = Accessors{
 	client.HmhGVR: new(HelmHistory),
 
 	client.CrdGVR: new(CustomResourceDefinition),
+
+	client.SmonGVR: new(ServiceMonitor),
+	client.PmonGVR: new(PodMonitor),
+	client.PrbGVR:  new(Probe),
 }
 
 // Accessors represents a collection of dao accessors.

--- a/internal/dao/monitoring.go
+++ b/internal/dao/monitoring.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/derailed/k9s/internal/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	_ Accessor = (*ServiceMonitor)(nil)
+	_ Accessor = (*PodMonitor)(nil)
+	_ Accessor = (*Probe)(nil)
+)
+
+// MonitoringTarget describes the set of resources selected by a Prometheus
+// Operator monitoring CRD. An empty Namespace means "search all namespaces";
+// the label selector is then relied on to narrow the results.
+type MonitoringTarget struct {
+	Namespace string
+	Selector  labels.Selector
+}
+
+// ServiceMonitor represents a Prometheus Operator ServiceMonitor CRD.
+type ServiceMonitor struct {
+	Resource
+}
+
+// PodMonitor represents a Prometheus Operator PodMonitor CRD.
+type PodMonitor struct {
+	Resource
+}
+
+// Probe represents a Prometheus Operator Probe CRD.
+type Probe struct {
+	Resource
+}
+
+// SelectedTarget returns the Services selected by the given ServiceMonitor.
+func (sm *ServiceMonitor) SelectedTarget(fqn string) (*MonitoringTarget, error) {
+	u, err := getUnstructured(sm.getFactory(), sm.gvr, fqn)
+	if err != nil {
+		return nil, err
+	}
+	return targetFromSpec(u, "spec")
+}
+
+// SelectedTarget returns the Pods selected by the given PodMonitor.
+func (pm *PodMonitor) SelectedTarget(fqn string) (*MonitoringTarget, error) {
+	u, err := getUnstructured(pm.getFactory(), pm.gvr, fqn)
+	if err != nil {
+		return nil, err
+	}
+	return targetFromSpec(u, "spec")
+}
+
+// SelectedTarget returns the Ingresses selected by the given Probe. Returns
+// (nil, nil) when the Probe has no ingress selector (i.e. staticConfig-only).
+func (p *Probe) SelectedTarget(fqn string) (*MonitoringTarget, error) {
+	u, err := getUnstructured(p.getFactory(), p.gvr, fqn)
+	if err != nil {
+		return nil, err
+	}
+	if _, found, _ := unstructured.NestedMap(u.Object, "spec", "targets", "ingress"); !found {
+		return nil, nil
+	}
+	return targetFromSpec(u, "spec", "targets", "ingress")
+}
+
+func getUnstructured(f Factory, gvr *client.GVR, fqn string) (*unstructured.Unstructured, error) {
+	o, err := f.Get(gvr, fqn, true, labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	u, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("expected unstructured object for %s", fqn)
+	}
+	return u, nil
+}
+
+// targetFromSpec builds a MonitoringTarget from a nested location on the
+// unstructured object. specPath ends at the parent map that carries both a
+// "selector" (metav1.LabelSelector) and a "namespaceSelector" (Prometheus
+// Operator's NamespaceSelector: {any, matchNames}).
+func targetFromSpec(u *unstructured.Unstructured, specPath ...string) (*MonitoringTarget, error) {
+	labelSel, err := labelSelectorAt(u, append(specPath, "selector")...)
+	if err != nil {
+		return nil, err
+	}
+	sel, err := metav1.LabelSelectorAsSelector(labelSel)
+	if err != nil {
+		return nil, fmt.Errorf("invalid selector: %w", err)
+	}
+
+	nsPath := append(specPath, "namespaceSelector")
+	anyNS, _, err := unstructured.NestedBool(u.Object, append(nsPath, "any")...)
+	if err != nil {
+		return nil, fmt.Errorf("invalid namespaceSelector.any: %w", err)
+	}
+	names, _, err := unstructured.NestedStringSlice(u.Object, append(nsPath, "matchNames")...)
+	if err != nil {
+		return nil, fmt.Errorf("invalid namespaceSelector.matchNames: %w", err)
+	}
+
+	return &MonitoringTarget{
+		Namespace: namespaceFromSelector(u.GetNamespace(), anyNS, names),
+		Selector:  sel,
+	}, nil
+}
+
+// labelSelectorAt reads a metav1.LabelSelector out of the given unstructured
+// path. A missing selector is treated as the empty selector (matches nothing);
+// this mirrors how metav1.LabelSelectorAsSelector treats a nil pointer.
+func labelSelectorAt(u *unstructured.Unstructured, path ...string) (*metav1.LabelSelector, error) {
+	raw, found, err := unstructured.NestedMap(u.Object, path...)
+	if err != nil {
+		return nil, fmt.Errorf("invalid selector at %v: %w", path, err)
+	}
+	if !found {
+		return &metav1.LabelSelector{}, nil
+	}
+	var sel metav1.LabelSelector
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(raw, &sel); err != nil {
+		return nil, errors.New("selector is not a valid LabelSelector")
+	}
+	return &sel, nil
+}
+
+// namespaceFromSelector resolves a Prometheus Operator NamespaceSelector to a
+// single k9s active-namespace value. Because k9s' active-namespace model is
+// single-namespace-or-all, a matchNames list with more than one entry is
+// widened to all-namespaces; the label selector still filters the results.
+func namespaceFromSelector(ownNS string, anyNS bool, matchNames []string) string {
+	switch {
+	case anyNS:
+		return client.NamespaceAll
+	case len(matchNames) == 1:
+		return matchNames[0]
+	case len(matchNames) > 1:
+		return client.NamespaceAll
+	default:
+		return ownNS
+	}
+}

--- a/internal/dao/monitoring_test.go
+++ b/internal/dao/monitoring_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+import (
+	"testing"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestNamespaceFromSelector(t *testing.T) {
+	uu := map[string]struct {
+		ownNS      string
+		anyNS      bool
+		matchNames []string
+		want       string
+	}{
+		"any wins":               {ownNS: "monitoring", anyNS: true, matchNames: []string{"foo"}, want: client.NamespaceAll},
+		"single matchName":       {ownNS: "monitoring", matchNames: []string{"foo"}, want: "foo"},
+		"multiple matchNames":    {ownNS: "monitoring", matchNames: []string{"foo", "bar"}, want: client.NamespaceAll},
+		"empty falls back to own": {ownNS: "monitoring", want: "monitoring"},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.want, namespaceFromSelector(u.ownNS, u.anyNS, u.matchNames))
+		})
+	}
+}
+
+func TestTargetFromSpec(t *testing.T) {
+	uu := map[string]struct {
+		obj          map[string]any
+		wantNS       string
+		wantSelector string
+		wantEmpty    bool
+		wantErr      bool
+	}{
+		"matchLabels only": {
+			obj: map[string]any{
+				"metadata": map[string]any{"namespace": "monitoring"},
+				"spec": map[string]any{
+					"selector": map[string]any{
+						"matchLabels": map[string]any{"app": "api"},
+					},
+				},
+			},
+			wantNS:       "monitoring",
+			wantSelector: "app=api",
+		},
+		"matchExpressions": {
+			obj: map[string]any{
+				"metadata": map[string]any{"namespace": "monitoring"},
+				"spec": map[string]any{
+					"selector": map[string]any{
+						"matchExpressions": []any{
+							map[string]any{
+								"key":      "tier",
+								"operator": "In",
+								"values":   []any{"backend", "frontend"},
+							},
+						},
+					},
+				},
+			},
+			wantNS:       "monitoring",
+			wantSelector: "tier in (backend,frontend)",
+		},
+		"namespaceSelector any": {
+			obj: map[string]any{
+				"metadata": map[string]any{"namespace": "monitoring"},
+				"spec": map[string]any{
+					"selector":          map[string]any{"matchLabels": map[string]any{"app": "api"}},
+					"namespaceSelector": map[string]any{"any": true},
+				},
+			},
+			wantNS:       client.NamespaceAll,
+			wantSelector: "app=api",
+		},
+		"namespaceSelector matchNames single": {
+			obj: map[string]any{
+				"metadata": map[string]any{"namespace": "monitoring"},
+				"spec": map[string]any{
+					"selector":          map[string]any{"matchLabels": map[string]any{"app": "api"}},
+					"namespaceSelector": map[string]any{"matchNames": []any{"prod"}},
+				},
+			},
+			wantNS:       "prod",
+			wantSelector: "app=api",
+		},
+		"namespaceSelector matchNames multi widens to all": {
+			obj: map[string]any{
+				"metadata": map[string]any{"namespace": "monitoring"},
+				"spec": map[string]any{
+					"selector":          map[string]any{"matchLabels": map[string]any{"app": "api"}},
+					"namespaceSelector": map[string]any{"matchNames": []any{"prod", "staging"}},
+				},
+			},
+			wantNS:       client.NamespaceAll,
+			wantSelector: "app=api",
+		},
+		"missing selector is empty": {
+			obj: map[string]any{
+				"metadata": map[string]any{"namespace": "monitoring"},
+				"spec":     map[string]any{},
+			},
+			wantNS:    "monitoring",
+			wantEmpty: true,
+		},
+		"invalid selector type errors": {
+			obj: map[string]any{
+				"metadata": map[string]any{"namespace": "monitoring"},
+				"spec":     map[string]any{"selector": "not-a-map"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			un := &unstructured.Unstructured{Object: u.obj}
+			got, err := targetFromSpec(un, "spec")
+			if u.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, u.wantNS, got.Namespace)
+			if u.wantEmpty {
+				assert.True(t, got.Selector.Empty())
+			} else {
+				assert.Equal(t, u.wantSelector, got.Selector.String())
+			}
+		})
+	}
+}
+
+func TestProbeTargetFromSpec(t *testing.T) {
+	obj := map[string]any{
+		"metadata": map[string]any{"namespace": "monitoring"},
+		"spec": map[string]any{
+			"targets": map[string]any{
+				"ingress": map[string]any{
+					"selector":          map[string]any{"matchLabels": map[string]any{"tier": "edge"}},
+					"namespaceSelector": map[string]any{"matchNames": []any{"prod"}},
+				},
+			},
+		},
+	}
+	un := &unstructured.Unstructured{Object: obj}
+	got, err := targetFromSpec(un, "spec", "targets", "ingress")
+	require.NoError(t, err)
+	assert.Equal(t, "prod", got.Namespace)
+	assert.Equal(t, "tier=edge", got.Selector.String())
+}

--- a/internal/view/helpers.go
+++ b/internal/view/helpers.go
@@ -161,6 +161,53 @@ func showPods(app *App, path string, labelSel labels.Selector, fieldSel string) 
 	}
 }
 
+// showPodsIn is like showPods but injects the view in an explicit target
+// namespace rather than the parent resource's namespace. Used when the parent
+// resource selects targets across a different namespace scope (e.g. a
+// Prometheus Operator PodMonitor's namespaceSelector).
+func showPodsIn(app *App, path, targetNS string, labelSel labels.Selector) {
+	v := NewPod(client.PodGVR)
+	v.SetContextFn(podCtx(app, path, ""))
+	v.SetLabelSelector(labelSel, true)
+
+	if err := app.Config.SetActiveNamespace(targetNS); err != nil {
+		slog.Error("Unable to set active namespace during show pods", slogs.Error, err)
+	}
+	if err := app.inject(v, false); err != nil {
+		app.Flash().Err(err)
+	}
+}
+
+func showServices(app *App, path, targetNS string, labelSel labels.Selector) {
+	v := NewService(client.SvcGVR)
+	v.SetContextFn(func(ctx context.Context) context.Context {
+		return context.WithValue(ctx, internal.KeyPath, path)
+	})
+	v.SetLabelSelector(labelSel, true)
+
+	if err := app.Config.SetActiveNamespace(targetNS); err != nil {
+		slog.Error("Unable to set active namespace during show services", slogs.Error, err)
+	}
+	if err := app.inject(v, false); err != nil {
+		app.Flash().Err(err)
+	}
+}
+
+func showIngresses(app *App, path, targetNS string, labelSel labels.Selector) {
+	v := NewBrowser(client.IngGVR)
+	v.SetContextFn(func(ctx context.Context) context.Context {
+		return context.WithValue(ctx, internal.KeyPath, path)
+	})
+	v.SetLabelSelector(labelSel, true)
+
+	if err := app.Config.SetActiveNamespace(targetNS); err != nil {
+		slog.Error("Unable to set active namespace during show ingresses", slogs.Error, err)
+	}
+	if err := app.inject(v, false); err != nil {
+		app.Flash().Err(err)
+	}
+}
+
 func podCtx(_ *App, path, fieldSel string) ContextFunc {
 	return func(ctx context.Context) context.Context {
 		ctx = context.WithValue(ctx, internal.KeyPath, path)

--- a/internal/view/podmonitor.go
+++ b/internal/view/podmonitor.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/dao"
+	"github.com/derailed/k9s/internal/ui"
+)
+
+// PodMonitor represents a Prometheus Operator PodMonitor viewer.
+type PodMonitor struct {
+	ResourceViewer
+}
+
+// NewPodMonitor returns a new PodMonitor viewer.
+func NewPodMonitor(gvr *client.GVR) ResourceViewer {
+	p := PodMonitor{
+		ResourceViewer: NewOwnerExtender(NewBrowser(gvr)),
+	}
+	p.GetTable().SetEnterFn(p.showPods)
+
+	return &p
+}
+
+func (p *PodMonitor) showPods(a *App, _ ui.Tabular, _ *client.GVR, path string) {
+	var d dao.PodMonitor
+	d.Init(a.factory, p.GVR())
+
+	tgt, err := d.SelectedTarget(path)
+	if err != nil {
+		a.Flash().Err(err)
+		return
+	}
+	if tgt.Selector.Empty() {
+		a.Flash().Warnf("PodMonitor %s has no pod selector", path)
+		return
+	}
+	showPodsIn(a, path, tgt.Namespace, tgt.Selector)
+}

--- a/internal/view/probe.go
+++ b/internal/view/probe.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/dao"
+	"github.com/derailed/k9s/internal/ui"
+)
+
+// Probe represents a Prometheus Operator Probe viewer.
+type Probe struct {
+	ResourceViewer
+}
+
+// NewProbe returns a new Probe viewer.
+func NewProbe(gvr *client.GVR) ResourceViewer {
+	p := Probe{
+		ResourceViewer: NewOwnerExtender(NewBrowser(gvr)),
+	}
+	p.GetTable().SetEnterFn(p.showIngresses)
+
+	return &p
+}
+
+func (p *Probe) showIngresses(a *App, _ ui.Tabular, _ *client.GVR, path string) {
+	var d dao.Probe
+	d.Init(a.factory, p.GVR())
+
+	tgt, err := d.SelectedTarget(path)
+	if err != nil {
+		a.Flash().Err(err)
+		return
+	}
+	if tgt == nil {
+		a.Flash().Warnf("Probe %s has no ingress selector (static targets only)", path)
+		return
+	}
+	if tgt.Selector.Empty() {
+		a.Flash().Warnf("Probe %s has an empty ingress selector", path)
+		return
+	}
+	showIngresses(a, path, tgt.Namespace, tgt.Selector)
+}

--- a/internal/view/registrar.go
+++ b/internal/view/registrar.go
@@ -16,6 +16,7 @@ func loadCustomViewers() MetaViewers {
 	batchViewers(m)
 	crdViewers(m)
 	helmViewers(m)
+	monitoringViewers(m)
 
 	return m
 }
@@ -143,5 +144,17 @@ func batchViewers(vv MetaViewers) {
 func crdViewers(vv MetaViewers) {
 	vv[client.CrdGVR] = MetaViewer{
 		viewerFn: NewCRD,
+	}
+}
+
+func monitoringViewers(vv MetaViewers) {
+	vv[client.SmonGVR] = MetaViewer{
+		viewerFn: NewServiceMonitor,
+	}
+	vv[client.PmonGVR] = MetaViewer{
+		viewerFn: NewPodMonitor,
+	}
+	vv[client.PrbGVR] = MetaViewer{
+		viewerFn: NewProbe,
 	}
 }

--- a/internal/view/servicemonitor.go
+++ b/internal/view/servicemonitor.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/dao"
+	"github.com/derailed/k9s/internal/ui"
+)
+
+// ServiceMonitor represents a Prometheus Operator ServiceMonitor viewer.
+type ServiceMonitor struct {
+	ResourceViewer
+}
+
+// NewServiceMonitor returns a new ServiceMonitor viewer.
+func NewServiceMonitor(gvr *client.GVR) ResourceViewer {
+	s := ServiceMonitor{
+		ResourceViewer: NewOwnerExtender(NewBrowser(gvr)),
+	}
+	s.GetTable().SetEnterFn(s.showServices)
+
+	return &s
+}
+
+func (s *ServiceMonitor) showServices(a *App, _ ui.Tabular, _ *client.GVR, path string) {
+	var d dao.ServiceMonitor
+	d.Init(a.factory, s.GVR())
+
+	tgt, err := d.SelectedTarget(path)
+	if err != nil {
+		a.Flash().Err(err)
+		return
+	}
+	if tgt.Selector.Empty() {
+		a.Flash().Warnf("ServiceMonitor %s has no service selector", path)
+		return
+	}
+	showServices(a, path, tgt.Namespace, tgt.Selector)
+}


### PR DESCRIPTION
Add Enter-key navigation from ServiceMonitor, PodMonitor, and Probe rows to the resources they select. Selectors and namespaceSelectors are read from the unstructured payload so no Prometheus Operator SDK dependency is added.