### PR TITLE
fix(config): plug file descriptor leak in SaveYAML

### DIFF
--- a/internal/config/data/helpers.go
+++ b/internal/config/data/helpers.go
@@ -66,13 +66,20 @@ func WriteYAML(content any) ([]byte, error) {
 }
 
 // SaveYAML writes a yaml file to disk.
-func SaveYAML(path string, content any) error {
+func SaveYAML(path string, content any) (err error) {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, DefaultFileMod)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		err = errors.Join(err, f.Close())
+	}()
+
 	ec := yaml.NewEncoder(f)
 	ec.SetIndent(2)
+	if err = ec.Encode(content); err != nil {
+		return err
+	}
 
-	return ec.Encode(content)
+	return ec.Close()
 }

--- a/internal/config/data/helpers.go
+++ b/internal/config/data/helpers.go
@@ -77,7 +77,7 @@ func SaveYAML(path string, content any) (err error) {
 
 	ec := yaml.NewEncoder(f)
 	ec.SetIndent(2)
-	if err = ec.Encode(content); err != nil {
+	if err := ec.Encode(content); err != nil {
 		return err
 	}
 

--- a/internal/config/data/helpers_test.go
+++ b/internal/config/data/helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/derailed/k9s/internal/config/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestSanitizeFileName(t *testing.T) {
@@ -75,6 +76,29 @@ func TestEnsureDirPathNone(t *testing.T) {
 	p, err := os.Stat(dir)
 	require.NoError(t, err)
 	assert.Equal(t, "drwxr--r--", p.Mode().String())
+}
+
+func TestSaveYAML(t *testing.T) {
+	type payload struct {
+		Name  string `yaml:"name"`
+		Count int    `yaml:"count"`
+	}
+
+	path := filepath.Join(t.TempDir(), "out.yaml")
+	require.NoError(t, data.SaveYAML(path, payload{Name: "fred", Count: 3}))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var out payload
+	require.NoError(t, yaml.Unmarshal(raw, &out))
+	assert.Equal(t, payload{Name: "fred", Count: 3}, out)
+
+	// Rewriting with shorter content must truncate, leaving no stale bytes.
+	require.NoError(t, data.SaveYAML(path, payload{Name: "bo", Count: 7}))
+	raw, err = os.ReadFile(path)
+	require.NoError(t, err)
+	require.NoError(t, yaml.Unmarshal(raw, &out))
+	assert.Equal(t, payload{Name: "bo", Count: 7}, out)
 }
 
 func TestEnsureDirPathNoOpt(t *testing.T) {

--- a/internal/config/data/helpers_unix_test.go
+++ b/internal/config/data/helpers_unix_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+//go:build unix
+
+package data_test
+
+import (
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/derailed/k9s/internal/config/data"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSaveYAMLNoFDLeak lowers the fd limit so a leaked fd per call
+// would fail with "too many open files" within a few dozen iterations.
+func TestSaveYAMLNoFDLeak(t *testing.T) {
+	var cur syscall.Rlimit
+	require.NoError(t, syscall.Getrlimit(syscall.RLIMIT_NOFILE, &cur))
+	require.NoError(t, syscall.Setrlimit(syscall.RLIMIT_NOFILE, &syscall.Rlimit{Cur: 64, Max: cur.Max}))
+	defer func() {
+		_ = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &cur)
+	}()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	for i := 1; i <= 200; i++ {
+		require.NoErrorf(t, data.SaveYAML(path, map[string]int{"iteration": i}),
+			"SaveYAML leaked file descriptors: failed at iteration %d", i)
+	}
+}


### PR DESCRIPTION
## Summary

`SaveYAML` opens the target file but never closes it, leaking one file
descriptor per call. It sits on hot paths — the main config save, the
per-context config save on **every context switch**, and alias saves — so a
long-running k9s session steadily burns fds until the process hits
`RLIMIT_NOFILE`, at which point unrelated operations (API connections, log
streaming, opening new contexts) start failing with `too many open files`.

The yaml encoder is never closed either (the stream is never finalized), and
any error surfaced at close time is silently dropped.

## Root cause

```go
func SaveYAML(path string, content any) error {
	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, DefaultFileMod)
	if err != nil {
		return err
	}
	ec := yaml.NewEncoder(f)
	ec.SetIndent(2)

	return ec.Encode(content) // f and ec are never closed
}
```

The bug went unnoticed because yaml.v3 flushes its buffer on document end, so
file contents always landed intact — the leak is only visible on the resource
axis, not the data axis.

## Changes

- `internal/config/data/helpers.go` — close the file via `defer` on all paths,
  joining close errors into the returned error (`errors.Join`), and finalize
  the yaml stream with `ec.Close()`. Signature unchanged.
- `internal/config/data/helpers_unix_test.go` — regression test: lowers
  `RLIMIT_NOFILE` to 64 and calls `SaveYAML` 200 times. The previous
  implementation fails around iteration 60 with `too many open files`; the
  fixed one passes. Unix-only (`//go:build unix`), skipped on Windows.
- `internal/config/data/helpers_test.go` — `TestSaveYAML` verifies content
  round-trips and that rewriting with shorter content truncates cleanly.

## Test plan

| Scenario | Result |
|----------|--------|
| Regression test against pre-fix code | FAIL — `too many open files` at iteration ~60 |
| Regression test against this branch | PASS — 200 iterations, fd count stays flat |
| `go test ./internal/config/data/` (full package) | PASS |
| `go vet ./internal/config/data/` | clean |

Reproduce locally:

```sh
go test -v -run TestSaveYAML ./internal/config/data/
```