### PR TITLE
fix(client): surface authentication errors instead of 'command not found' (#3730)

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/derailed/k9s/internal/slogs"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/apimachinery/pkg/version"
@@ -51,7 +52,27 @@ type APIClient struct {
 	mx                sync.RWMutex
 	cache             *cache.LRUExpireCache
 	connOK            bool
+	connErr           error
 	log               *slog.Logger
+}
+
+// IsAuthError returns true if the given error indicates the api server
+// rejected the request due to missing/expired/insufficient credentials
+// (HTTP 401/403 or a token-refresh style credentials failure).
+func IsAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err) {
+		return true
+	}
+	// Some auth failures (e.g. exec/token credential-plugin refresh errors)
+	// surface as a plain error rather than a typed api status.
+	msg := strings.ToLower(err.Error())
+
+	return strings.Contains(msg, "provide credentials") ||
+		strings.Contains(msg, "unauthorized") ||
+		strings.Contains(msg, "the server has asked for the client")
 }
 
 // NewTestAPIClient for testing ONLY!!
@@ -317,6 +338,7 @@ func (a *APIClient) CheckConnectivity() bool {
 	cfg, err := a.config.RESTConfig()
 	if err != nil {
 		slog.Error("RestConfig load failed", slogs.Error, err)
+		a.setConnErr(err)
 		a.connOK = false
 		return a.connOK
 	}
@@ -324,21 +346,41 @@ func (a *APIClient) CheckConnectivity() bool {
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		slog.Error("Unable to connect to api server", slogs.Error, err)
+		a.setConnErr(err)
 		a.setConnOK(false)
 		return a.getConnOK()
 	}
 
 	if _, err := client.ServerVersion(); err == nil {
+		a.setConnErr(nil)
 		a.setClient(client)
 		if !a.getConnOK() {
 			a.reset()
 		}
 	} else {
 		slog.Error("Unable to fetch server version", slogs.Error, err)
+		a.setConnErr(err)
 		a.setConnOK(false)
 	}
 
 	return a.getConnOK()
+}
+
+// ConnectivityError returns the error from the most recent failed connectivity
+// check, or nil if the last check succeeded. It is used to surface actionable
+// messages (e.g. authentication failures) to the user.
+func (a *APIClient) ConnectivityError() error {
+	a.mx.RLock()
+	defer a.mx.RUnlock()
+
+	return a.connErr
+}
+
+func (a *APIClient) setConnErr(err error) {
+	a.mx.Lock()
+	defer a.mx.Unlock()
+
+	a.connErr = err
 }
 
 // Config return a kubernetes configuration.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,12 +4,59 @@
 package client
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+func TestIsAuthError(t *testing.T) {
+	uu := map[string]struct {
+		err error
+		e   bool
+	}{
+		"nil": {
+			err: nil,
+			e:   false,
+		},
+		"unauthorized": {
+			err: apierrors.NewUnauthorized("the server has asked for the client to provide credentials"),
+			e:   true,
+		},
+		"wrapped-unauthorized": {
+			err: fmt.Errorf("dial failed: %w", apierrors.NewUnauthorized("nope")),
+			e:   true,
+		},
+		"forbidden": {
+			err: apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "", errors.New("nope")),
+			e:   true,
+		},
+		"credentials-plugin": {
+			err: errors.New("getting credentials: exec: executable failed; the server has asked for the client to provide credentials"),
+			e:   true,
+		},
+		"generic": {
+			err: errors.New("boom"),
+			e:   false,
+		},
+		"not-found": {
+			err: apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "fred"),
+			e:   false,
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, IsAuthError(u.err))
+		})
+	}
+}
 
 func TestMakeSAR(t *testing.T) {
 	uu := map[string]struct {

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -132,6 +132,10 @@ type Connection interface {
 	// CheckConnectivity checks if api server connection is happy or not.
 	CheckConnectivity() bool
 
+	// ConnectivityError returns the error from the last failed connectivity
+	// check, or nil if the last check succeeded.
+	ConnectivityError() error
+
 	// ActiveContext returns the current context name.
 	ActiveContext() string
 

--- a/internal/config/mock/test_helpers.go
+++ b/internal/config/mock/test_helpers.go
@@ -118,7 +118,8 @@ func (m mockKubeSettings) ContextNames() (map[string]struct{}, error) {
 func (mockKubeSettings) SetProxy(func(*http.Request) (*url.URL, error)) {}
 
 type mockConnection struct {
-	ct string
+	ct      string
+	connErr error
 }
 
 func NewMockConnection() mockConnection {
@@ -126,6 +127,9 @@ func NewMockConnection() mockConnection {
 }
 func NewMockConnectionWithContext(ct string) mockConnection {
 	return mockConnection{ct: ct}
+}
+func NewMockConnectionWithError(err error) mockConnection {
+	return mockConnection{connErr: err}
 }
 
 func (mockConnection) CanI(string, *client.GVR, string, []string) (bool, error) {
@@ -172,6 +176,9 @@ func (mockConnection) ServerVersion() (*version.Info, error) {
 }
 func (mockConnection) CheckConnectivity() bool {
 	return false
+}
+func (m mockConnection) ConnectivityError() error {
+	return m.connErr
 }
 func (m mockConnection) ActiveContext() string {
 	return m.ct

--- a/internal/dao/container_test.go
+++ b/internal/dao/container_test.go
@@ -57,6 +57,7 @@ func (*conn) MXDial() (*versioned.Clientset, error)                    { return 
 func (*conn) DynDial() (dynamic.Interface, error)                      { return nil, nil }
 func (*conn) HasMetrics() bool                                         { return false }
 func (*conn) CheckConnectivity() bool                                  { return false }
+func (*conn) ConnectivityError() error                                 { return nil }
 func (*conn) IsNamespaced(string) bool                                 { return false }
 func (*conn) SupportsResource(string) bool                             { return false }
 func (*conn) ValidNamespaces() ([]v1.Namespace, error)                 { return nil, nil }

--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -318,6 +318,16 @@ func (c *Command) viewMetaFor(p *cmd.Interpreter) (*client.GVR, *MetaViewer, *cm
 	}
 	gvr, ok := c.alias.Resolve(p)
 	if !ok {
+		// A resolution failure is frequently a symptom of a dead connection
+		// rather than a bad command. When the api server rejected us for auth
+		// reasons, surface that instead of a misleading "command not found".
+		if c.app != nil {
+			if conn := c.app.Conn(); conn != nil {
+				if err := conn.ConnectivityError(); client.IsAuthError(err) {
+					return client.NoGVR, nil, nil, fmt.Errorf("authentication failed — credentials may be expired; check your kubeconfig/token (%w)", err)
+				}
+			}
+		}
 		return client.NoGVR, nil, nil, fmt.Errorf("`%s` command not found", p.Cmd())
 	}
 

--- a/internal/view/command_test.go
+++ b/internal/view/command_test.go
@@ -6,10 +6,52 @@ import (
 
 	"github.com/derailed/k9s/internal/client"
 	"github.com/derailed/k9s/internal/config"
+	"github.com/derailed/k9s/internal/config/mock"
 	"github.com/derailed/k9s/internal/dao"
 	"github.com/derailed/k9s/internal/view/cmd"
 	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
+
+// Test_viewMetaForAuthError ensures that when a command can't be resolved and
+// the api server rejected us for auth reasons, we surface an authentication
+// error instead of the misleading "command not found" (issue #3730).
+func Test_viewMetaForAuthError(t *testing.T) {
+	app := NewApp(mock.NewMockConfig(t))
+	authErr := apierrors.NewUnauthorized("the server has asked for the client to provide credentials")
+	app.Config.SetConnection(mock.NewMockConnectionWithError(authErr))
+
+	c := &Command{
+		app: app,
+		alias: &dao.Alias{
+			Aliases: config.NewAliases(),
+		},
+	}
+
+	_, _, _, err := c.viewMetaFor(cmd.NewInterpreter("v1/pods"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication failed")
+	assert.NotContains(t, err.Error(), "command not found")
+	assert.ErrorIs(t, err, authErr)
+}
+
+// Test_viewMetaForNoAuthError ensures a genuinely unknown command still
+// reports "command not found" when the connection is healthy.
+func Test_viewMetaForNoAuthError(t *testing.T) {
+	app := NewApp(mock.NewMockConfig(t))
+	app.Config.SetConnection(mock.NewMockConnection())
+
+	c := &Command{
+		app: app,
+		alias: &dao.Alias{
+			Aliases: config.NewAliases(),
+		},
+	}
+
+	_, _, _, err := c.viewMetaFor(cmd.NewInterpreter("v1/bogus"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "command not found")
+}
 
 func Test_viewMetaFor(t *testing.T) {
 	uu := map[string]struct {


### PR DESCRIPTION
### Summary
Fixes #3730. When credentials are expired/invalid, `CheckConnectivity` caught the 401 from `ServerVersion()` but discarded it (it returned a bare `bool`), so downstream alias resolution failed and the user saw the generic `‹Ruroh? 'v1/pods' command not found›` error instead of an authentication error.

### Changes
- `internal/client/client.go`: added an `IsAuthError` helper (`apierrors.IsUnauthorized` / `IsForbidden`, plus a string fallback for credential-plugin refresh failures), a mutex-guarded `connErr` field on `APIClient`, and a `ConnectivityError()` accessor. `CheckConnectivity` now records the error on failure and clears it on success.
- `internal/client/types.go`: added `ConnectivityError() error` to the `Connection` interface.
- `internal/view/command.go`: `viewMetaFor` now returns "authentication failed — credentials may be expired; check your kubeconfig/token" (wrapping the original error) when the connectivity error is an auth error, instead of "command not found".
- Interface-compliance + tests: `internal/config/mock/test_helpers.go`, `internal/dao/container_test.go`, and new tests for `IsAuthError` and the `viewMetaFor` auth / non-auth paths.

Additive only — RBAC / `CanI` fail-closed gating is unchanged; this only improves the user-facing message on a resolution miss.

### Testing
`go build ./...`, `go vet ./...`, and `go test ./internal/client/... ./internal/view/... ./internal/config/... ./internal/dao/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)