### PR TITLE
fix(render): decouple pod display and health counts

### DIFF
--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -161,9 +161,11 @@ func (p *Pod) defaultRow(pwm *PodWithMetrics, row *model1.Row) error {
 
 	dt := pwm.Raw.GetDeletionTimestamp()
 	cReady, _, cRestarts, lastRestart := p.ContainerStats(st.ContainerStatuses)
+	declaredReady, _, _, _ := p.declaredContainerStats(spec.Containers, st.ContainerStatuses)
 
 	iReady, iTotal, iRestarts := p.initContainerStats(spec.InitContainers, st.InitContainerStatuses)
 	cReady += iReady
+	declaredReady += iReady
 	allCounts := len(spec.Containers) + iTotal
 	rgr, rgt := p.readinessGateStats(spec, &st)
 	ready := hasPodReadyCondition(st.Conditions)
@@ -203,7 +205,7 @@ func (p *Pod) defaultRow(pwm *PodWithMetrics, row *model1.Row) error {
 		asReadinessGate(spec, &st),
 		p.mapQOS(st.QOSClass),
 		mapToStr(pwm.Raw.GetLabels()),
-		AsStatus(p.diagnose(phase, cReady, allCounts, ready, rgr, rgt)),
+		AsStatus(p.diagnose(phase, declaredReady, allCounts, ready, rgr, rgt)),
 		ToAge(pwm.Raw.GetCreationTimestamp()),
 	}
 
@@ -229,8 +231,8 @@ func (p *Pod) Healthy(_ context.Context, o any) error {
 	}
 	dt := pwm.Raw.GetDeletionTimestamp()
 	phase := p.Phase(dt, spec, &st)
-	cr, _, _, _ := p.ContainerStats(st.ContainerStatuses)
-	ct := len(st.ContainerStatuses)
+	cr, _, _, _ := p.declaredContainerStats(spec.Containers, st.ContainerStatuses)
+	ct := len(spec.Containers)
 
 	icr, ict, _ := p.initContainerStats(spec.InitContainers, st.InitContainerStatuses)
 	cr += icr
@@ -405,7 +407,25 @@ func (*Pod) mapQOS(class v1.PodQOSClass) string {
 
 // ContainerStats reports pod container stats.
 func (*Pod) ContainerStats(cc []v1.ContainerStatus) (readyCnt, terminatedCnt, restartCnt int, latest metav1.Time) {
+	return containerStats(cc, nil)
+}
+
+func (*Pod) declaredContainerStats(containers []v1.Container, statuses []v1.ContainerStatus) (readyCnt, terminatedCnt, restartCnt int, latest metav1.Time) {
+	declared := make(map[string]struct{}, len(containers))
+	for i := range containers {
+		declared[containers[i].Name] = struct{}{}
+	}
+
+	return containerStats(statuses, declared)
+}
+
+func containerStats(cc []v1.ContainerStatus, declared map[string]struct{}) (readyCnt, terminatedCnt, restartCnt int, latest metav1.Time) {
 	for i := range cc {
+		if declared != nil {
+			if _, ok := declared[cc[i].Name]; !ok {
+				continue
+			}
+		}
 		if cc[i].State.Terminated != nil {
 			terminatedCnt++
 		}

--- a/internal/render/pod_test.go
+++ b/internal/render/pod_test.go
@@ -4,6 +4,7 @@
 package render_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/derailed/k9s/internal/model1"
@@ -166,6 +167,32 @@ func TestPodRender(t *testing.T) {
 	assert.Equal(t, "default/nginx", r.ID)
 	e := model1.Fields{"default", "nginx", "n/a", "●", "1/1", "Running", "0", "<unknown>", "100", "100:0", "100", "n/a", "50", "70:170", "71", "29", "0:0", "172.17.0.6", "minikube", "default", "<none>"}
 	assert.Equal(t, e, r.Fields[:21])
+}
+
+func TestPodRenderShowsAdditionalContainerStatusWithoutMarkingPodUnhealthy(t *testing.T) {
+	pom := render.PodWithMetrics{Raw: load(t, "po")}
+	status := pom.Raw.Object["status"].(map[string]any)
+	statuses := status["containerStatuses"].([]any)
+	injectedStatus := map[string]any{
+		"name":         "[logtail-ds-supernode]logtail",
+		"ready":        true,
+		"restartCount": int64(0),
+		"state": map[string]any{
+			"running": map[string]any{},
+		},
+	}
+	status["containerStatuses"] = append(statuses, injectedStatus)
+
+	po := render.NewPod()
+	r := model1.NewRow(14)
+	require.NoError(t, po.Render(&pom, "", &r))
+
+	assert.Equal(t, "2/1", r.Fields[4])
+	re := model1.RowEvent{Kind: model1.EventAdd, Row: r}
+	assert.Equal(t, model1.StdColor, po.ColorerFunc()("", po.Header(""), &re))
+
+	injectedStatus["ready"] = false
+	assert.NoError(t, po.Healthy(context.Background(), &pom))
 }
 
 func BenchmarkPodRender(b *testing.B) {


### PR DESCRIPTION
## Summary

- Keep all ready entries from `status.containerStatuses` visible in the Pod `READY` column.
- Validate Pod health against container statuses whose names match `spec.containers`.
- Add a regression test covering both row coloring and the `Healthy` check.

## Why

Some virtual-node providers add provider-managed containers directly to `status.containerStatuses` without adding them to `spec.containers`. In the reported TKE case, a Pod with two declared containers has three ready status entries and a `Ready=True` condition.

K9s currently displays `3/2`, then passes the displayed ready count to `diagnose` together with the declared container count. The resulting count mismatch marks an otherwise healthy Pod row as invalid.

Filtering the extra status from the display would make the row look healthy, but it would also hide useful information that a provider-managed container exists. This change therefore separates the two concerns:

- Display statistics continue to include all reported regular container statuses.
- Health validation uses only statuses that correspond to containers declared in the Pod spec, plus the existing Pod `Ready` and readiness-gate checks.

The implementation is provider-neutral and does not depend on TKE annotations or container naming conventions.

## Testing

- `make test`
- `golangci-lint v2.6.2 run` (`0 issues`)

Fixes #4145
