### PR TITLE
fix: apply text filter on top of fault filter

### DIFF
--- a/internal/model1/table_data.go
+++ b/internal/model1/table_data.go
@@ -150,10 +150,10 @@ func (t *TableData) Filter(f FilterOpts) *TableData {
 		return td
 	}
 	if f, ok := internal.IsFuzzySelector(f.Filter); ok {
-		td.rowEvents = t.fuzzyFilter(f)
+		td.rowEvents = td.fuzzyFilter(f)
 		return td
 	}
-	rr, err := t.rxFilter(f.Filter, internal.IsInverseSelector(f.Filter))
+	rr, err := td.rxFilter(f.Filter, internal.IsInverseSelector(f.Filter))
 	if err == nil {
 		td.rowEvents = rr
 	} else {


### PR DESCRIPTION
## What
When `Ctrl+Z` (fault filter) is active and you type a text filter, the fault filter gets silently dropped, you end up seeing all resources matching the text, not just the faulty ones. Removing the text filter brings the fault filter back.

## Why
In `TableData.Filter()` in `internal/model1/table_data.go`, when both toast and a text filter are set, the code correctly filters to faults first and stores the result in `td.rowEvents`. But `rxFilter`/`fuzzyFilter` are then called on `t` (the original full dataset) instead of `td`, overwriting the fault-filtered rows entirely.

## Fix
Changed `t.fuzzyFilter` and `t.rxFilter` to `td.fuzzyFilter` and `td.rxFilter` so the text filter runs on the fault-filtered subset.

## Behavior
- Fault filter only: works as before
- Text filter only: works as before
- Both active: text filter now correctly narrows within the fault-filtered results

Fixes #4133