### PR TITLE
fix(ci): restore test workflow push triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: K9s Test
 
 on:
   workflow_dispatch:
-    push:
+  push:
     branches:
       - master
     tags:


### PR DESCRIPTION
## Summary

Restore the test workflow's `push` trigger as a top-level workflow event.

## Root cause

`push`, `branches`, and `tags` were nested under `workflow_dispatch`, where they are not valid trigger configuration. As a result, the test workflow did not run for direct pushes to `master` or release tags.

## Validation

- Parsed `.github/workflows/test.yml` and asserted the expected `workflow_dispatch` and `push` mapping structure.
- Ran `git diff --check`.

Fixes #4119
