### PR TITLE
Add build time flag to override rev check

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,7 +35,7 @@ const (
 var _ data.KubeSettings = (*client.Config)(nil)
 
 var (
-	version, commit, date = "dev", "dev", client.NA
+	version, commit, date, skipLatestRevCheck = "dev", "dev", client.NA, "false"
 	k9sFlags              *config.Flags
 	k8sFlags              *genericclioptions.ConfigFlags
 
@@ -150,6 +151,9 @@ func loadConfiguration() (*config.Config, error) {
 	if err := k9sCfg.Refine(k8sFlags, k9sFlags, k8sCfg); err != nil {
 		slog.Error("Fail to refine k9s config", slogs.Error, err)
 		errs = errors.Join(errs, err)
+	}
+	if b, err := strconv.ParseBool(skipLatestRevCheck); err == nil {
+		k9sCfg.K9s.SkipLatestRevCheck = b
 	}
 
 	// Try to access server version if that fail. Connectivity issue?


### PR DESCRIPTION
I am the maintainer of k9s in Fedora and would like to completely deactivate the k9s version check. If someone downloads k9s from the official Fedora repository then he expects to receive updates there. Having the version check active only bothers users because they can't really do anything about it until I have time to update k9s.

This PR enables me to do "-X %{goipath}/cmd.skipLatestRevCheck=true".