### PR TITLE
docs: remove nonexistent keepMissingClusters option from config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,8 +526,6 @@ Clipboard behavior can also be controlled via environment variables:
     noIcons: false
     # Toggles whether k9s should check for the latest revision from the GitHub repository releases. Default is false.
     skipLatestRevCheck: false
-    # When altering kubeconfig or using multiple kube configs, k9s will clean up clusters configurations that are no longer in use. Setting this flag to true will keep k9s from cleaning up inactive cluster configs. Defaults to false.
-    keepMissingClusters: false
     # Logs configuration
     logger:
       # Defines the number of lines to return. Default 100


### PR DESCRIPTION
The `k9s:` config example in the README documents a `keepMissingClusters` option:

```yaml
    # When altering kubeconfig ... keep k9s from cleaning up inactive cluster configs. Defaults to false.
    keepMissingClusters: false
```

There is no such config key in k9s — it does not exist in the `K9s` config struct (`internal/config/k9s.go`) and is not in the config JSON schema, which sets `additionalProperties: false`. As a result, a config file copied from this example fails schema validation and won't load (see e.g. #3319, where a user pasted this block). Removed the unsupported key so the documented example is valid.