### PR TITLE
fix: add context flag for kube-metrics plugin

### DIFF
--- a/plugins/kube-metrics.yaml
+++ b/plugins/kube-metrics.yaml
@@ -14,7 +14,7 @@ plugins:
       - -c
       - |
         if [ -n "$NAMESPACE" ]; then
-          kube-metrics pod --namespace=$NAMESPACE $NAME
+          kube-metrics pod --context=$CONTEXT --namespace=$NAMESPACE $NAME
         else
-          kube-metrics node $NAME
+          kube-metrics node --context=$CONTEXT $NAME
         fi


### PR DESCRIPTION
Updates the kube-metris plugin config by adding the context flag