### PR TITLE
Feat: added support to view resources from multiple namespaces

### DIFF
--- a/internal/client/helper_test.go
+++ b/internal/client/helper_test.go
@@ -226,3 +226,64 @@ func TestFQN(t *testing.T) {
 		assert.Equal(t, u.e, client.FQN(u.ns, u.n))
 	}
 }
+
+func TestIsMultiNamespace(t *testing.T) {
+	uu := map[string]struct {
+		ns string
+		e  bool
+	}{
+		"empty":          {ns: client.BlankNamespace},
+		"single":         {ns: "ns1"},
+		"all":            {ns: client.NamespaceAll},
+		"cluster":        {ns: client.ClusterScope},
+		"multi":          {ns: "ns1,ns2", e: true},
+		"trailing-comma": {ns: "ns1,", e: true},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, client.IsMultiNamespace(u.ns))
+		})
+	}
+}
+
+func TestNamespaces(t *testing.T) {
+	uu := map[string]struct {
+		ns string
+		e  []string
+	}{
+		"single":  {ns: "ns1", e: []string{"ns1"}},
+		"multi":   {ns: "ns1,ns2", e: []string{"ns1", "ns2"}},
+		"spaces":  {ns: " ns1 , ns2 ", e: []string{"ns1", "ns2"}},
+		"empties": {ns: "ns1,,ns2,", e: []string{"ns1", "ns2"}},
+		"blank":   {ns: client.BlankNamespace, e: []string{}},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, client.Namespaces(u.ns))
+		})
+	}
+}
+
+func TestNormalizeNamespaces(t *testing.T) {
+	uu := map[string]struct {
+		ns string
+		e  string
+	}{
+		"single":     {ns: "ns1", e: "ns1"},
+		"all":        {ns: client.NamespaceAll, e: client.NamespaceAll},
+		"multi":      {ns: "ns1,ns2", e: "ns1,ns2"},
+		"dedup":      {ns: "ns1,ns2,ns1", e: "ns1,ns2"},
+		"trim-empty": {ns: " ns1 , , ns2 ,", e: "ns1,ns2"},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, client.NormalizeNamespaces(u.ns))
+		})
+	}
+}

--- a/internal/client/helpers.go
+++ b/internal/client/helpers.go
@@ -59,6 +59,47 @@ func IsClusterScoped(ns string) bool {
 	return ns == ClusterScope
 }
 
+// IsMultiNamespace returns true if ns designates more than one namespace.
+func IsMultiNamespace(ns string) bool {
+	return strings.Contains(ns, NamespaceDelimiter)
+}
+
+// Namespaces splits a (possibly comma-delimited) namespace selector into its
+// individual namespaces, trimming blanks and dropping empties. A single
+// namespace yields a one element slice.
+func Namespaces(ns string) []string {
+	nss := strings.Split(ns, NamespaceDelimiter)
+	oo := make([]string, 0, len(nss))
+	for _, n := range nss {
+		if n = strings.TrimSpace(n); n != "" {
+			oo = append(oo, n)
+		}
+	}
+
+	return oo
+}
+
+// NormalizeNamespaces canonicalizes a (possibly comma-delimited) namespace
+// selector: trims blanks, drops empties and duplicates, and preserves order.
+// A single namespace is returned unchanged.
+func NormalizeNamespaces(ns string) string {
+	if !IsMultiNamespace(ns) {
+		return ns
+	}
+	nss := Namespaces(ns)
+	seen := make(map[string]struct{}, len(nss))
+	oo := make([]string, 0, len(nss))
+	for _, n := range nss {
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		oo = append(oo, n)
+	}
+
+	return strings.Join(oo, NamespaceDelimiter)
+}
+
 // Namespaced converts a resource path to namespace and resource name.
 func Namespaced(p string) (ns, name string) {
 	ns, name = path.Split(p)

--- a/internal/client/metrics.go
+++ b/internal/client/metrics.go
@@ -226,8 +226,22 @@ func (m *MetricsServer) FetchPodsMetricsMap(ctx context.Context, ns string) (Pod
 	return hh, nil
 }
 
-// FetchPodsMetrics return all metrics for pods in a given namespace.
+// FetchPodsMetrics return all metrics for pods in a given namespace. A
+// comma-delimited selector fetches and merges metrics across each namespace,
+// skipping any the user cannot access.
 func (m *MetricsServer) FetchPodsMetrics(ctx context.Context, ns string) (*mv1beta1.PodMetricsList, error) {
+	if IsMultiNamespace(ns) {
+		out := &mv1beta1.PodMetricsList{}
+		for _, n := range Namespaces(ns) {
+			mm, err := m.FetchPodsMetrics(ctx, n)
+			if err != nil {
+				continue
+			}
+			out.Items = append(out.Items, mm.Items...)
+		}
+		return out, nil
+	}
+
 	mx := new(mv1beta1.PodMetricsList)
 	const msg = "user is not authorized to list pods metrics"
 

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -32,6 +32,9 @@ const (
 	// NotNamespaced designates a non resource namespace.
 	NotNamespaced = "*"
 
+	// NamespaceDelimiter separates multiple namespaces in a namespace selector.
+	NamespaceDelimiter = ","
+
 	// CreateVerb represents create access on a resource.
 	CreateVerb = "create"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -127,7 +127,7 @@ func (c *Config) Refine(flags *genericclioptions.ConfigFlags, k9sFlags *Flags, c
 		ns = client.NamespaceAll
 		c.ResetActiveView()
 	case isStringSet(flags.Namespace):
-		ns = *flags.Namespace
+		ns = client.NormalizeNamespaces(*flags.Namespace)
 		c.ResetActiveView()
 	default:
 		nss, err := c.K9s.ActiveContextNamespace()

--- a/internal/config/data/ns.go
+++ b/internal/config/data/ns.go
@@ -63,7 +63,7 @@ func (n *Namespace) Validate(conn client.Connection) {
 	n.mx.RLock()
 	defer n.mx.RUnlock()
 
-	if conn == nil || !conn.IsValidNamespace(n.Active) {
+	if conn == nil || !isValidNamespace(conn, n.Active) {
 		return
 	}
 	for _, ns := range n.Favorites {
@@ -93,11 +93,28 @@ func (n *Namespace) SetActive(ns string, _ KubeSettings) error {
 	}
 	n.Active = ns
 
-	if ns != "" && !n.LockFavorites {
+	// A multi-namespace selection (e.g. "ns1,ns2") is persisted as the active
+	// namespace but never stored as a single favorite entry.
+	if ns != "" && !n.LockFavorites && !client.IsMultiNamespace(ns) {
 		n.addFavNS(ns)
 	}
 
 	return nil
+}
+
+// isValidNamespace reports whether ns is valid, treating a comma-delimited
+// selector as valid only when every namespace in it is valid.
+func isValidNamespace(conn client.Connection, ns string) bool {
+	if !client.IsMultiNamespace(ns) {
+		return conn.IsValidNamespace(ns)
+	}
+	for _, n := range client.Namespaces(ns) {
+		if !conn.IsValidNamespace(n) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (n *Namespace) isAllNamespaces() bool {

--- a/internal/config/data/ns_test.go
+++ b/internal/config/data/ns_test.go
@@ -75,3 +75,16 @@ func TestNSValidateRmFavs(t *testing.T) {
 
 	assert.Equal(t, []string{"default", "fred"}, ns.Favorites)
 }
+
+func TestNSSetActiveMulti(t *testing.T) {
+	mk := mock.NewMockKubeSettings(makeFlags("cl-1", "ct-1"))
+	ns := data.NewNamespace()
+
+	// A multi-namespace selection persists as the active namespace but must
+	// not pollute the favorites list with the combined entry.
+	err := ns.SetActive("ns1,ns2", mk)
+	require.NoError(t, err)
+	assert.Equal(t, "ns1,ns2", ns.Active)
+	assert.NotContains(t, ns.Favorites, "ns1,ns2")
+	assert.Equal(t, []string{"default"}, ns.Favorites)
+}

--- a/internal/config/json/schemas/skin.json
+++ b/internal/config/json/schemas/skin.json
@@ -72,7 +72,8 @@
               "properties": {
                 "fgColor": {"type": "string"},
                 "keyColor": {"type": "string"},
-                "numKeyColor": {"type": "string"}
+                "numKeyColor": {"type": "string"},
+                "activeColor": {"type": "string"}
               }
             },
             "crumbs": {

--- a/internal/config/styles.go
+++ b/internal/config/styles.go
@@ -236,6 +236,7 @@ type (
 		FgStyle     TextStyle `json:"fgStyle" yaml:"fgStyle"`
 		KeyColor    Color     `json:"keyColor" yaml:"keyColor"`
 		NumKeyColor Color     `json:"numKeyColor" yaml:"numKeyColor"`
+		ActiveColor Color     `json:"activeColor" yaml:"activeColor"`
 	}
 
 	// Charts tracks charts styles.
@@ -463,6 +464,7 @@ func newMenu() Menu {
 		FgColor:     "white",
 		KeyColor:    "dodgerblue",
 		NumKeyColor: "fuchsia",
+		ActiveColor: "aqua",
 	}
 }
 

--- a/internal/config/templates/stock-skin.yaml
+++ b/internal/config/templates/stock-skin.yaml
@@ -39,6 +39,7 @@ k9s:
       fgColor: white
       keyColor: dodgerblue
       numKeyColor: fuchsia
+      activeColor: aqua
     crumbs:
       fgColor: black
       bgColor: aqua

--- a/internal/dao/generic.go
+++ b/internal/dao/generic.go
@@ -5,6 +5,7 @@ package dao
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/derailed/k9s/internal"
@@ -43,6 +44,38 @@ func (g *Generic) List(ctx context.Context, ns string) ([]runtime.Object, error)
 	if !ok {
 		labelSel = labels.Everything()
 	}
+	if client.IsMultiNamespace(ns) {
+		return g.listMulti(ctx, ns, labelSel)
+	}
+
+	return g.listInNamespace(ctx, ns, labelSel)
+}
+
+// listMulti lists a resource across several namespaces and merges the results,
+// skipping namespaces that error out unless every namespace fails.
+func (g *Generic) listMulti(ctx context.Context, ns string, labelSel labels.Selector) ([]runtime.Object, error) {
+	var (
+		oo    []runtime.Object
+		errs  error
+		anyOK bool
+	)
+	for _, n := range client.Namespaces(ns) {
+		nsoo, err := g.listInNamespace(ctx, n, labelSel)
+		if err != nil {
+			errs = errors.Join(errs, err)
+			continue
+		}
+		anyOK = true
+		oo = append(oo, nsoo...)
+	}
+	if !anyOK && errs != nil {
+		return nil, errs
+	}
+
+	return oo, nil
+}
+
+func (g *Generic) listInNamespace(ctx context.Context, ns string, labelSel labels.Selector) ([]runtime.Object, error) {
 	if client.IsAllNamespace(ns) {
 		ns = client.BlankNamespace
 	}

--- a/internal/model/menu_hint.go
+++ b/internal/model/menu_hint.go
@@ -12,6 +12,7 @@ type MenuHint struct {
 	Mnemonic    string
 	Description string
 	Visible     bool
+	Active      bool
 }
 
 // IsBlank checks if menu hint is a place holder.

--- a/internal/model1/header.go
+++ b/internal/model1/header.go
@@ -178,7 +178,7 @@ func (h Header) FilterColIndices(ns string, wide bool) sets.Set[int] {
 	if len(h) == 0 {
 		return nil
 	}
-	nsed := client.IsNamespaced(ns)
+	nsed := client.IsNamespaced(ns) && !client.IsMultiNamespace(ns)
 
 	cc := sets.New[int]()
 	for i, c := range h {

--- a/internal/model1/table_data.go
+++ b/internal/model1/table_data.go
@@ -314,7 +314,7 @@ func (t *TableData) Labelize(labels []string) *TableData {
 		return t
 	}
 	cols := []int{0, 1}
-	if client.IsNamespaced(t.namespace) {
+	if client.IsNamespaced(t.namespace) && !client.IsMultiNamespace(t.namespace) {
 		cols = cols[1:]
 	}
 	data := TableData{
@@ -358,7 +358,7 @@ func (t *TableData) sortCol(vs *config.ViewSetting) (SortColumn, error) {
 		psc.Name, psc.ASC = name, order
 		return psc, nil
 	}
-	if client.IsAllNamespaces(t.GetNamespace()) {
+	if client.IsAllNamespaces(t.GetNamespace()) || client.IsMultiNamespace(t.GetNamespace()) {
 		if _, ok := t.header.IndexOf("NAMESPACE", false); ok {
 			psc.Name = "NAMESPACE"
 		} else if _, ok := t.header.IndexOf("NAME", false); ok {

--- a/internal/ui/action.go
+++ b/internal/ui/action.go
@@ -27,6 +27,7 @@ type (
 		Plugin    bool
 		HotKey    bool
 		Dangerous bool
+		Active    bool
 	}
 
 	// KeyAction represents a keyboard action.
@@ -209,6 +210,7 @@ func (a *KeyActions) Hints() model.MenuHints {
 					Mnemonic:    name,
 					Description: a.actions[k].Description,
 					Visible:     a.actions[k].Opts.Visible,
+					Active:      a.actions[k].Opts.Active,
 				},
 			)
 		} else {

--- a/internal/ui/key.go
+++ b/internal/ui/key.go
@@ -129,6 +129,20 @@ var NumKeys = map[int]tcell.Key{
 	9: Key9,
 }
 
+// ShiftNumKeys tracks shifted number keys (Shift+0..Shift+9).
+var ShiftNumKeys = map[int]tcell.Key{
+	0: KeyShift0,
+	1: KeyShift1,
+	2: KeyShift2,
+	3: KeyShift3,
+	4: KeyShift4,
+	5: KeyShift5,
+	6: KeyShift6,
+	7: KeyShift7,
+	8: KeyShift8,
+	9: KeyShift9,
+}
+
 func initNumbKeys() {
 	tcell.KeyNames[Key0] = "0"
 	tcell.KeyNames[Key1] = "1"

--- a/internal/ui/menu.go
+++ b/internal/ui/menu.go
@@ -163,7 +163,7 @@ func (m *Menu) formatMenu(h model.MenuHint, size int) string {
 	styles := m.styles.Frame()
 	i, err := strconv.Atoi(h.Mnemonic)
 	if err == nil {
-		return formatNSMenu(i, h.Description, &styles)
+		return formatNSMenu(i, h.Description, h.Active, &styles)
 	}
 
 	return formatPlainMenu(h, size, &styles)
@@ -196,10 +196,15 @@ func ToMnemonic(s string) string {
 	return "<" + keyConv(strings.ToLower(s)) + ">"
 }
 
-func formatNSMenu(i int, name string, styles *config.Frame) string {
+func formatNSMenu(i int, name string, active bool, styles *config.Frame) string {
+	// Highlight the namespace name when it is part of the current (multi-)namespace view.
+	fgColor := styles.Menu.FgColor
+	if active {
+		fgColor = styles.Menu.ActiveColor
+	}
 	fmat := strings.Replace(menuIndexFmt, "[key", "["+styles.Menu.NumKeyColor.String(), 1)
 	fmat = strings.ReplaceAll(fmat, ":bg:", ":"+styles.Title.BgColor.String()+":")
-	fmat = strings.Replace(fmat, "[fg", "["+styles.Menu.FgColor.String(), 1)
+	fmat = strings.Replace(fmat, "[fg", "["+fgColor.String(), 1)
 	fmat = strings.Replace(fmat, "fgstyle]", styles.Menu.FgStyle.ToShortString()+"]", 1)
 
 	return fmt.Sprintf(fmat, i, name)

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 
 	"github.com/derailed/k9s/internal"
@@ -22,7 +23,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-const maxTruncate = 50
+const (
+	maxTruncate = 50
+	// maxNSTruncate caps how wide a multi-namespace selector renders in a title.
+	maxNSTruncate = 40
+)
 
 type (
 	// ColorerFunc represents a row colorer.
@@ -440,7 +445,7 @@ func (t *Table) GetNamespace() string {
 }
 
 func (t *Table) doUpdate(data *model1.TableData) *model1.TableData {
-	if client.IsAllNamespaces(data.GetNamespace()) {
+	if client.IsAllNamespaces(data.GetNamespace()) || client.IsMultiNamespace(data.GetNamespace()) {
 		t.actions.Add(
 			KeyShiftP,
 			NewKeyAction("Sort Namespace", t.SortColCmd("NAMESPACE", true), false),
@@ -464,7 +469,7 @@ func (t *Table) doUpdate(data *model1.TableData) *model1.TableData {
 
 func (t *Table) shouldExcludeColumn(h model1.HeaderColumn) bool {
 	return (h.Hide || (!t.wide && h.Wide)) ||
-		(h.Name == "NAMESPACE" && !t.GetModel().ClusterWide()) ||
+		(h.Name == "NAMESPACE" && !t.GetModel().ClusterWide() && !client.IsMultiNamespace(t.GetModel().GetNamespace())) ||
 		(h.MX && !t.hasMetrics) ||
 		(h.VS && vul.ImgScanner == nil)
 }
@@ -632,7 +637,9 @@ func (t *Table) NameColIndex() int {
 func (t *Table) AddHeaderCell(col int, h model1.HeaderColumn) {
 	sc := t.getSortCol()
 	sortCol := h.Name == sc.Name
-	selectedCol := col == t.getSelectedColIdx()
+	// The NAMESPACE column is a prepended informational column; keep it rendered
+	// with the standard header color rather than the selected-column highlight.
+	selectedCol := col == t.getSelectedColIdx() && !strings.EqualFold(h.Name, "NAMESPACE")
 	styles := t.styles.Table()
 	c := tview.NewTableCell(columnIndicator(sortCol, selectedCol, sc.ASC, &styles, h.Name))
 	c.SetExpansion(1)
@@ -688,6 +695,9 @@ func (t *Table) styleTitle() string {
 	}
 	if t.Extras != "" {
 		ns = t.Extras
+	}
+	if client.IsMultiNamespace(ns) {
+		ns = render.Truncate(ns, maxNSTruncate)
 	}
 
 	resource := t.gvr.R()

--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -613,6 +614,67 @@ func (b *Browser) switchNamespaceCmd(evt *tcell.EventKey) *tcell.EventKey {
 	return nil
 }
 
+// toggleNamespaceCmd adds/removes the favorite namespace bound to the pressed
+// Shift+<number> to/from the current (possibly multi-namespace) view.
+func (b *Browser) toggleNamespaceCmd(evt *tcell.EventKey) *tcell.EventKey {
+	key := tcell.Key(evt.Rune())
+	index := -1
+	for i := range b.namespaces {
+		if sk, ok := ui.ShiftNumKeys[i]; ok && sk == key {
+			index = i
+			break
+		}
+	}
+	if index < 0 {
+		return evt
+	}
+	ns := b.namespaces[index]
+	if ns == "" || ns == client.NamespaceAll {
+		return nil
+	}
+
+	// Start from the current selection, treating all/cluster-wide as empty.
+	var set []string
+	if cur := b.GetModel().GetNamespace(); !client.IsClusterWide(cur) {
+		set = client.Namespaces(cur)
+	}
+
+	if pos := slices.Index(set, ns); pos >= 0 {
+		if len(set) == 1 {
+			b.app.Flash().Warnf("Cannot remove the last namespace `%s` from the view", ns)
+			return nil
+		}
+		set = slices.Delete(set, pos, pos+1)
+	} else {
+		auth, err := b.App().factory.Client().CanI(ns, b.GVR(), "", client.ListAccess)
+		if !auth {
+			if err == nil {
+				err = fmt.Errorf("access denied for user on: %s/%s", ns, b.GVR())
+			}
+			b.App().Flash().Err(err)
+			return nil
+		}
+		set = append(set, ns)
+	}
+
+	joined := strings.Join(set, client.NamespaceDelimiter)
+	if err := b.app.switchNS(joined); err != nil {
+		b.App().Flash().Err(err)
+		return nil
+	}
+	b.setNamespace(joined)
+	b.app.Flash().Infof("Viewing %s in namespaces `%s`...", b.GVR(), joined)
+	b.refresh()
+	b.UpdateTitle()
+	b.SelectRow(1, 0, true)
+	b.app.CmdBuff().Reset()
+	if err := b.app.Config.SetActiveNamespace(b.GetModel().GetNamespace()); err != nil {
+		slog.Error("Unable to set active namespace during ns toggle", slogs.Error, err)
+	}
+
+	return nil
+}
+
 // ----------------------------------------------------------------------------
 // Helpers...
 
@@ -703,6 +765,10 @@ func (b *Browser) namespaceActions(aa *ui.KeyActions) {
 		aa.Add(ui.KeyW, ui.NewKeyAction("Warp To Namespace", b.nsWarpCmd, true))
 	}
 
+	// Namespaces currently included in the (possibly multi-namespace) view; used
+	// to highlight their menu entries.
+	sel := client.Namespaces(client.CleanseNamespace(b.GetModel().GetNamespace()))
+
 	b.namespaces = make(map[int]string, data.MaxFavoritesNS)
 	var index int
 	if ok, _ := b.app.Conn().CanI(client.NamespaceAll, client.NsGVR, "", client.ListAccess); ok {
@@ -716,7 +782,13 @@ func (b *Browser) namespaceActions(aa *ui.KeyActions) {
 			continue
 		}
 		if numKey, ok := ui.NumKeys[index]; ok {
-			aa.Add(numKey, ui.NewKeyAction(ns, b.switchNamespaceCmd, true))
+			aa.Add(numKey, ui.NewKeyActionWithOpts(ns, b.switchNamespaceCmd,
+				ui.ActionOpts{Visible: true, Active: slices.Contains(sel, ns)}))
+			// Shift+<number> toggles the favorite in/out of a multi-namespace
+			// view. Registered hidden to avoid doubling the menu.
+			if shiftKey, ok := ui.ShiftNumKeys[index]; ok {
+				aa.Add(shiftKey, ui.NewKeyAction("Toggle "+ns, b.toggleNamespaceCmd, false))
+			}
 			b.namespaces[index] = ns
 			index++
 		} else {

--- a/internal/watch/factory.go
+++ b/internal/watch/factory.go
@@ -4,6 +4,7 @@
 package watch
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -73,6 +74,9 @@ func (f *Factory) Terminate() {
 
 // List returns a resource collection.
 func (f *Factory) List(gvr *client.GVR, ns string, wait bool, lbls labels.Selector) ([]runtime.Object, error) {
+	if client.IsMultiNamespace(ns) {
+		return f.listMulti(gvr, ns, wait, lbls)
+	}
 	if client.IsAllNamespace(ns) {
 		ns = client.BlankNamespace
 	}
@@ -98,8 +102,52 @@ func (f *Factory) List(gvr *client.GVR, ns string, wait bool, lbls labels.Select
 	return inf.Lister().ByNamespace(ns).List(lbls)
 }
 
+// listMulti lists a resource across several namespaces and merges the results.
+// Namespaces the user cannot access (or that error out) are skipped so the
+// remaining namespaces still render; an error is only surfaced when every
+// namespace fails.
+func (f *Factory) listMulti(gvr *client.GVR, ns string, wait bool, lbls labels.Selector) ([]runtime.Object, error) {
+	var (
+		oo    []runtime.Object
+		errs  error
+		anyOK bool
+	)
+	for _, n := range client.Namespaces(ns) {
+		nsoo, err := f.List(gvr, n, wait, lbls)
+		if err != nil {
+			slog.Warn("Unable to list resource in namespace; skipping",
+				slogs.GVR, gvr,
+				slogs.Namespace, n,
+				slogs.Error, err,
+			)
+			errs = errors.Join(errs, err)
+			continue
+		}
+		anyOK = true
+		oo = append(oo, nsoo...)
+	}
+	if !anyOK && errs != nil {
+		return nil, errs
+	}
+
+	return oo, nil
+}
+
 // HasSynced checks if given informer is up to date.
 func (f *Factory) HasSynced(gvr *client.GVR, ns string) (bool, error) {
+	if client.IsMultiNamespace(ns) {
+		for _, n := range client.Namespaces(ns) {
+			ok, err := f.HasSynced(gvr, n)
+			if err != nil {
+				return false, err
+			}
+			if !ok {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+
 	inf, err := f.CanForResource(ns, gvr, client.ListAccess)
 	if err != nil {
 		return false, err
@@ -187,6 +235,14 @@ func (f *Factory) SetActiveNS(ns string) error {
 	if f.isClusterWide() {
 		return nil
 	}
+	if client.IsMultiNamespace(ns) {
+		for _, n := range client.Namespaces(ns) {
+			if _, err := f.ensureFactory(n); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 	_, err := f.ensureFactory(ns)
 	return err
 }
@@ -201,6 +257,22 @@ func (f *Factory) isClusterWide() bool {
 
 // CanForResource return an informer is user has access.
 func (f *Factory) CanForResource(ns string, gvr *client.GVR, verbs []string) (informers.GenericInformer, error) {
+	// For a multi-namespace selector, return an informer for the first
+	// accessible namespace; error only when access is denied for all of them.
+	// This mirrors the partial-access semantics of listMulti.
+	if client.IsMultiNamespace(ns) {
+		var lastErr error
+		for _, n := range client.Namespaces(ns) {
+			inf, err := f.CanForResource(n, gvr, verbs)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			return inf, nil
+		}
+		return nil, lastErr
+	}
+
 	var resName string
 	if gvr == client.NsGVR {
 		resName = ns

--- a/internal/watch/factory_test.go
+++ b/internal/watch/factory_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package watch_test
+
+import (
+	"testing"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/config/mock"
+	"github.com/derailed/k9s/internal/watch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// spyConn records the namespaces CanI is asked about and answers from an allow-list.
+type spyConn struct {
+	client.Connection
+	seen  []string
+	allow map[string]bool
+}
+
+func (c *spyConn) CanI(ns string, _ *client.GVR, _ string, _ []string) (bool, error) {
+	c.seen = append(c.seen, ns)
+
+	return c.allow[ns], nil
+}
+
+func TestFactoryCanForResourceMultiNS(t *testing.T) {
+	// Deny every individual namespace but "allow" the joined string. The fix must
+	// decompose "ns1,ns2" and check each namespace on its own, so it never queries
+	// the joined value and access ends up denied for all -> error.
+	conn := &spyConn{
+		Connection: mock.NewMockConnection(),
+		allow:      map[string]bool{"ns1,ns2": true},
+	}
+	f := watch.NewFactory(conn)
+
+	_, err := f.CanForResource("ns1,ns2", client.PodGVR, client.ListAccess)
+	require.Error(t, err)
+	assert.Equal(t, []string{"ns1", "ns2"}, conn.seen)
+}


### PR DESCRIPTION
Hi hi!

My current k9s use-case involves navigating back-and-forth between namespaces, and it proves to be quite tedious. Unfortunately, access to all namespace is restricted, which means I always need to specify what namespace (singular) I want to enter. I needed a way to show all the pods (among other resources) in one single view.

This PR adds the ability to view resources across several namespaces simultaneously, instead of being limited to one namespace (or all) at a time.
- Client helpers: new client package helpers for parsing/joining comma-delimited namespace lists (Namespaces, IsMultiNamespace, NamespaceDelimiter, etc.).
- CLI/config support: resolve a comma-separated -n flag into a multi-namespace selection; persist the multi-ns selection as the active namespace across navigation (without polluting favorites with combined entries).
- Resource listing: fetch/list resources across all selected namespaces and merge results for display.
- UI rendering: show a NAMESPACE column and update the view title when displaying resources from more than one namespace.
- Namespace toggling: Shift+<number> on a favorite namespace key adds/removes it from the current multi-namespace view; currently-selected namespaces are highlighted in the namespace menu.

Also touched: metrics fetching, watch factory (to watch multiple namespaces), skin config/schema (new highlight style), and corresponding unit tests (helper_test.go, ns_test.go, factory_test.go).

I believe this PR would prove to be beneficial especially for those that have encountered the same problem. Would appreciate any feedback on this! Thanks!