### PR TITLE
fix(dao): classify k8s.io resources from CRD discovery

### DIFF
--- a/internal/dao/registry.go
+++ b/internal/dao/registry.go
@@ -392,13 +392,22 @@ func loadCRDs(f Factory, m ResourceMetas) {
 			slog.Error("CRD conversion failed", slogs.Error, err)
 			continue
 		}
-		for gvr, version := range client.NewGVRFromCRD(&crd) {
-			if meta, ok := m[gvr]; ok && version.Subresources != nil && version.Subresources.Scale != nil {
-				if !slices.Contains(meta.Categories, scaleCat) {
-					meta.Categories = append(meta.Categories, scaleCat)
-					m[gvr] = meta
-				}
-			}
+		addCRDProperties(m, &crd)
+	}
+}
+
+func addCRDProperties(m ResourceMetas, crd *apiext.CustomResourceDefinition) {
+	for gvr, version := range client.NewGVRFromCRD(crd) {
+		meta, ok := m[gvr]
+		if !ok {
+			continue
 		}
+		if !slices.Contains(meta.Categories, crdCat) {
+			meta.Categories = append(meta.Categories, crdCat)
+		}
+		if version.Subresources != nil && version.Subresources.Scale != nil && !slices.Contains(meta.Categories, scaleCat) {
+			meta.Categories = append(meta.Categories, scaleCat)
+		}
+		m[gvr] = meta
 	}
 }

--- a/internal/dao/registry_test.go
+++ b/internal/dao/registry_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/derailed/k9s/internal/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -78,4 +79,44 @@ func TestMetaFor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAddCRDPropertiesMarksK8sIOCRD(t *testing.T) {
+	gatewayGVR := client.NewGVR("gateway.networking.k8s.io/v1/httproutes")
+	gatewayMeta := &metav1.APIResource{
+		Name:       "httproutes",
+		Group:      "gateway.networking.k8s.io",
+		Version:    "v1",
+		Kind:       "HTTPRoute",
+		Categories: []string{"gateway-api"},
+	}
+	ingressGVR := client.NewGVR("networking.k8s.io/v1/ingresses")
+	ingressMeta := &metav1.APIResource{
+		Name:    "ingresses",
+		Group:   "networking.k8s.io",
+		Version: "v1",
+		Kind:    "Ingress",
+	}
+	metas := ResourceMetas{
+		gatewayGVR: gatewayMeta,
+		ingressGVR: ingressMeta,
+	}
+	crd := apiext.CustomResourceDefinition{
+		Spec: apiext.CustomResourceDefinitionSpec{
+			Group: "gateway.networking.k8s.io",
+			Names: apiext.CustomResourceDefinitionNames{
+				Plural: "httproutes",
+				Kind:   "HTTPRoute",
+			},
+			Versions: []apiext.CustomResourceDefinitionVersion{
+				{Name: "v1", Served: true},
+			},
+		},
+	}
+
+	addCRDProperties(metas, &crd)
+
+	assert.True(t, IsCRD(gatewayMeta))
+	assert.Equal(t, []string{"gateway-api", crdCat}, gatewayMeta.Categories)
+	assert.False(t, IsCRD(ingressMeta))
 }


### PR DESCRIPTION
## Summary

  - mark resources confirmed by CRD discovery with the CRD category
  - preserve standard Kubernetes group classification
  - cover Gateway API and built-in networking groups with a cluster-free regression test

  Fixes #4141.

  ## Testing

  - `go test -p 2 ./internal/dao -run '^TestAddCRDPropertiesMarksK8sIOCRD$' -count=1 -v`
    - passed
  - `golangci-lint run --new-from-rev=HEAD ./internal/dao`
    - passed with local v2.10.1
  - `git diff --check`
    - passed