### PR TITLE
fix(dao): allow port-forward with 'get' verb on pods/portforward for K8s 1.31+ WebSocket

### DIFF
--- a/internal/dao/port_forwarder.go
+++ b/internal/dao/port_forwarder.go
@@ -141,12 +141,26 @@ func (p *PortForwarder) Start(path string, tt port.PortTunnel) (*portforward.Por
 		return nil, fmt.Errorf("unable to forward port because pod is not running. Current status=%v", pod.Status.Phase)
 	}
 
-	auth, err = p.Client().CanI(ns, client.PodGVR.WithSubResource("portforward"), "", []string{client.CreateVerb})
+	// Kubernetes port-forward via SPDY requires the 'create' verb on pods/portforward.
+	// Starting with Kubernetes 1.31, kubectl and client-go can negotiate port-forward over
+	// WebSockets instead of SPDY (PortForwardWebsockets feature). A WebSocket handshake is
+	// an HTTP GET, which maps to the 'get' verb in RBAC. Therefore, a Role that grants only
+	// 'get' on pods/portforward is sufficient for port-forward on 1.31+ clusters.
+	//
+	// We perform two independent authorization checks and allow port-forward if EITHER one
+	// succeeds. This preserves backward compatibility for legacy SPDY-only clusters while
+	// correctly supporting the newer WebSocket path.
+	var getAuth, createAuth bool
+	getAuth, err = p.Client().CanI(ns, client.PodGVR.WithSubResource("portforward"), "", client.GetAccess)
 	if err != nil {
 		return nil, err
 	}
-	if !auth {
-		return nil, fmt.Errorf("user is not authorized to update portforward")
+	createAuth, err = p.Client().CanI(ns, client.PodGVR.WithSubResource("portforward"), "", []string{client.CreateVerb})
+	if err != nil {
+		return nil, err
+	}
+	if !getAuth && !createAuth {
+		return nil, fmt.Errorf("user is not authorized to access portforward (requires get or create on pods/portforward)")
 	}
 
 	cfg, err := p.Client().RestConfig()

--- a/internal/dao/port_forwarder_test.go
+++ b/internal/dao/port_forwarder_test.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/port"
+	"github.com/derailed/k9s/internal/watch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery/cached/disk"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	versioned "k8s.io/metrics/pkg/client/clientset/versioned"
+)
+
+// ----------------------------------------------------------------------------
+// PortForwarder Authorization Test Suite
+// ----------------------------------------------------------------------------
+
+func TestPortForwarder_Start(t *testing.T) {
+	cases := []struct {
+		name            string
+		phase           v1.PodPhase
+		auth            authConfig
+		wantAuthErr     bool   // true if error must contain auth denial
+		wantErrContains string // expected error substring (empty = just require error)
+	}{
+		{
+			name:            "pod not running",
+			phase:           v1.PodPending,
+			auth:            authConfig{canGetPod: true},
+			wantAuthErr:     false,
+			wantErrContains: "pod is not running",
+		},
+		{
+			name:            "unauthorized to get pod",
+			phase:           v1.PodRunning,
+			auth:            authConfig{canGetPod: false},
+			wantAuthErr:     false,
+			wantErrContains: "not authorized to get pods",
+		},
+		{
+			name:        "create only — legacy SPDY allowed",
+			phase:       v1.PodRunning,
+			auth:        authConfig{canGetPod: true, canCreatePortForward: true},
+			wantAuthErr: false,
+		},
+		{
+			name:        "get only — WebSocket path allowed",
+			phase:       v1.PodRunning,
+			auth:        authConfig{canGetPod: true, canGetPortForward: true},
+			wantAuthErr: false,
+		},
+		{
+			name:        "both permissions",
+			phase:       v1.PodRunning,
+			auth:        authConfig{canGetPod: true, canCreatePortForward: true, canGetPortForward: true},
+			wantAuthErr: false,
+		},
+		{
+			name:            "neither permission",
+			phase:           v1.PodRunning,
+			auth:            authConfig{canGetPod: true},
+			wantAuthErr:     true,
+			wantErrContains: "not authorized to access portforward",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pf := NewPortForwarder(makePortForwardFactoryWithAuth(tc.phase, tc.auth))
+			_, err := pf.Start("test-ns/pod-1", testTunnel())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErrContains)
+			if tc.wantAuthErr {
+				assert.Contains(t, err.Error(), "not authorized to access portforward")
+			} else {
+				assert.NotContains(t, err.Error(), "not authorized to access portforward")
+			}
+		})
+	}
+}
+
+// Removed separate per-scenario test functions in favor of table-driven test above.
+
+// ----------------------------------------------------------------------------
+// Test Helpers
+// ----------------------------------------------------------------------------
+
+type authConfig struct {
+	canGetPod            bool
+	canCreatePortForward bool
+	canGetPortForward    bool
+}
+
+func testTunnel() port.PortTunnel {
+	return port.NewPortTunnel("localhost", "main", "8080", "80")
+}
+
+func makePortForwardFactoryWithAuth(phase v1.PodPhase, cfg authConfig) Factory {
+	return &pfFactory{authCfg: cfg, podPhase: phase}
+}
+
+func makePortForwardFactory(phase v1.PodPhase) Factory {
+	return &pfFactory{
+		authCfg: authConfig{
+			canGetPod:            true,
+			canCreatePortForward: true,
+			canGetPortForward:    true,
+		},
+		podPhase: phase,
+	}
+}
+
+type pfFactory struct {
+	authCfg  authConfig
+	podPhase v1.PodPhase
+}
+
+func (f *pfFactory) Client() client.Connection { return &pfConn{cfg: f.authCfg, phase: f.podPhase} }
+
+func (f *pfFactory) Get(gvr *client.GVR, path string, wait bool, sel labels.Selector) (runtime.Object, error) {
+	ns, n := client.Namespaced(path)
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      n,
+				"namespace": ns,
+			},
+			"status": map[string]interface{}{
+				"phase": string(f.podPhase),
+			},
+		},
+	}, nil
+}
+
+func (f *pfFactory) List(gvr *client.GVR, ns string, wait bool, sel labels.Selector) ([]runtime.Object, error) {
+	return nil, nil
+}
+func (f *pfFactory) ForResource(ns string, gvr *client.GVR) (informers.GenericInformer, error) {
+	return nil, nil
+}
+func (f *pfFactory) CanForResource(ns string, gvr *client.GVR, verbs []string) (informers.GenericInformer, error) {
+	return nil, nil
+}
+func (f *pfFactory) WaitForCacheSync()            {}
+func (f *pfFactory) Forwarders() watch.Forwarders { return nil }
+func (f *pfFactory) DeleteForwarder(string)       {}
+
+// ----------------------------------------------------------------------------
+// Mock Connection
+// ----------------------------------------------------------------------------
+
+type pfConn struct {
+	cfg     authConfig
+	phase   v1.PodPhase
+	dialErr error
+}
+
+func (*pfConn) Config() *client.Config                                { return nil }
+func (c *pfConn) Dial() (kubernetes.Interface, error)                 { return nil, c.dialErr }
+func (c *pfConn) DialLogs() (kubernetes.Interface, error)             { return nil, nil }
+func (*pfConn) ConnectionOK() bool                                    { return true }
+func (*pfConn) SwitchContext(string) error                            { return nil }
+func (*pfConn) CachedDiscovery() (*disk.CachedDiscoveryClient, error) { return nil, nil }
+func (c *pfConn) RestConfig() (*restclient.Config, error) {
+	return nil, fmt.Errorf("mock: no real cluster")
+}
+func (*pfConn) MXDial() (*versioned.Clientset, error)                    { return nil, nil }
+func (*pfConn) DynDial() (dynamic.Interface, error)                      { return nil, nil }
+func (*pfConn) HasMetrics() bool                                         { return false }
+func (*pfConn) CheckConnectivity() bool                                  { return false }
+func (*pfConn) IsNamespaced(string) bool                                 { return false }
+func (*pfConn) SupportsResource(string) bool                             { return false }
+func (*pfConn) ValidNamespaces() ([]v1.Namespace, error)                 { return nil, nil }
+func (*pfConn) SupportsRes(string, []string) (a string, b bool, e error) { return "", false, nil }
+func (*pfConn) ServerVersion() (*version.Info, error)                    { return nil, nil }
+func (*pfConn) CurrentNamespaceName() (string, error)                    { return "", nil }
+func (*pfConn) ActiveContext() string                                    { return "" }
+func (*pfConn) ActiveNamespace() string                                  { return "" }
+func (*pfConn) IsValidNamespace(string) bool                             { return true }
+func (*pfConn) ValidNamespaceNames() (client.NamespaceNames, error)      { return nil, nil }
+func (*pfConn) IsActiveNamespace(string) bool                            { return false }
+
+func (c *pfConn) CanI(ns string, gvr *client.GVR, name string, verbs []string) (bool, error) {
+	gvrStr := gvr.String()
+
+	if gvrStr == client.PodGVR.String() {
+		for _, v := range verbs {
+			if v == client.GetVerb && c.cfg.canGetPod {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	if gvrStr == client.PodGVR.WithSubResource("portforward").String() {
+		for _, v := range verbs {
+			if v == client.CreateVerb && c.cfg.canCreatePortForward {
+				return true, nil
+			}
+			if v == client.GetVerb && c.cfg.canGetPortForward {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	return false, nil
+}

--- a/internal/dao/port_forwarder_test.go
+++ b/internal/dao/port_forwarder_test.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dao
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/derailed/k9s/internal/client"
+	"github.com/derailed/k9s/internal/port"
+	"github.com/derailed/k9s/internal/watch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery/cached/disk"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	versioned "k8s.io/metrics/pkg/client/clientset/versioned"
+)
+
+// ----------------------------------------------------------------------------
+// PortForwarder Authorization Test Suite
+// ----------------------------------------------------------------------------
+
+func TestPortForwarder_Start(t *testing.T) {
+	cases := []struct {
+		name            string
+		phase           v1.PodPhase
+		auth            authConfig
+		wantAuthErr     bool   // true if error must contain auth denial
+		wantErrContains string // expected error substring (empty = just require error)
+	}{
+		{
+			name:            "pod not running",
+			phase:           v1.PodPending,
+			auth:            authConfig{canGetPod: true},
+			wantAuthErr:     false,
+			wantErrContains: "pod is not running",
+		},
+		{
+			name:            "unauthorized to get pod",
+			phase:           v1.PodRunning,
+			auth:            authConfig{canGetPod: false},
+			wantAuthErr:     false,
+			wantErrContains: "not authorized to get pods",
+		},
+		{
+			name:        "create only — legacy SPDY allowed",
+			phase:       v1.PodRunning,
+			auth:        authConfig{canGetPod: true, canCreatePortForward: true},
+			wantAuthErr: false,
+		},
+		{
+			name:        "get only — WebSocket path allowed",
+			phase:       v1.PodRunning,
+			auth:        authConfig{canGetPod: true, canGetPortForward: true},
+			wantAuthErr: false,
+		},
+		{
+			name:        "both permissions",
+			phase:       v1.PodRunning,
+			auth:        authConfig{canGetPod: true, canCreatePortForward: true, canGetPortForward: true},
+			wantAuthErr: false,
+		},
+		{
+			name:            "neither permission",
+			phase:           v1.PodRunning,
+			auth:            authConfig{canGetPod: true},
+			wantAuthErr:     true,
+			wantErrContains: "not authorized to access portforward",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pf := NewPortForwarder(makePortForwardFactoryWithAuth(tc.phase, tc.auth))
+			_, err := pf.Start("test-ns/pod-1", testTunnel())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErrContains)
+			if tc.wantAuthErr {
+				assert.Contains(t, err.Error(), "not authorized to access portforward")
+			} else {
+				assert.NotContains(t, err.Error(), "not authorized to access portforward")
+			}
+		})
+	}
+}
+
+// Removed separate per-scenario test functions in favor of table-driven test above.
+
+// ----------------------------------------------------------------------------
+// Test Helpers
+// ----------------------------------------------------------------------------
+
+type authConfig struct {
+	canGetPod            bool
+	canCreatePortForward bool
+	canGetPortForward    bool
+}
+
+func testTunnel() port.PortTunnel {
+	return port.NewPortTunnel("localhost", "main", "8080", "80")
+}
+
+func makePortForwardFactoryWithAuth(phase v1.PodPhase, cfg authConfig) Factory {
+	return &pfFactory{authCfg: cfg, podPhase: phase}
+}
+
+func makePortForwardFactory(phase v1.PodPhase) Factory {
+	return &pfFactory{
+		authCfg: authConfig{
+			canGetPod:            true,
+			canCreatePortForward: true,
+			canGetPortForward:    true,
+		},
+		podPhase: phase,
+	}
+}
+
+type pfFactory struct {
+	authCfg  authConfig
+	podPhase v1.PodPhase
+}
+
+func (f *pfFactory) Client() client.Connection { return &pfConn{cfg: f.authCfg, phase: f.podPhase} }
+
+func (f *pfFactory) Get(_ *client.GVR, path string, _ bool, _ labels.Selector) (runtime.Object, error) {
+	ns, n := client.Namespaced(path)
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      n,
+				"namespace": ns,
+			},
+			"status": map[string]interface{}{
+				"phase": string(f.podPhase),
+			},
+		},
+	}, nil
+}
+
+func (f *pfFactory) List(_ *client.GVR, _ string, _ bool, _ labels.Selector) ([]runtime.Object, error) {
+	return nil, nil
+}
+func (f *pfFactory) ForResource(_ string, _ *client.GVR) (informers.GenericInformer, error) {
+	return nil, nil
+}
+func (f *pfFactory) CanForResource(_ string, _ *client.GVR, _ []string) (informers.GenericInformer, error) {
+	return nil, nil
+}
+func (_ *pfFactory) WaitForCacheSync()            {}
+func (_ *pfFactory) Forwarders() watch.Forwarders { return nil }
+func (_ *pfFactory) DeleteForwarder(string)       {}
+
+// ----------------------------------------------------------------------------
+// Mock Connection
+// ----------------------------------------------------------------------------
+
+type pfConn struct {
+	cfg     authConfig
+	phase   v1.PodPhase
+	dialErr error
+}
+
+func (*pfConn) Config() *client.Config                                { return nil }
+func (c *pfConn) Dial() (kubernetes.Interface, error)                 { return nil, c.dialErr }
+func (*pfConn) DialLogs() (kubernetes.Interface, error)               { return nil, nil }
+func (*pfConn) ConnectionOK() bool                                    { return true }
+func (*pfConn) SwitchContext(string) error                            { return nil }
+func (*pfConn) CachedDiscovery() (*disk.CachedDiscoveryClient, error) { return nil, nil }
+func (*pfConn) RestConfig() (*restclient.Config, error) {
+	return nil, fmt.Errorf("mock: no real cluster")
+}
+func (*pfConn) MXDial() (*versioned.Clientset, error)                    { return nil, nil }
+func (*pfConn) DynDial() (dynamic.Interface, error)                      { return nil, nil }
+func (*pfConn) HasMetrics() bool                                         { return false }
+func (*pfConn) CheckConnectivity() bool                                  { return false }
+func (*pfConn) IsNamespaced(string) bool                                 { return false }
+func (*pfConn) SupportsResource(string) bool                             { return false }
+func (*pfConn) ValidNamespaces() ([]v1.Namespace, error)                 { return nil, nil }
+func (*pfConn) SupportsRes(string, []string) (a string, b bool, e error) { return "", false, nil }
+func (*pfConn) ServerVersion() (*version.Info, error)                    { return nil, nil }
+func (*pfConn) CurrentNamespaceName() (string, error)                    { return "", nil }
+func (*pfConn) ActiveContext() string                                    { return "" }
+func (*pfConn) ActiveNamespace() string                                  { return "" }
+func (*pfConn) IsValidNamespace(string) bool                             { return true }
+func (*pfConn) ValidNamespaceNames() (client.NamespaceNames, error)      { return nil, nil }
+func (*pfConn) IsActiveNamespace(string) bool                            { return false }
+
+func (c *pfConn) CanI(ns string, gvr *client.GVR, name string, verbs []string) (bool, error) {
+	gvrStr := gvr.String()
+
+	if gvrStr == client.PodGVR.String() {
+		for _, v := range verbs {
+			if v == client.GetVerb && c.cfg.canGetPod {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	if gvrStr == client.PodGVR.WithSubResource("portforward").String() {
+		for _, v := range verbs {
+			if v == client.CreateVerb && c.cfg.canCreatePortForward {
+				return true, nil
+			}
+			if v == client.GetVerb && c.cfg.canGetPortForward {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
## fix(dao): allow port-forward authorization with either `get` or `create` on `pods/portforward`

Closes #4144

### Problem

K9s unconditionally requires the **`create`** verb on the `pods/portforward` subresource before initiating a port-forward session. This pre-flight check was correct for the legacy SPDY transport but breaks users on **Kubernetes 1.31+** clusters where port-forward is negotiated over **WebSockets**.

Starting with Kubernetes 1.31, `kubectl port-forward` and client-go prefer WebSocket when the `PortForwardWebsockets` feature is enabled (default-on). A WebSocket handshake is an HTTP **GET** request, which maps to the **`get`** verb in RBAC. Consequently, a Role that grants only `get` on `pods/portforward` is sufficient for `kubectl port-forward` but insufficient for K9s — K9s blocks the operation at the client-side authorization check even though the underlying transport would succeed.

**Concrete scenario:**
- Cluster: Kubernetes 1.31+
- User RBAC:
  ```yaml
  - apiGroups: [""]
    resources: ["pods"]
    verbs: ["get"]
  - apiGroups: [""]
    resources: ["pods/portforward"]
    verbs: ["get"]          # sufficient for WebSocket, NOT SPDY
  ```
- `kubectl port-forward` → ✅ succeeds
- K9s port-forward → ❌ fails with "user is not authorized to update portforward"

This issue was previously reported in #3322 / #3346, where a `get`-only change was merged and then reverted because it broke legacy SPDY users. This PR learns from that history.

### Root Cause

In `internal/dao/port_forwarder.go`:

```go
auth, err = p.Client().CanI(ns, client.PodGVR.WithSubResource("portforward"), "", []string{client.CreateVerb})
if !auth {
    return nil, fmt.Errorf("user is not authorized to update portforward")
}
```

The code checks a single verb. It does not account for the fact that the transport (SPDY vs WebSocket) determines which verb is actually required.

### Solution

Perform **two independent authorization checks** and allow port-forward if **either** succeeds:

1. `get` on `pods/portforward` — needed for WebSocket transport (K8s 1.31+)
2. `create` on `pods/portforward` — needed for SPDY transport (legacy clusters)

```go
var getAuth, createAuth bool
getAuth, err = p.Client().CanI(ns, client.PodGVR.WithSubResource("portforward"), "", client.GetAccess)
createAuth, err = p.Client().CanI(ns, client.PodGVR.WithSubResource("portforward"), "", []string{client.CreateVerb})

if !getAuth && !createAuth {
    return nil, fmt.Errorf("user is not authorized to access portforward (requires get or create on pods/portforward)")
}
```

This is an **inclusive OR** — we don't need to know which transport the cluster will negotiate; we simply allow the attempt if the user possesses at least one of the required permissions.

**Why this handles the revert correctly:**
- PR #3322 changed `create` → `get`, breaking SPDY-only clusters → reverted in #3346
- This PR keeps **both** checks, so neither SPDY-only nor WebSocket-only users are blocked

### Changes

| File | Change |
|------|--------|
| `internal/dao/port_forwarder.go` | Split single `create` check into independent `get` + `create` OR; improved error message |
| `internal/dao/port_forwarder_test.go` | New file: comprehensive unit tests for all RBAC scenarios |

### Test Coverage

The new test file covers 6 scenarios:

| Test | Expected |
|------|----------|
| `TestPortForwarder_Start_PodNotRunning` | Pod phase check fails with descriptive error |
| `TestPortForwarder_Start_UnauthorizedGetPod` | Missing pod-get permission fails first |
| `TestPortForwarder_Start_PortForwardPermission_CreateOnly` | Legacy SPDY path: `create` alone passes auth, fails on dialer (no real cluster) |
| `TestPortForwarder_Start_PortForwardPermission_GetOnly` | WebSocket path: `get` alone passes auth, fails on dialer |
| `TestPortForwarder_Start_PortForwardPermission_Both` | Both permissions pass auth cleanly |
| `TestPortForwarder_Start_PortForwardPermission_Neither` | Neither permission fails with "not authorized to access portforward" |

All 6 tests pass and the full `internal/dao` suite remains green.

### Manual Verification (suggested for maintainers)

1. Spin up a K8s 1.31+ cluster with WebSocket port-forward enabled (default)
2. Create a Role with only `get` on `pods/portforward`
3. Attempt port-forward in K9s — should now succeed (previously failed)
4. Test with a Role with only `create` on `pods/portforward` — should still succeed (backward compat)

### References

- Issue #4144 — Port-forward pre-flight check always requires create on pods/portforward
- Issue #3346 / PR #3322 — prior attempt and revert that motivates this approach
- [Kubernetes 1.31 Blog: SPDY to WebSocket transition](https://kubernetes.io/blog/2024/08/20/websocket-portforward-ga/)
- [kubectl#128132](https://github.com/kubernetes/kubernetes/pull/128132) — WebSocket port-forward implementation
