### PR TITLE
fix: render pod limit ratios as n/a unless all containers set limits

### DIFF
--- a/internal/render/node.go
+++ b/internal/render/node.go
@@ -242,6 +242,9 @@ type metric struct {
 	lcpu, lmem     int64
 	gpu, gpuShared int64
 	lgpu           int64
+	// lcpuOK, lmemOK indicate whether every container of a pod declares a
+	// limit for the given resource, ie the limit sum covers the full pod.
+	lcpuOK, lmemOK bool
 }
 
 func gatherNodeMX(no *v1.Node, mx *mv1beta1.NodeMetrics) (c, a metric) {

--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -190,11 +190,11 @@ func (p *Pod) defaultRow(pwm *PodWithMetrics, row *model1.Row) error {
 		toMc(c.cpu),
 		toMc(r.cpu) + ":" + toMc(r.lcpu),
 		client.ToPercentageStr(c.cpu, r.cpu),
-		client.ToPercentageStr(c.cpu, r.lcpu),
+		toLimitPct(c.cpu, r.lcpu, r.lcpuOK),
 		toMi(c.mem),
 		toMi(r.mem) + ":" + toMi(r.lmem),
 		client.ToPercentageStr(c.mem, r.mem),
-		client.ToPercentageStr(c.mem, r.lmem),
+		toLimitPct(c.mem, r.lmem, r.lmemOK),
 		toMc(r.gpu) + ":" + toMc(r.lgpu),
 		na(st.PodIP),
 		na(spec.NodeName),
@@ -309,6 +309,17 @@ func (p *PodWithMetrics) DeepCopyObject() runtime.Object {
 	return p
 }
 
+// toLimitPct renders a usage/limit ratio. The ratio is only meaningful when
+// every container of the pod declares a limit for the resource; otherwise it
+// renders as n/a since the pod can outrun the displayed value (#881 plan A).
+func toLimitPct(v, dv int64, allLimited bool) string {
+	if !allLimited {
+		return client.NA
+	}
+
+	return client.ToPercentageStr(v, dv)
+}
+
 func gatherPodMX(spec *v1.PodSpec, ccmx []mv1beta1.ContainerMetrics) (c, r metric) {
 	cc := make([]v1.Container, 0, len(spec.InitContainers)+len(spec.Containers))
 	cc = append(cc, filterSidecarCO(spec.InitContainers)...)
@@ -317,8 +328,9 @@ func gatherPodMX(spec *v1.PodSpec, ccmx []mv1beta1.ContainerMetrics) (c, r metri
 	rcpu, rmem, rgpu := cosRequests(cc)
 	r.cpu, r.mem, r.gpu = rcpu.MilliValue(), rmem.Value(), rgpu.Value()
 
-	lcpu, lmem, lgpu := cosLimits(cc)
+	lcpu, lmem, lgpu, lcpuOK, lmemOK := cosLimits(cc)
 	r.lcpu, r.lmem, r.lgpu = lcpu.MilliValue(), lmem.Value(), lgpu.Value()
+	r.lcpuOK, r.lmemOK = lcpuOK, lmemOK
 
 	ccpu, cmem := currentRes(ccmx)
 	c.cpu, c.mem = ccpu.MilliValue(), cmem.Value()
@@ -326,10 +338,17 @@ func gatherPodMX(spec *v1.PodSpec, ccmx []mv1beta1.ContainerMetrics) (c, r metri
 	return
 }
 
-func cosLimits(cc []v1.Container) (cpuQ, memQ, gpuQ *resource.Quantity) {
+func cosLimits(cc []v1.Container) (cpuQ, memQ, gpuQ *resource.Quantity, allCPU, allMem bool) {
 	cpuQ, gpuQ, memQ = new(resource.Quantity), new(resource.Quantity), new(resource.Quantity)
+	allCPU, allMem = true, true
 	for i := range cc {
 		limits := cc[i].Resources.Limits
+		if _, ok := limits[v1.ResourceCPU]; !ok {
+			allCPU = false
+		}
+		if _, ok := limits[v1.ResourceMemory]; !ok {
+			allMem = false
+		}
 		if len(limits) == 0 {
 			continue
 		}

--- a/internal/render/pod_int_test.go
+++ b/internal/render/pod_int_test.go
@@ -569,31 +569,69 @@ func Test_gatherPodMX(t *testing.T) {
 
 func Test_podLimits(t *testing.T) {
 	uu := map[string]struct {
-		cc []v1.Container
-		l  v1.ResourceList
+		cc             []v1.Container
+		l              v1.ResourceList
+		allCPU, allMem bool
 	}{
 		"plain": {
 			cc: []v1.Container{
 				makeContainer("c1", false, "10m", "1Mi", "20m", "2Mi"),
 			},
-			l: makeRes("20m", "2Mi"),
+			l:      makeRes("20m", "2Mi"),
+			allCPU: true,
+			allMem: true,
 		},
 		"multi-co": {
 			cc: []v1.Container{
 				makeContainer("c1", false, "10m", "1Mi", "20m", "2Mi"),
 				makeContainer("c2", false, "10m", "1Mi", "40m", "4Mi"),
 			},
-			l: makeRes("60m", "6Mi"),
+			l:      makeRes("60m", "6Mi"),
+			allCPU: true,
+			allMem: true,
+		},
+		"container-without-limits": {
+			cc: []v1.Container{
+				makeContainer("c1", false, "10m", "1Mi", "20m", "2Mi"),
+				{
+					Name: "c2",
+					Resources: v1.ResourceRequirements{
+						Requests: makeRes("5m", "1Mi"),
+					},
+				},
+			},
+			l: makeRes("20m", "2Mi"),
+		},
+		"cpu-only-limits": {
+			cc: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU: res.MustParse("20m"),
+						},
+					},
+				},
+				makeContainer("c2", false, "10m", "1Mi", "40m", "4Mi"),
+			},
+			l: v1.ResourceList{
+				v1.ResourceCPU:                    res.MustParse("60m"),
+				v1.ResourceMemory:                 res.MustParse("4Mi"),
+				v1.ResourceName("nvidia.com/gpu"): res.MustParse("40m"),
+			},
+			allCPU: true,
 		},
 	}
 
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			c, m, g := cosLimits(u.cc)
+			c, m, g, allCPU, allMem := cosLimits(u.cc)
 			assert.True(t, c.Equal(*u.l.Cpu()))
 			assert.True(t, m.Equal(*u.l.Memory()))
 			assert.True(t, g.Equal(*extractGPU(u.l)))
+			assert.Equal(t, u.allCPU, allCPU)
+			assert.Equal(t, u.allMem, allMem)
 		})
 	}
 }

--- a/internal/render/pod_test.go
+++ b/internal/render/pod_test.go
@@ -199,6 +199,61 @@ func TestPodInitRender(t *testing.T) {
 	assert.Equal(t, e, r.Fields[:21])
 }
 
+func TestPodLimitlessRender(t *testing.T) {
+	pom := render.PodWithMetrics{
+		Raw: load(t, "po_limitless"),
+		MX: &mv1beta1.PodMetrics{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nginx",
+				Namespace: "default",
+			},
+			Containers: []mv1beta1.ContainerMetrics{
+				{Usage: makeRes("100m", "90Mi")},
+				{Usage: makeRes("100m", "90Mi")},
+			},
+		},
+	}
+
+	po := render.NewPod()
+	r := model1.NewRow(14)
+	err := po.Render(&pom, "", &r)
+	require.NoError(t, err)
+
+	// Only the nginx container declares cpu/mem limits; the logger container
+	// has none. Per #881 plan A the %CPU/L and %MEM/L ratios must render as
+	// n/a instead of a misleading partial ratio (180Mi/120Mi == 150%).
+	assert.Equal(t, "default/nginx", r.ID)
+	e := model1.Fields{"default", "nginx", "n/a", "●", "2/2", "Running", "0", "<unknown>", "200", "150:300", "133", "n/a", "180", "100:120", "180", "n/a", "0:0", "172.17.0.6", "minikube", "default", "<none>"}
+	assert.Equal(t, e, r.Fields[:21])
+}
+
+func TestPodLimitRender(t *testing.T) {
+	pom := render.PodWithMetrics{
+		Raw: load(t, "po_limited"),
+		MX: &mv1beta1.PodMetrics{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nginx",
+				Namespace: "default",
+			},
+			Containers: []mv1beta1.ContainerMetrics{
+				{Usage: makeRes("100m", "90Mi")},
+				{Usage: makeRes("100m", "90Mi")},
+			},
+		},
+	}
+
+	po := render.NewPod()
+	r := model1.NewRow(14)
+	err := po.Render(&pom, "", &r)
+	require.NoError(t, err)
+
+	// Both containers declare cpu/mem limits, so the %CPU/L and %MEM/L ratios
+	// must render real values: cpu 200m/400m == 50%, mem 180Mi/180Mi == 100%.
+	assert.Equal(t, "default/nginx", r.ID)
+	e := model1.Fields{"default", "nginx", "n/a", "●", "2/2", "Running", "0", "<unknown>", "200", "150:400", "133", "50", "180", "100:180", "180", "100", "0:0", "172.17.0.6", "minikube", "default", "<none>"}
+	assert.Equal(t, e, r.Fields[:21])
+}
+
 func TestPodSidecarRender(t *testing.T) {
 	pom := render.PodWithMetrics{
 		Raw: load(t, "po_sidecar"),

--- a/internal/render/testdata/po_limited.json
+++ b/internal/render/testdata/po_limited.json
@@ -1,0 +1,177 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"image\":\"nginx:alpine\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}],\"volumeMounts\":[{\"mountPath\":\"/usr/share/nginx/html\",\"name\":\"index\"}]}],\"terminationGracePeriodSeconds\":0,\"volumes\":[{\"name\":\"index\",\"persistentVolumeClaim\":{\"claimName\":\"web\"}}]}}\n"
+    },
+    "creationTimestamp": "2019-08-09T05:12:19Z",
+    "name": "nginx",
+    "namespace": "default",
+    "resourceVersion": "1482816",
+    "selfLink": "/api/v1/namespaces/default/pods/nginx",
+    "uid": "614908ed-415b-4506-8370-e3e36fa8cc13"
+  },
+  "spec": {
+    "containers": [
+      {
+        "image": "nginx:alpine",
+        "imagePullPolicy": "IfNotPresent",
+        "name": "nginx",
+        "ports": [
+          {
+            "containerPort": 80,
+            "protocol": "TCP"
+          }
+        ],
+        "resources": {
+          "limits": {
+            "cpu": "300m",
+            "memory": "120Mi"
+          },
+          "requests": {
+            "cpu": "100m",
+            "memory": "70Mi"
+          }
+        },
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File",
+        "volumeMounts": [
+          {
+            "mountPath": "/usr/share/nginx/html",
+            "name": "index"
+          },
+          {
+            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+            "name": "default-token-9ph8s",
+            "readOnly": true
+          }
+        ]
+      },
+      {
+        "image": "busybox:1.36",
+        "imagePullPolicy": "IfNotPresent",
+        "name": "logger",
+        "command": [
+          "sh",
+          "-c",
+          "tail -f /var/log/nginx/access.log"
+        ],
+        "resources": {
+          "requests": {
+            "cpu": "50m",
+            "memory": "30Mi"
+          },
+          "limits": {
+            "cpu": "100m",
+            "memory": "60Mi"
+          }
+        },
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File"
+      }
+    ],
+    "dnsPolicy": "ClusterFirst",
+    "enableServiceLinks": true,
+    "nodeName": "minikube",
+    "priority": 0,
+    "restartPolicy": "Always",
+    "schedulerName": "default-scheduler",
+    "securityContext": {},
+    "serviceAccount": "default",
+    "serviceAccountName": "default",
+    "terminationGracePeriodSeconds": 0,
+    "tolerations": [
+      {
+        "effect": "NoExecute",
+        "key": "node.kubernetes.io/not-ready",
+        "operator": "Exists",
+        "tolerationSeconds": 300
+      },
+      {
+        "effect": "NoExecute",
+        "key": "node.kubernetes.io/unreachable",
+        "operator": "Exists",
+        "tolerationSeconds": 300
+      }
+    ],
+    "volumes": [
+      {
+        "name": "index",
+        "persistentVolumeClaim": {
+          "claimName": "web"
+        }
+      },
+      {
+        "name": "default-token-9ph8s",
+        "secret": {
+          "defaultMode": 420,
+          "secretName": "default-token-9ph8s"
+        }
+      }
+    ]
+  },
+  "status": {
+    "conditions": [
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:19Z",
+        "status": "True",
+        "type": "Initialized"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:21Z",
+        "status": "True",
+        "type": "Ready"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:21Z",
+        "status": "True",
+        "type": "ContainersReady"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:19Z",
+        "status": "True",
+        "type": "PodScheduled"
+      }
+    ],
+    "containerStatuses": [
+      {
+        "containerID": "docker://421bd26d6c682f14b5ea1dcaf06e14a509b2b702fc7793e820520eb1e28e2eaf",
+        "image": "nginx:alpine",
+        "imageID": "docker-pullable://nginx@sha256:482ead44b2203fa32b3390abdaf97cbdc8ad15c07fb03a3e68d7c35a19ad7595",
+        "lastState": {},
+        "name": "nginx",
+        "ready": true,
+        "restartCount": 0,
+        "state": {
+          "running": {
+            "startedAt": "2019-08-09T05:12:20Z"
+          }
+        }
+      },
+      {
+        "containerID": "docker://522bd26d6c682f14b5ea1dcaf06e14a509b2b702fc7793e820520eb1e28e2eba",
+        "image": "busybox:1.36",
+        "imageID": "docker-pullable://busybox@sha256:482ead44b2203fa32b3390abdaf97cbdc8ad15c07fb03a3e68d7c35a19ad7596",
+        "lastState": {},
+        "name": "logger",
+        "ready": true,
+        "restartCount": 0,
+        "state": {
+          "running": {
+            "startedAt": "2019-08-09T05:12:21Z"
+          }
+        }
+      }
+    ],
+    "hostIP": "192.168.64.104",
+    "phase": "Running",
+    "podIP": "172.17.0.6",
+    "qosClass": "Burstable",
+    "startTime": "2019-08-09T05:12:19Z"
+  }
+}

--- a/internal/render/testdata/po_limitless.json
+++ b/internal/render/testdata/po_limitless.json
@@ -1,0 +1,173 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"image\":\"nginx:alpine\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}],\"volumeMounts\":[{\"mountPath\":\"/usr/share/nginx/html\",\"name\":\"index\"}]}],\"terminationGracePeriodSeconds\":0,\"volumes\":[{\"name\":\"index\",\"persistentVolumeClaim\":{\"claimName\":\"web\"}}]}}\n"
+    },
+    "creationTimestamp": "2019-08-09T05:12:19Z",
+    "name": "nginx",
+    "namespace": "default",
+    "resourceVersion": "1482816",
+    "selfLink": "/api/v1/namespaces/default/pods/nginx",
+    "uid": "614908ed-415b-4506-8370-e3e36fa8cc13"
+  },
+  "spec": {
+    "containers": [
+      {
+        "image": "nginx:alpine",
+        "imagePullPolicy": "IfNotPresent",
+        "name": "nginx",
+        "ports": [
+          {
+            "containerPort": 80,
+            "protocol": "TCP"
+          }
+        ],
+        "resources": {
+          "limits": {
+            "cpu": "300m",
+            "memory": "120Mi"
+          },
+          "requests": {
+            "cpu": "100m",
+            "memory": "70Mi"
+          }
+        },
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File",
+        "volumeMounts": [
+          {
+            "mountPath": "/usr/share/nginx/html",
+            "name": "index"
+          },
+          {
+            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+            "name": "default-token-9ph8s",
+            "readOnly": true
+          }
+        ]
+      },
+      {
+        "image": "busybox:1.36",
+        "imagePullPolicy": "IfNotPresent",
+        "name": "logger",
+        "command": [
+          "sh",
+          "-c",
+          "tail -f /var/log/nginx/access.log"
+        ],
+        "resources": {
+          "requests": {
+            "cpu": "50m",
+            "memory": "30Mi"
+          }
+        },
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File"
+      }
+    ],
+    "dnsPolicy": "ClusterFirst",
+    "enableServiceLinks": true,
+    "nodeName": "minikube",
+    "priority": 0,
+    "restartPolicy": "Always",
+    "schedulerName": "default-scheduler",
+    "securityContext": {},
+    "serviceAccount": "default",
+    "serviceAccountName": "default",
+    "terminationGracePeriodSeconds": 0,
+    "tolerations": [
+      {
+        "effect": "NoExecute",
+        "key": "node.kubernetes.io/not-ready",
+        "operator": "Exists",
+        "tolerationSeconds": 300
+      },
+      {
+        "effect": "NoExecute",
+        "key": "node.kubernetes.io/unreachable",
+        "operator": "Exists",
+        "tolerationSeconds": 300
+      }
+    ],
+    "volumes": [
+      {
+        "name": "index",
+        "persistentVolumeClaim": {
+          "claimName": "web"
+        }
+      },
+      {
+        "name": "default-token-9ph8s",
+        "secret": {
+          "defaultMode": 420,
+          "secretName": "default-token-9ph8s"
+        }
+      }
+    ]
+  },
+  "status": {
+    "conditions": [
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:19Z",
+        "status": "True",
+        "type": "Initialized"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:21Z",
+        "status": "True",
+        "type": "Ready"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:21Z",
+        "status": "True",
+        "type": "ContainersReady"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:19Z",
+        "status": "True",
+        "type": "PodScheduled"
+      }
+    ],
+    "containerStatuses": [
+      {
+        "containerID": "docker://421bd26d6c682f14b5ea1dcaf06e14a509b2b702fc7793e820520eb1e28e2eaf",
+        "image": "nginx:alpine",
+        "imageID": "docker-pullable://nginx@sha256:482ead44b2203fa32b3390abdaf97cbdc8ad15c07fb03a3e68d7c35a19ad7595",
+        "lastState": {},
+        "name": "nginx",
+        "ready": true,
+        "restartCount": 0,
+        "state": {
+          "running": {
+            "startedAt": "2019-08-09T05:12:20Z"
+          }
+        }
+      },
+      {
+        "containerID": "docker://522bd26d6c682f14b5ea1dcaf06e14a509b2b702fc7793e820520eb1e28e2eba",
+        "image": "busybox:1.36",
+        "imageID": "docker-pullable://busybox@sha256:482ead44b2203fa32b3390abdaf97cbdc8ad15c07fb03a3e68d7c35a19ad7596",
+        "lastState": {},
+        "name": "logger",
+        "ready": true,
+        "restartCount": 0,
+        "state": {
+          "running": {
+            "startedAt": "2019-08-09T05:12:21Z"
+          }
+        }
+      }
+    ],
+    "hostIP": "192.168.64.104",
+    "phase": "Running",
+    "podIP": "172.17.0.6",
+    "qosClass": "Burstable",
+    "startTime": "2019-08-09T05:12:19Z"
+  }
+}


### PR DESCRIPTION
# fix: render pod limit ratios as n/a unless all containers set limits

Fixes #3953

## Problem

In the pod view, `%CPU/L` and `%MEM/L` divide the summed usage of **all**
containers by the limits of **only the containers that declare one**
(`cosLimits` skips limit-less containers, while `currentRes` keeps their
usage in the numerator). A limit-less container therefore inflates the
ratio past 100% — e.g. two containers using 90Mi each with a single
120Mi limit render as `180Mi / 120Mi = 150%`, which is meaningless for
assessing pod health.

## Fix

Implements the semantic chosen in #881 (plan A): a pod-level limit ratio is
only meaningful when **every** container of the pod declares a limit for
that resource. When any container lacks a cpu/memory limit, the
corresponding column renders `n/a` instead of a misleading number — which
also gives operators a visible clue that resources are not fully set.

- `cosLimits` now also reports per-resource completeness (checked via
  limit key presence, cpu and memory independently).
- `defaultRow` renders the limit ratios through a small `toLimitPct`
  helper that falls back to `client.NA` (the same `n/a` form
  `ToPercentageStr` uses for a zero divisor) when coverage is partial.
- Pods where all containers declare limits are unaffected; request ratios
  (`%CPU/R`, `%MEM/R`) and the `CPU/RL`/`MEM/RL` sums are unchanged.

## Tests

- `TestPodLimitlessRender` (new `testdata/po_limitless.json`): 2
  containers, 180Mi total usage, only one container limited at 120Mi —
  `%MEM/L` now renders `n/a` (previously `150`), `%CPU/L` renders `n/a`
  (previously `66`).
- `Test_podLimits` extended with `container-without-limits` and
  `cpu-only-limits` cases covering the new completeness flags.
- `go test ./internal/render/... -count=1` — PASS.

Root cause analysis credit: @maximilize in #3953.
