### PR TITLE
fix #4139: preserve node pod counting when jumping to node view

### DIFF
--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -639,6 +639,9 @@ func (b *Browser) defaultContext() context.Context {
 	}
 	ctx = context.WithValue(ctx, internal.KeyNamespace, client.CleanseNamespace(b.App().Config.ActiveNamespace()))
 	ctx = context.WithValue(ctx, internal.KeyWithMetrics, b.app.factory.Client().HasMetrics())
+	if b.GVR() == client.NodeGVR {
+		ctx = context.WithValue(ctx, internal.KeyPodCounting, !b.app.Config.K9s.DisablePodCounting)
+	}
 
 	return ctx
 }


### PR DESCRIPTION
Fix #4139 

Set KeyPodCounting in the browser default context for nodes so navigation still counts pods after context callbacks are overridden.