### PR TITLE
fix: skip namespace validation when -n is explicitly provided

### DIFF
--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -481,7 +481,8 @@ func (a *App) switchContext(ci *cmd.Interpreter, force bool) error {
 			a.Config.SetActiveView(client.PodGVR.String())
 		}
 		ns := a.Config.ActiveNamespace()
-		if !a.Conn().IsValidNamespace(ns) {
+		_, nsExplicit := ci.NSArg()
+		if !nsExplicit && !a.Conn().IsValidNamespace(ns) {
 			slog.Warn("Unable to validate namespace", slogs.Namespace, ns)
 			if err := a.Config.SetActiveNamespace(ns); err != nil {
 				return err


### PR DESCRIPTION
Root cause fix for #4159

When a namespace is passed via `-n`, `isValidNamespace()` still calls 
`ValidNamespaceNames()` which attempts a cluster-wide namespace list. 
If RBAC blocks this, the namespace is incorrectly treated as invalid.

Fix: when the user explicitly provides a namespace via `-n`, trust it 
and skip cluster-wide validation entirely. The API server will reject 
requests if the namespace doesn't exist anyway.

Tested with a kind cluster + restricted service account that has pod 
access in one namespace but no cluster-wide namespace list permission.

Fixes #4163 

Open to comments and suggestions.