### PR TITLE
fix: don't hang on sync when namespace list is RBAC-denied

### DIFF
--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -312,8 +312,12 @@ func (b *Browser) TableNoData(mdata *model1.TableData) {
 
 	// While the informer cache hasn't synced yet, show a neutral status
 	// instead of a misleading "no resources found" warning.
-	if synced, _ := b.app.factory.HasSynced(b.GVR(), b.GetNamespace()); !synced {
+	if synced, err := b.app.factory.HasSynced(b.GVR(), b.GetNamespace()); !synced {
 		b.app.QueueUpdateDraw(func() {
+			if err != nil {
+				b.app.Flash().Warnf("Unable to sync %s: %s", b.GVR(), err)
+				return
+			}
 			b.app.Flash().Infof("Synchronizing %s in %q namespace...", b.GVR(), client.PrintNamespace(b.GetNamespace()))
 		})
 		return


### PR DESCRIPTION
When `k9s -n <namespace>` is used on a cluster that blocks `list namespaces` via RBAC, 

`HasSynced` returns false with an error indefinitely, causing k9s to loop forever showing 
"Synchronizing..." with no way out.

This fix checks the error returned by `HasSynced` — if it's non-nil (e.g. RBAC denied), 
show a warning flash instead of treating it as a pending sync.

Tested with a kind cluster + restricted service account that has pod access in one namespace 
but no cluster-wide namespace list permission. 

Open to comments and suggestions.

Fixes #4159