### PR TITLE
feat: derive version from build info when installed via `go install`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,7 @@ func init() {
 		fmt.Printf("Fail to init k9s logs location %s\n", err)
 	}
 
+	initVersion()
 	rootCmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
 		return flagError{err: err}
 	})
@@ -64,6 +65,16 @@ func init() {
 	rootCmd.AddCommand(versionCmd(), infoCmd())
 	initK9sFlags()
 	initK8sFlags()
+}
+
+func initVersion() {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	if v := bi.Main.Version; v != "" && v != "(devel)" {
+		version = v
+	}
 }
 
 // Execute root command.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,7 +57,9 @@ func init() {
 		fmt.Printf("Fail to init k9s logs location %s\n", err)
 	}
 
-	initVersion()
+	if version == "dev" {
+		initVersion()
+	}
 	rootCmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
 		return flagError{err: err}
 	})


### PR DESCRIPTION
## Description

When k9s is installed with `go install github.com/derailed/k9s@<tag>` (or `@latest`), the resulting binary reports its version as `dev`, because the version is only ever injected via `-ldflags` during official (Makefile / goreleaser) builds.

This PR adds an `initVersion()` step that reads the module version from Go's build info (`debug.ReadBuildInfo().Main.Version`) and uses it as the version when a real one is available.

## Behavior

- **`go install ...@<tag>` builds** — `Main.Version` is the git tag (e.g. `v0.51.0`), so `k9s version` now reports that tag instead of `dev`.
- **Official ldflags builds** — goreleaser/Makefile build from a local checkout, so `Main.Version` is `(devel)`, which is explicitly ignored. The version supplied via `-ldflags` is therefore preserved unchanged.
- **Plain local `go build`** — `Main.Version` is `(devel)`, ignored; still shows the `dev` default.

## `k9s version` — before vs. after

Both binaries installed via `go install github.com/derailed/k9s@v0.51.0` (the latest tag):

**Before (master):**
```
Version:    dev
Commit:     dev
Date:       n/a
```

**After (this PR):**
```
Version:    v0.51.0
Commit:     dev
Date:       n/a
```

> Note: `Commit`/`Date` remain unset for tag installs — Go's build info does not embed a `vcs.revision` for a module installed at a tag. Those fields continue to be populated via `-ldflags` in official release builds.