### PR TITLE
docs(readme): remove portForwardAddress from cluster config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,6 @@ k9s:
     active: po
   featureGates:
     nodeShell: true # => Enable this feature gate to make nodeShell available on this cluster
-  portForwardAddress: localhost
 ```
 
 ### Customizing the Shell Pod
@@ -1315,7 +1314,6 @@ k9s:
     active: po
   featureGates:
     nodeShell: false
-  portForwardAddress: localhost
 ```
 
 You can also specify a default skin for all contexts in the root k9s config file as so:


### PR DESCRIPTION
## Description

`portForwardAddress` is a global k9s config option (defined in `internal/config/k9s.go`), not a per-cluster setting. It was incorrectly shown in the cluster-specific YAML examples in the README.

This removes it from both cluster config examples to avoid confusion.

Fixes #4142