### PR TITLE
fix: don't mark pod unhealthy for an undeclared, provider-injected status container

### DIFF
--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -164,7 +164,18 @@ func (p *Pod) defaultRow(pwm *PodWithMetrics, row *model1.Row) error {
 
 	iReady, iTotal, iRestarts := p.initContainerStats(spec.InitContainers, st.InitContainerStatuses)
 	cReady += iReady
+	// allCounts reflects the containers declared in the spec, so status-only
+	// entries injected by some providers (e.g. a virtual-node logging sidecar
+	// that never appears in spec.containers) still show up in the displayed
+	// ready count, e.g. "3/2".
 	allCounts := len(spec.Containers) + iTotal
+	// hr/ht are used for the health check below instead of cReady/allCounts:
+	// they only count status entries that match a container declared in the
+	// spec, so provider-injected status-only containers can't make an
+	// otherwise-healthy pod (all declared containers ready) show as unhealthy.
+	hr, ht := p.matchedContainerStats(spec.Containers, st.ContainerStatuses)
+	hr += iReady
+	ht += iTotal
 	rgr, rgt := p.readinessGateStats(spec, &st)
 	ready := hasPodReadyCondition(st.Conditions)
 
@@ -203,7 +214,7 @@ func (p *Pod) defaultRow(pwm *PodWithMetrics, row *model1.Row) error {
 		asReadinessGate(spec, &st),
 		p.mapQOS(st.QOSClass),
 		mapToStr(pwm.Raw.GetLabels()),
-		AsStatus(p.diagnose(phase, cReady, allCounts, ready, rgr, rgt)),
+		AsStatus(p.diagnose(phase, hr, ht, ready, rgr, rgt)),
 		ToAge(pwm.Raw.GetCreationTimestamp()),
 	}
 
@@ -229,8 +240,10 @@ func (p *Pod) Healthy(_ context.Context, o any) error {
 	}
 	dt := pwm.Raw.GetDeletionTimestamp()
 	phase := p.Phase(dt, spec, &st)
-	cr, _, _, _ := p.ContainerStats(st.ContainerStatuses)
-	ct := len(st.ContainerStatuses)
+	// Only count status entries that match a container declared in the spec,
+	// so status-only containers injected by some providers can't make an
+	// otherwise-healthy pod show as unhealthy.
+	cr, ct := p.matchedContainerStats(spec.Containers, st.ContainerStatuses)
 
 	icr, ict, _ := p.initContainerStats(spec.InitContainers, st.InitContainerStatuses)
 	cr += icr
@@ -419,6 +432,31 @@ func (*Pod) ContainerStats(cc []v1.ContainerStatus) (readyCnt, terminatedCnt, re
 			if latest.IsZero() || ts.After(latest.Time) {
 				latest = ts
 			}
+		}
+	}
+
+	return
+}
+
+// matchedContainerStats reports ready/total counts for status entries that
+// match a container declared in the spec. Some providers (e.g. virtual-node
+// implementations) report extra status-only containers that never appear in
+// spec.containers; ignoring those here keeps pod health based on the
+// containers the user actually declared, regardless of what else a provider
+// injects into status.
+func (*Pod) matchedContainerStats(cc []v1.Container, cos []v1.ContainerStatus) (readyCnt, total int) {
+	mm := make(sets.Set[string], len(cc))
+	for i := range cc {
+		mm.Insert(cc[i].Name)
+	}
+
+	for i := range cos {
+		if !mm.Has(cos[i].Name) {
+			continue
+		}
+		total++
+		if cos[i].Ready {
+			readyCnt++
 		}
 	}
 

--- a/internal/render/pod_test.go
+++ b/internal/render/pod_test.go
@@ -4,6 +4,7 @@
 package render_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/derailed/k9s/internal/model1"
@@ -213,6 +214,44 @@ func TestPodSidecarRender(t *testing.T) {
 	assert.Equal(t, "default/sleep", r.ID)
 	e := model1.Fields{"default", "sleep", "n/a", "●", "2/2", "Running", "0", "<unknown>", "100", "50:250", "200", "40", "40", "50:80", "80", "50", "0:0", "10.244.0.8", "kind-control-plane", "default", "<none>"}
 	assert.Equal(t, e, r.Fields[:21])
+}
+
+// TestPodExtraStatusContainerRender is a regression test for
+// https://github.com/derailed/k9s/issues/4145: a provider (e.g. a
+// virtual-node implementation) can report a container in
+// status.containerStatuses that has no corresponding entry in
+// spec.containers. The READY column should still surface this (e.g.
+// "3/2"), but the pod must not be marked unhealthy on account of a
+// container the user never declared, as long as the containers actually
+// declared in the spec are all ready and the pod's Ready condition holds.
+func TestPodExtraStatusContainerRender(t *testing.T) {
+	pom := render.PodWithMetrics{
+		Raw: load(t, "po_extra_status_container"),
+	}
+
+	po := render.NewPod()
+	r := model1.NewRow(26)
+	err := po.Render(&pom, "", &r)
+	require.NoError(t, err)
+
+	assert.Equal(t, "default/virtual-node-pod", r.ID)
+	assert.Equal(t, "3/2", r.Fields[4], "READY should still surface the extra status-only container")
+	assert.Equal(t, "", r.Fields[24], "STATUS should not flag the pod unhealthy solely because of an undeclared, ready status container")
+}
+
+// TestPodHealthyIgnoresExtraStatusContainer is a regression test for
+// https://github.com/derailed/k9s/issues/4145, exercising the Healthy()
+// path directly (used e.g. by the pulse view) rather than the rendered
+// row: a pod whose declared containers are all ready must not be reported
+// unhealthy just because status carries an extra, undeclared container -
+// even when that undeclared container isn't itself ready.
+func TestPodHealthyIgnoresExtraStatusContainer(t *testing.T) {
+	pom := render.PodWithMetrics{
+		Raw: load(t, "po_extra_status_container_not_ready"),
+	}
+
+	po := render.NewPod()
+	assert.NoError(t, po.Healthy(context.Background(), &pom))
 }
 
 func TestCheckPodStatus(t *testing.T) {

--- a/internal/render/testdata/po_extra_status_container.json
+++ b/internal/render/testdata/po_extra_status_container.json
@@ -1,0 +1,119 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "creationTimestamp": "2019-08-09T05:12:19Z",
+    "name": "virtual-node-pod",
+    "namespace": "default",
+    "resourceVersion": "1482816",
+    "selfLink": "/api/v1/namespaces/default/pods/virtual-node-pod",
+    "uid": "614908ed-415b-4506-8370-e3e36fa8cc14"
+  },
+  "spec": {
+    "containers": [
+      {
+        "image": "app:latest",
+        "imagePullPolicy": "IfNotPresent",
+        "name": "app",
+        "resources": {},
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File"
+      },
+      {
+        "image": "sidecar:latest",
+        "imagePullPolicy": "IfNotPresent",
+        "name": "sidecar",
+        "resources": {},
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File"
+      }
+    ],
+    "dnsPolicy": "ClusterFirst",
+    "enableServiceLinks": true,
+    "nodeName": "virtual-node",
+    "priority": 0,
+    "restartPolicy": "Always",
+    "schedulerName": "default-scheduler",
+    "securityContext": {},
+    "serviceAccount": "default",
+    "serviceAccountName": "default",
+    "terminationGracePeriodSeconds": 0
+  },
+  "status": {
+    "conditions": [
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:19Z",
+        "status": "True",
+        "type": "Initialized"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:21Z",
+        "status": "True",
+        "type": "Ready"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:21Z",
+        "status": "True",
+        "type": "ContainersReady"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:19Z",
+        "status": "True",
+        "type": "PodScheduled"
+      }
+    ],
+    "containerStatuses": [
+      {
+        "containerID": "docker://421bd26d6c682f14b5ea1dcaf06e14a509b2b702fc7793e820520eb1e28e2ea1",
+        "image": "app:latest",
+        "imageID": "docker-pullable://app@sha256:482ead44b2203fa32b3390abdaf97cbdc8ad15c07fb03a3e68d7c35a19ad7591",
+        "lastState": {},
+        "name": "app",
+        "ready": true,
+        "restartCount": 0,
+        "state": {
+          "running": {
+            "startedAt": "2019-08-09T05:12:20Z"
+          }
+        }
+      },
+      {
+        "containerID": "docker://421bd26d6c682f14b5ea1dcaf06e14a509b2b702fc7793e820520eb1e28e2ea2",
+        "image": "sidecar:latest",
+        "imageID": "docker-pullable://sidecar@sha256:482ead44b2203fa32b3390abdaf97cbdc8ad15c07fb03a3e68d7c35a19ad7592",
+        "lastState": {},
+        "name": "sidecar",
+        "ready": true,
+        "restartCount": 0,
+        "state": {
+          "running": {
+            "startedAt": "2019-08-09T05:12:20Z"
+          }
+        }
+      },
+      {
+        "containerID": "docker://421bd26d6c682f14b5ea1dcaf06e14a509b2b702fc7793e820520eb1e28e2ea3",
+        "image": "provider-agent:latest",
+        "imageID": "docker-pullable://provider-agent@sha256:482ead44b2203fa32b3390abdaf97cbdc8ad15c07fb03a3e68d7c35a19ad7593",
+        "lastState": {},
+        "name": "provider-agent",
+        "ready": true,
+        "restartCount": 0,
+        "state": {
+          "running": {
+            "startedAt": "2019-08-09T05:12:20Z"
+          }
+        }
+      }
+    ],
+    "hostIP": "192.168.64.104",
+    "phase": "Running",
+    "podIP": "172.17.0.6",
+    "qosClass": "BestEffort",
+    "startTime": "2019-08-09T05:12:19Z"
+  }
+}

--- a/internal/render/testdata/po_extra_status_container_not_ready.json
+++ b/internal/render/testdata/po_extra_status_container_not_ready.json
@@ -1,0 +1,119 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "creationTimestamp": "2019-08-09T05:12:19Z",
+    "name": "virtual-node-pod",
+    "namespace": "default",
+    "resourceVersion": "1482816",
+    "selfLink": "/api/v1/namespaces/default/pods/virtual-node-pod",
+    "uid": "614908ed-415b-4506-8370-e3e36fa8cc15"
+  },
+  "spec": {
+    "containers": [
+      {
+        "image": "app:latest",
+        "imagePullPolicy": "IfNotPresent",
+        "name": "app",
+        "resources": {},
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File"
+      },
+      {
+        "image": "sidecar:latest",
+        "imagePullPolicy": "IfNotPresent",
+        "name": "sidecar",
+        "resources": {},
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File"
+      }
+    ],
+    "dnsPolicy": "ClusterFirst",
+    "enableServiceLinks": true,
+    "nodeName": "virtual-node",
+    "priority": 0,
+    "restartPolicy": "Always",
+    "schedulerName": "default-scheduler",
+    "securityContext": {},
+    "serviceAccount": "default",
+    "serviceAccountName": "default",
+    "terminationGracePeriodSeconds": 0
+  },
+  "status": {
+    "conditions": [
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:19Z",
+        "status": "True",
+        "type": "Initialized"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:21Z",
+        "status": "True",
+        "type": "Ready"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:21Z",
+        "status": "True",
+        "type": "ContainersReady"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:19Z",
+        "status": "True",
+        "type": "PodScheduled"
+      }
+    ],
+    "containerStatuses": [
+      {
+        "containerID": "docker://421bd26d6c682f14b5ea1dcaf06e14a509b2b702fc7793e820520eb1e28e2ea1",
+        "image": "app:latest",
+        "imageID": "docker-pullable://app@sha256:482ead44b2203fa32b3390abdaf97cbdc8ad15c07fb03a3e68d7c35a19ad7591",
+        "lastState": {},
+        "name": "app",
+        "ready": true,
+        "restartCount": 0,
+        "state": {
+          "running": {
+            "startedAt": "2019-08-09T05:12:20Z"
+          }
+        }
+      },
+      {
+        "containerID": "docker://421bd26d6c682f14b5ea1dcaf06e14a509b2b702fc7793e820520eb1e28e2ea2",
+        "image": "sidecar:latest",
+        "imageID": "docker-pullable://sidecar@sha256:482ead44b2203fa32b3390abdaf97cbdc8ad15c07fb03a3e68d7c35a19ad7592",
+        "lastState": {},
+        "name": "sidecar",
+        "ready": true,
+        "restartCount": 0,
+        "state": {
+          "running": {
+            "startedAt": "2019-08-09T05:12:20Z"
+          }
+        }
+      },
+      {
+        "containerID": "docker://421bd26d6c682f14b5ea1dcaf06e14a509b2b702fc7793e820520eb1e28e2ea3",
+        "image": "provider-agent:latest",
+        "imageID": "docker-pullable://provider-agent@sha256:482ead44b2203fa32b3390abdaf97cbdc8ad15c07fb03a3e68d7c35a19ad7593",
+        "lastState": {},
+        "name": "provider-agent",
+        "ready": false,
+        "restartCount": 0,
+        "state": {
+          "running": {
+            "startedAt": "2019-08-09T05:12:20Z"
+          }
+        }
+      }
+    ],
+    "hostIP": "192.168.64.104",
+    "phase": "Running",
+    "podIP": "172.17.0.6",
+    "qosClass": "BestEffort",
+    "startTime": "2019-08-09T05:12:19Z"
+  }
+}


### PR DESCRIPTION
## What's the bug

Some providers (e.g. virtual-node implementations, as reported on Tencent Cloud TKE virtual nodes) report a container in `status.containerStatuses` that has no corresponding entry in `spec.containers` - for example a provider-managed logging sidecar. K9s already surfaces this usefully in the READY column (e.g. `3/2` for 3 status entries vs 2 declared containers), but the row was also colored **unhealthy** for the same reason, even though every container the user actually declared was ready and both the `Ready` and `ContainersReady` pod conditions were `True`.

## Root cause

In `internal/render/pod.go`'s `defaultRow`, the READY column's own numerator/denominator pair is:

- `cReady` - ready count from **all** entries in `status.containerStatuses` (via `ContainerStats`)
- `allCounts` - total count from `spec.containers` (+ init container total)

These are deliberately sourced differently so the display can show something like `3/2`. The problem is this same pair was then fed straight into `diagnose()` to decide the row's health/color:

```go
AsStatus(p.diagnose(phase, cReady, allCounts, ready, rgr, rgt))
```

`diagnose()` simply flags anything where `cr != ct`. Since `cReady` and `allCounts` can legitimately differ even when every declared container is fully ready (a provider just adds one more, ready, status entry), `diagnose()` has no way to tell "extra ready container" apart from "a declared container isn't ready".

`Healthy()` (used e.g. by the pulse view) has a related but distinct issue: it builds its own ready/total pair from all of `status.containerStatuses` (`cr, _, _, _ := p.ContainerStats(...)`, `ct := len(st.ContainerStatuses)`), so it doesn't misfire when every status entry happens to be ready, but it *would* still flag the pod unhealthy if the undeclared, provider-injected container simply isn't ready yet - even though everything actually declared in the spec is fine.

## The fix

Add a `matchedContainerStats` helper that filters `status.containerStatuses` down to only the entries whose name matches a container declared in `spec.containers` (mirroring the pattern `initContainerStats` already uses for init containers), and use it to compute the ready/total pair passed into `diagnose()` from both `defaultRow` and `Healthy()`. The existing display computation (`cReady`/`allCounts`) is left untouched, so the `3/2`-style READY column is unaffected - only the health/coloring decision now ignores containers the user never declared.

## Testing

- `TestPodExtraStatusContainerRender` - full `Render()` path with a pod that has 2 declared containers and 3 ready status entries (an extra `provider-agent`). Asserts READY still shows `3/2` and STATUS is not flagged unhealthy. Verified this fails without the fix (`container ready check failed: 3 of 2`).
- `TestPodHealthyIgnoresExtraStatusContainer` - exercises `Healthy()` directly with a fixture where the extra, undeclared container is **not** ready. Verified this fails without the fix too (`container ready check failed: 2 of 3`), confirming the latent issue in the original `Healthy()` logic that the render-path fixture alone wouldn't have caught.
- `go build ./...`, `go vet ./...` and `go test ./...` all pass (built/tested in Docker on Linux, since I don't have a Go toolchain on this machine). The one pre-existing failure in `internal/config` (`TestConfigReset`, `TestEnsureBenchmarkCfg`) is an unrelated `\r\n` vs `\n` line-ending mismatch from the Windows checkout, not something this change touches or introduces.

Fixes #4145
