### PR TITLE
feat: Add in-cluster service account support (#768)

### DIFF
--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -6,8 +6,11 @@ package client
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -25,15 +28,24 @@ const (
 	// UsePersistentConfig caches client config to avoid reloads.
 	UsePersistentConfig = true
 
+	// InClusterContext names the synthesized context when running in a pod
+	// with no kubeconfig, using the mounted service account credentials.
+	InClusterContext = "in-cluster"
+
 	defaultQPS   float32 = 50
 	defaultBurst         = 100
 )
 
+// saDir is a var so tests can point at a fake service account mount.
+var saDir = "/var/run/secrets/kubernetes.io/serviceaccount"
+
 // Config tracks a kubernetes configuration.
 type Config struct {
-	flags *genericclioptions.ConfigFlags
-	mx    sync.RWMutex
-	proxy func(*http.Request) (*url.URL, error)
+	flags  *genericclioptions.ConfigFlags
+	mx     sync.RWMutex
+	proxy  func(*http.Request) (*url.URL, error)
+	icOnce sync.Once
+	ic     bool
 }
 
 // NewConfig returns a new k8s config or an error if the flags are invalid.
@@ -82,7 +94,67 @@ func (c *Config) RawConfig() (api.Config, error) {
 }
 
 func (c *Config) clientConfig() clientcmd.ClientConfig {
+	if c.inCluster() {
+		return clientcmd.NewNonInteractiveClientConfig(
+			*inClusterKubeConfig(),
+			InClusterContext,
+			&clientcmd.ConfigOverrides{},
+			&clientcmd.ClientConfigLoadingRules{},
+		)
+	}
+
 	return c.flags.ToRawKubeConfigLoader()
+}
+
+// inCluster reports whether no kubeconfig nor api credentials were provided
+// and the pod's service account is mounted, mirroring clientcmd's in-cluster
+// fallback detection.
+func (c *Config) inCluster() bool {
+	c.icOnce.Do(func() {
+		if c.flags == nil || isSet(c.flags.APIServer) || isSet(c.flags.BearerToken) {
+			return
+		}
+		cfg, err := c.flags.ToRawKubeConfigLoader().RawConfig()
+		if err != nil || len(cfg.Contexts) > 0 {
+			return
+		}
+		fi, err := os.Stat(filepath.Join(saDir, "token"))
+		c.ic = err == nil && !fi.IsDir() &&
+			os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
+			os.Getenv("KUBERNETES_SERVICE_PORT") != ""
+	})
+
+	return c.ic
+}
+
+// inClusterKubeConfig synthesizes a single-context kubeconfig from the pod's
+// service account mount so the context machinery works without a kubeconfig.
+func inClusterKubeConfig() *api.Config {
+	ns := "default"
+	if b, err := os.ReadFile(filepath.Join(saDir, "namespace")); err == nil {
+		if s := strings.TrimSpace(string(b)); s != "" {
+			ns = s
+		}
+	}
+	cfg := api.NewConfig()
+	cfg.Clusters[InClusterContext] = &api.Cluster{
+		Server: "https://" + net.JoinHostPort(
+			os.Getenv("KUBERNETES_SERVICE_HOST"),
+			os.Getenv("KUBERNETES_SERVICE_PORT"),
+		),
+		CertificateAuthority: filepath.Join(saDir, "ca.crt"),
+	}
+	cfg.AuthInfos[InClusterContext] = &api.AuthInfo{
+		TokenFile: filepath.Join(saDir, "token"),
+	}
+	cfg.Contexts[InClusterContext] = &api.Context{
+		Cluster:   InClusterContext,
+		AuthInfo:  InClusterContext,
+		Namespace: ns,
+	}
+	cfg.CurrentContext = InClusterContext
+
+	return cfg
 }
 
 func (*Config) reset() {}

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -282,6 +283,66 @@ func TestConfigRestConfig(t *testing.T) {
 	rc, err := cfg.RESTConfig()
 	require.NoError(t, err)
 	assert.Equal(t, "https://localhost:3002", rc.Host)
+}
+
+func setupInCluster(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "token"), []byte("s3cr3t"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "namespace"), []byte("fred-ns\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ca.crt"), []byte("ca"), 0600))
+	t.Cleanup(client.MockSADir(dir))
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+	// Hide any kubeconfig present on the host running the tests.
+	t.Setenv("KUBECONFIG", filepath.Join(dir, "no-such-kubeconfig"))
+}
+
+func TestConfigInCluster(t *testing.T) {
+	setupInCluster(t)
+	cfg := client.NewConfig(genericclioptions.NewConfigFlags(false))
+
+	ctx, err := cfg.CurrentContextName()
+	require.NoError(t, err)
+	assert.Equal(t, client.InClusterContext, ctx)
+
+	cl, err := cfg.CurrentClusterName()
+	require.NoError(t, err)
+	assert.Equal(t, client.InClusterContext, cl)
+
+	ns, err := cfg.CurrentNamespaceName()
+	require.NoError(t, err)
+	assert.Equal(t, "fred-ns", ns)
+
+	cc, err := cfg.Contexts()
+	require.NoError(t, err)
+	assert.Len(t, cc, 1)
+
+	rc, err := cfg.RESTConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "https://10.96.0.1:443", rc.Host)
+	assert.NotEmpty(t, rc.BearerTokenFile)
+}
+
+func TestConfigInClusterKubeConfigWins(t *testing.T) {
+	setupInCluster(t)
+	flags := genericclioptions.NewConfigFlags(false)
+	flags.KubeConfig = &kubeConfig
+	cfg := client.NewConfig(flags)
+
+	ctx, err := cfg.CurrentContextName()
+	require.NoError(t, err)
+	assert.Equal(t, "fred", ctx)
+}
+
+func TestConfigNoKubeConfigNotInCluster(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "no-such-kubeconfig"))
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+	cfg := client.NewConfig(genericclioptions.NewConfigFlags(false))
+
+	ctx, err := cfg.CurrentContextName()
+	require.NoError(t, err)
+	assert.Empty(t, ctx)
 }
 
 func TestConfigBadConfig(t *testing.T) {

--- a/internal/client/export_test.go
+++ b/internal/client/export_test.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package client
+
+// MockSADir overrides the service account mount dir for tests.
+func MockSADir(dir string) (undo func()) {
+	old := saDir
+	saDir = dir
+
+	return func() { saDir = old }
+}


### PR DESCRIPTION
## Motivation

Running k9s inside a cluster currently requires generating a kubeconfig from the mounted service account before starting k9s (wrapper scripts around `kubectl config set-credentials` etc.). kubectl and client-go fall back to in-cluster credentials automatically; k9s should too.

Addresses #768 (closed as stale — please consider reopening; I'm the original reporter).

## Approach

When no kubeconfig and no explicit `--server`/`--token` are provided and the service account mount (`/var/run/secrets/kubernetes.io/serviceaccount`) is present, `client.Config` synthesizes a single-context kubeconfig named `in-cluster`:

- server from `KUBERNETES_SERVICE_HOST`/`KUBERNETES_SERVICE_PORT`
- CA and token as file references, so token rotation keeps working via `BearerTokenFile`
- the service account namespace as the default namespace

All downstream context machinery (context activation, per-context config, skins, context view) works unchanged off that synthesized config. Detection mirrors clientcmd's `inClusterClientConfig.Possible()`, so REST credentials stay consistent with client-go's own in-cluster fallback. An existing kubeconfig always takes precedence, matching kubectl. No new flags.

## Testing

- Unit tests: in-cluster detection, kubeconfig precedence, and unchanged no-config behavior (`internal/client/config_test.go`).
- e2e in kind: pod with a dedicated ServiceAccount and no kubeconfig, k9s started with just the SA mount:

```
 Context: in-cluster [RW]                          <0> all       <a>       Attach       <ctrl-k>  Kill           … ____  __ ________
 Cluster: in-cluster                               <1> default   <ctrl-d>  Delete       <l>       Logs            |    |/  /   __   \______
 User:    in-cluster                                             <d>       Describe     <p>       Logs Previous   |       /\____    /  ___/
 K9s Rev: v0.0.0                                                 <e>       Edit         <shift-f> Port-Forward    |    \   \  /    /\___  \
 K8s Rev: v1.36.1                                                <?>       Help         <z>       Sanitize        |____|\__ \/____//____  /
 CPU:     n/a                                                    <shift-j> Jump Owner   <s>       Shell                    \/           \/
 MEM:     n/a
┌──────────────────────────────────────────────── pods(default)[1] ────────────────────────────────────────────────┐
│ NAME↑         PF        READY        STATUS          RESTARTS IP                  NODE                     AGE   │
│ k9s           ●         1/1          Running                0 10.244.0.5          k9s-test-control-plane   22h   │
│                                                                                                                  │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
  <pod>
```

Startup log:

```
DBG Using active context context=in-cluster
INF ✅ Kubernetes connectivity OK
```

(`CPU/MEM: n/a` is only the missing metrics-server in kind; `K9s Rev: v0.0.0` is a dev build without version ldflags — neither is related to this change.)
