### PR TITLE
fix: pod views often fail to load on large clusters (informer timeout, blocking metrics, cache bloat)

### DIFF
--- a/internal/client/metrics.go
+++ b/internal/client/metrics.go
@@ -7,10 +7,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"strconv"
+	"sync"
 	"time"
 
+	"github.com/derailed/k9s/internal/slogs"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/cache"
@@ -21,7 +24,16 @@ const (
 	mxCacheSize           = 100
 	mxCacheExpiry         = 1 * time.Minute
 	metricsPageSize int64 = 500
+
+	// mxFetchWait caps how long callers block on a cold metrics fetch before
+	// falling back to the last known metrics while the fetch completes in the
+	// background. Listing pod metrics across all namespaces on large clusters
+	// can take tens of seconds and must not stall the views refresh loop.
+	mxFetchWait = 500 * time.Millisecond
 )
+
+// ErrMetricsNotReady indicates metrics have not been fetched yet for a given scope.
+var ErrMetricsNotReady = errors.New("metrics not yet available")
 
 // MetricsDial tracks global metric server handle.
 var MetricsDial *MetricsServer
@@ -44,7 +56,10 @@ func ResetMetrics() {
 type MetricsServer struct {
 	Connection
 
-	cache *cache.LRUExpireCache
+	cache    *cache.LRUExpireCache
+	fmx      sync.Mutex
+	inflight map[string]chan struct{}
+	stale    map[string]any
 }
 
 // NewMetricsServer return a metric server instance.
@@ -52,7 +67,69 @@ func NewMetricsServer(c Connection) *MetricsServer {
 	return &MetricsServer{
 		Connection: c,
 		cache:      cache.NewLRUExpireCache(mxCacheSize),
+		inflight:   make(map[string]chan struct{}),
+		stale:      make(map[string]any),
 	}
+}
+
+// fetchList returns cached metrics for a given key when fresh. On a cache miss,
+// the list is refreshed in the background (a single fetch per key at a time)
+// and the last known metrics are returned after a short grace period so callers
+// never stall on slow metrics api calls.
+func (m *MetricsServer) fetchList(ctx context.Context, key string, list func(context.Context) (any, error)) (any, error) {
+	if v, ok := m.cache.Get(key); ok {
+		return v, nil
+	}
+
+	m.fmx.Lock()
+	done, ok := m.inflight[key]
+	if !ok {
+		done = make(chan struct{})
+		m.inflight[key] = done
+		timeout := DefaultCallTimeoutDuration
+		if m.Connection != nil {
+			if cfg := m.Config(); cfg != nil {
+				timeout = cfg.CallTimeout()
+			}
+		}
+		go func() {
+			defer close(done)
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			v, err := list(ctx)
+			m.fmx.Lock()
+			defer m.fmx.Unlock()
+			delete(m.inflight, key)
+			if err != nil {
+				slog.Warn("Metrics fetch failed",
+					slogs.Key, key,
+					slogs.Error, err,
+				)
+				return
+			}
+			m.cache.Add(key, v, mxCacheExpiry)
+			m.stale[key] = v
+		}()
+	}
+	m.fmx.Unlock()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+	case <-time.After(mxFetchWait):
+	}
+
+	if v, ok := m.cache.Get(key); ok {
+		return v, nil
+	}
+	m.fmx.Lock()
+	v, ok := m.stale[key]
+	m.fmx.Unlock()
+	if ok {
+		return v, nil
+	}
+
+	return nil, ErrMetricsNotReady
 }
 
 // ClusterLoad retrieves all cluster nodes metrics.
@@ -157,17 +234,24 @@ func (m *MetricsServer) FetchNodesMetrics(ctx context.Context) (*mv1beta1.NodeMe
 	}
 
 	const key = "nodes"
-	if entry, ok := m.cache.Get(key); ok && entry != nil {
-		mxList, ok := entry.(*mv1beta1.NodeMetricsList)
-		if !ok {
-			return nil, fmt.Errorf("expected nodemetricslist but got %T", entry)
-		}
-		return mxList, nil
-	}
-
-	client, err := m.MXDial()
+	entry, err := m.fetchList(ctx, key, func(ctx context.Context) (any, error) {
+		return m.listNodesMetrics(ctx)
+	})
 	if err != nil {
 		return mx, err
+	}
+	mxList, ok := entry.(*mv1beta1.NodeMetricsList)
+	if !ok {
+		return nil, fmt.Errorf("expected nodemetricslist but got %T", entry)
+	}
+
+	return mxList, nil
+}
+
+func (m *MetricsServer) listNodesMetrics(ctx context.Context) (*mv1beta1.NodeMetricsList, error) {
+	client, err := m.MXDial()
+	if err != nil {
+		return nil, err
 	}
 	mxList := &mv1beta1.NodeMetricsList{
 		Items: make([]mv1beta1.NodeMetrics, 0, metricsPageSize),
@@ -176,7 +260,7 @@ func (m *MetricsServer) FetchNodesMetrics(ctx context.Context) (*mv1beta1.NodeMe
 	for {
 		page, err := client.MetricsV1beta1().NodeMetricses().List(ctx, opts)
 		if err != nil {
-			return mx, err
+			return nil, err
 		}
 		mxList.Items = append(mxList.Items, page.Items...)
 		if page.Continue == "" {
@@ -184,7 +268,6 @@ func (m *MetricsServer) FetchNodesMetrics(ctx context.Context) (*mv1beta1.NodeMe
 		}
 		opts.Continue = page.Continue
 	}
-	m.cache.Add(key, mxList, mxCacheExpiry)
 
 	return mxList, nil
 }
@@ -239,17 +322,24 @@ func (m *MetricsServer) FetchPodsMetrics(ctx context.Context, ns string) (*mv1be
 	}
 
 	key := FQN(ns, "pods")
-	if entry, ok := m.cache.Get(key); ok {
-		mxList, ok := entry.(*mv1beta1.PodMetricsList)
-		if !ok {
-			return mx, fmt.Errorf("expected PodMetricsList but got %T", entry)
-		}
-		return mxList, nil
-	}
-
-	client, err := m.MXDial()
+	entry, err := m.fetchList(ctx, key, func(ctx context.Context) (any, error) {
+		return m.listPodsMetrics(ctx, ns)
+	})
 	if err != nil {
 		return mx, err
+	}
+	mxList, ok := entry.(*mv1beta1.PodMetricsList)
+	if !ok {
+		return mx, fmt.Errorf("expected PodMetricsList but got %T", entry)
+	}
+
+	return mxList, nil
+}
+
+func (m *MetricsServer) listPodsMetrics(ctx context.Context, ns string) (*mv1beta1.PodMetricsList, error) {
+	client, err := m.MXDial()
+	if err != nil {
+		return nil, err
 	}
 	mxList := &mv1beta1.PodMetricsList{
 		Items: make([]mv1beta1.PodMetrics, 0, metricsPageSize),
@@ -258,7 +348,7 @@ func (m *MetricsServer) FetchPodsMetrics(ctx context.Context, ns string) (*mv1be
 	for {
 		page, err := client.MetricsV1beta1().PodMetricses(ns).List(ctx, opts)
 		if err != nil {
-			return mx, err
+			return nil, err
 		}
 		mxList.Items = append(mxList.Items, page.Items...)
 		if page.Continue == "" {
@@ -266,7 +356,6 @@ func (m *MetricsServer) FetchPodsMetrics(ctx context.Context, ns string) (*mv1be
 		}
 		opts.Continue = page.Continue
 	}
-	m.cache.Add(key, mxList, mxCacheExpiry)
 
 	return mxList, nil
 }

--- a/internal/client/metrics_int_test.go
+++ b/internal/client/metrics_int_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package client
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchListFreshCacheHit(t *testing.T) {
+	m := NewMetricsServer(nil)
+	m.cache.Add("nodes", "cached", mxCacheExpiry)
+
+	v, err := m.fetchList(context.Background(), "nodes", func(context.Context) (any, error) {
+		t.Fatal("list should not be called on a cache hit")
+		return nil, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "cached", v)
+}
+
+func TestFetchListColdWaitsForFastFetch(t *testing.T) {
+	m := NewMetricsServer(nil)
+
+	v, err := m.fetchList(context.Background(), "nodes", func(context.Context) (any, error) {
+		return "fresh", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "fresh", v)
+}
+
+func TestFetchListSlowFetchDoesNotBlock(t *testing.T) {
+	m := NewMetricsServer(nil)
+	release := make(chan struct{})
+
+	start := time.Now()
+	v, err := m.fetchList(context.Background(), "nodes", func(context.Context) (any, error) {
+		<-release
+		return "slow", nil
+	})
+	elapsed := time.Since(start)
+
+	assert.Nil(t, v)
+	assert.ErrorIs(t, err, ErrMetricsNotReady)
+	assert.Less(t, elapsed, 5*time.Second)
+
+	// Once the background fetch lands, callers get the data.
+	close(release)
+	assert.Eventually(t, func() bool {
+		v, err := m.fetchList(context.Background(), "nodes", func(context.Context) (any, error) {
+			return "slow", nil
+		})
+		return err == nil && v == "slow"
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestFetchListServesStaleWhileRefreshing(t *testing.T) {
+	m := NewMetricsServer(nil)
+	m.stale["nodes"] = "stale"
+	release := make(chan struct{})
+	defer close(release)
+
+	v, err := m.fetchList(context.Background(), "nodes", func(context.Context) (any, error) {
+		<-release
+		return "fresh", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "stale", v)
+}
+
+func TestFetchListSingleFlight(t *testing.T) {
+	m := NewMetricsServer(nil)
+	release := make(chan struct{})
+	defer close(release)
+	var calls atomic.Int32
+
+	for range 3 {
+		_, err := m.fetchList(context.Background(), "nodes", func(context.Context) (any, error) {
+			calls.Add(1)
+			<-release
+			return "fresh", nil
+		})
+		assert.ErrorIs(t, err, ErrMetricsNotReady)
+	}
+
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestFetchListErrorRetriesNextCall(t *testing.T) {
+	m := NewMetricsServer(nil)
+
+	_, err := m.fetchList(context.Background(), "nodes", func(context.Context) (any, error) {
+		return nil, errors.New("boom")
+	})
+	assert.ErrorIs(t, err, ErrMetricsNotReady)
+
+	v, err := m.fetchList(context.Background(), "nodes", func(context.Context) (any, error) {
+		return "recovered", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "recovered", v)
+}

--- a/internal/dao/node.go
+++ b/internal/dao/node.go
@@ -170,7 +170,7 @@ func (n *Node) List(ctx context.Context, ns string) ([]runtime.Object, error) {
 	}
 
 	var nmx client.NodesMetricsMap
-	if withMx, ok := ctx.Value(internal.KeyWithMetrics).(bool); withMx || !ok {
+	if withMx, ok := ctx.Value(internal.KeyWithMetrics).(bool); (withMx || !ok) && len(oo) > 0 {
 		nmx, _ = client.DialMetrics(n.Client()).FetchNodesMetricsMap(ctx)
 	}
 

--- a/internal/dao/pod.go
+++ b/internal/dao/pod.go
@@ -114,7 +114,7 @@ func (p *Pod) List(ctx context.Context, ns string) ([]runtime.Object, error) {
 	}
 
 	var pmx client.PodsMetricsMap
-	if withMx, ok := ctx.Value(internal.KeyWithMetrics).(bool); ok && withMx {
+	if withMx, ok := ctx.Value(internal.KeyWithMetrics).(bool); ok && withMx && len(oo) > 0 {
 		pmx, _ = client.DialMetrics(p.Client()).FetchPodsMetricsMap(ctx, ns)
 	}
 	sel, _ := ctx.Value(internal.KeyFields).(string)

--- a/internal/dao/resource.go
+++ b/internal/dao/resource.go
@@ -40,7 +40,16 @@ func (r *Resource) Get(_ context.Context, path string) (runtime.Object, error) {
 
 // ToYAML returns a resource yaml.
 func (r *Resource) ToYAML(path string, showManaged bool) (string, error) {
-	o, err := r.Get(context.Background(), path)
+	var (
+		o   runtime.Object
+		err error
+	)
+	if showManaged {
+		// The informer cache strips managed fields: fetch the live resource.
+		o, err = r.Generic.Get(context.Background(), path)
+	} else {
+		o, err = r.Get(context.Background(), path)
+	}
 	if err != nil {
 		return "", err
 	}

--- a/internal/watch/factory.go
+++ b/internal/watch/factory.go
@@ -16,8 +16,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
 	di "k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
 )
 
 const (
@@ -261,6 +263,23 @@ func (f *Factory) ForResource(ns string, gvr *client.GVR) (informers.GenericInfo
 		)
 		return inf, nil
 	}
+	// Reflector failures are logged via klog which k9s silences. Surface them
+	// so stalled cache syncs are diagnosable. Errors once started are expected.
+	_ = inf.Informer().SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
+		slog.Warn("Informer list/watch failed",
+			slogs.GVR, gvr,
+			slogs.Namespace, ns,
+			slogs.Error, err,
+		)
+	})
+	// Managed fields are server-side bookkeeping k9s never renders and can
+	// account for a third of an object's footprint on large clusters.
+	_ = inf.Informer().SetTransform(func(o any) (any, error) {
+		if u, ok := o.(*unstructured.Unstructured); ok {
+			u.SetManagedFields(nil)
+		}
+		return o, nil
+	})
 
 	f.mx.RLock()
 	defer f.mx.RUnlock()
@@ -279,7 +298,7 @@ func (f *Factory) ensureFactory(ns string) (di.DynamicSharedInformerFactory, err
 		return fac, nil
 	}
 
-	dial, err := f.client.DynDial()
+	dial, err := f.dynDialLongOps()
 	if err != nil {
 		return nil, err
 	}
@@ -291,6 +310,23 @@ func (f *Factory) ensureFactory(ns string) (di.DynamicSharedInformerFactory, err
 	)
 
 	return f.factories[ns], nil
+}
+
+// dynDialLongOps returns a dynamic client with no per-request timeout for
+// informer use. Reflectors manage their own list/watch lifecycles: on large
+// clusters the initial cluster-wide pod list can exceed the configured api
+// call timeout, endlessly aborting the sync and leaving views forever empty.
+func (f *Factory) dynDialLongOps() (dynamic.Interface, error) {
+	cfg, err := f.client.RestConfig()
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		return f.client.DynDial()
+	}
+	cfg.Timeout = 0
+
+	return dynamic.NewForConfig(cfg)
 }
 
 // AddForwarder registers a new portforward for a given container.


### PR DESCRIPTION
## Problem
On clusters with a large pod count, the all-namespaces pod view and the node→pods drill-down usually spin on `Synchronizing v1/pods…` without ever populating, while namespace-scoped views load fine. Occasionally a view does load — and then it stays live. The failure is always at initial informer cache sync.

## Root causes
**1. The global api call timeout aborts the informer's initial LIST.**
K9s applies `apiServerTimeout` (default 2m, formerly 15s) as `rest.Config.Timeout` on every client, including the dynamic client backing the shared informers. Go's `http.Client.Timeout` bounds the *entire response body read*, so the reflector's initial cluster-wide pod LIST — ~400 MB on the ~15k-pod cluster this was diagnosed on — is aborted mid-download with `Client.Timeout … while reading body`, then retried from zero by client-go, endlessly. The cache syncs only when the transfer happens to squeeze inside the window, which is why loading succeeded intermittently. Namespace-scoped lists fit comfortably, which is why they always worked.


```mermaid
sequenceDiagram
    participant V as Pod view (all namespaces)
    participant R as Reflector (client-go)
    participant A as API server

    rect rgba(255, 100, 100, 0.12)
    Note over V,A: Before — rest.Config.Timeout = apiServerTimeout (2m)
    V->>R: watch pods cluster-wide
    R->>A: LIST all pods (~400 MB)
    A-->>R: streaming body…
    Note over R: ⏱ client timeout fires mid-body
    R--xA: aborted, cache empty
    R->>A: retry LIST from zero
    A-->>R: streaming body…
    R--xA: aborted again — forever
    Note over V: "Synchronizing v1/pods…" 🔁
    end

    rect rgba(80, 220, 120, 0.12)
    Note over V,A: After — informer client has no request timeout
    V->>R: watch pods cluster-wide
    R->>A: LIST all pods (~400 MB)
    A-->>R: full body received (~45s, once)
    R->>A: WATCH (incremental updates)
    Note over V: table renders, stays live
    end
```

**2. Synchronous metrics fetches block the reconcile loop.**
`Pod.List`/`Node.List` fetch pod/node metrics inline with an unbounded context. An all-namespaces PodMetrics LIST is slow on large clusters, and each metrics-cache expiry (1 min) froze table updates for the fetch's full duration.

A contributing factor made this undiagnosable: reflector errors go to klog, which k9s silences (`main.go` sets `v=-10`), so the aborted LISTs were invisible in the k9s log.

## Changes
- **`internal/watch/factory.go`**: informers dial a dynamic client with no per-request timeout (same pattern as `DialLogs`); reflectors manage their own list/watch lifecycles. All other clients keep honoring `apiServerTimeout`.
- **`internal/watch/factory.go`**: register a `WatchErrorHandler` so list/watch failures land in the k9s log (`Informer list/watch failed` with GVR/namespace/error).
- **`internal/watch/factory.go`**: strip `managedFields` at informer admission via `SetTransform` — measured at 58% of the pod LIST payload on a live cluster — halving cache memory and per-refresh diff cost. **`internal/dao/resource.go`**: the YAML view's managed-fields toggle (`m`) now fetches the live object, so the feature keeps working.
- **`internal/client/metrics.go`**: pod/node metrics list fetches are stale-while-revalidate with singleflight — callers wait at most 500ms, then get last-known metrics (or `ErrMetricsNotReady` on cold start) while a single background fetch, bounded by `apiServerTimeout`, refreshes the cache. Tables render immediately; CPU/MEM columns fill on a following tick. All call sites already tolerate absent metrics (`n/a`).
- **`internal/dao/pod.go` / `internal/dao/node.go`**: skip metrics decoration when the informer has returned no objects yet.

## Testing
- Repro cluster (EKS, ~100 nodes / ~15k pods / ~400 MB pod list): before — all-namespaces pods and node→pods views rarely loaded; after — loads on first sync (~45s, the unavoidable one-time transfer) and stays live.
- Isolated repro of the timeout mechanism: a LIST streaming slower than `rest.Config.Timeout` fails mid-body; the identical LIST with `Timeout: 0` completes.
- New unit tests (run with `-race`) for the metrics coordinator: fresh-cache hit, fast fetch unchanged, slow fetch non-blocking with eventual delivery, stale serving, singleflight, error retry.
- Existing suites pass: `internal/client`, `internal/dao`, `internal/model`, `internal/watch`.

