### PR TITLE
feat: add default transfer directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,8 @@ Clipboard behavior can also be controlled via environment variables:
       bozo: bozo/gpu  # extends the gpu vendor and add "bozo"
     # The path to screen dump. Default: '%temp_dir%/k9s-screens-%username%' (k9s info)
     screenDumpDir: /tmp/dumps
+    # The default local directory for pod file transfers. Default: unset (relative paths use the current working directory)
+    defaultTransferDir: /tmp/k9s-downloads
     # Represents ui poll intervals in seconds. Default 2.0 secs. Minimum value is 2.0 - values below will be capped to the minimum.
     refreshRate: 2
     # Overrides the default k8s api server requests timeout. Defaults 120s

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -545,6 +545,7 @@ func TestConfigLoad(t *testing.T) {
 
 	require.NoError(t, cfg.Load("testdata/configs/k9s.yaml", true))
 	assert.InDelta(t, 2.0, cfg.K9s.RefreshRate, 0.001)
+	assert.Equal(t, "/tmp/k9s-test/downloads", cfg.K9s.DefaultTransferDir)
 	assert.Equal(t, int64(200), cfg.K9s.Logger.TailCount)
 	assert.Equal(t, 2000, cfg.K9s.Logger.BufferSize)
 }

--- a/internal/config/json/schemas/k9s.json
+++ b/internal/config/json/schemas/k9s.json
@@ -20,6 +20,7 @@
           }
         },
         "screenDumpDir": {"type": "string"},
+        "defaultTransferDir": {"type": "string"},
         "refreshRate": { "type": "number" },
         "apiServerTimeout": { "type": "string" },
         "maxConnRetry": { "type": "integer" },

--- a/internal/config/k9s.go
+++ b/internal/config/k9s.go
@@ -37,6 +37,7 @@ type K9s struct {
 	LiveViewAutoRefresh bool       `json:"liveViewAutoRefresh" yaml:"liveViewAutoRefresh"`
 	GPUVendors          gpuVendors `json:"gpuVendors" yaml:"gpuVendors"`
 	ScreenDumpDir       string     `json:"screenDumpDir" yaml:"screenDumpDir,omitempty"`
+	DefaultTransferDir  string     `json:"defaultTransferDir" yaml:"defaultTransferDir,omitempty"`
 	RefreshRate         float32    `json:"refreshRate" yaml:"refreshRate"`
 	APIServerTimeout    string     `json:"apiServerTimeout" yaml:"apiServerTimeout"`
 	MaxConnRetry        int32      `json:"maxConnRetry" yaml:"maxConnRetry"`
@@ -138,6 +139,7 @@ func (k *K9s) Merge(k1 *K9s) {
 	k.LiveViewAutoRefresh = k1.LiveViewAutoRefresh
 	k.DefaultView = k1.DefaultView
 	k.ScreenDumpDir = k1.ScreenDumpDir
+	k.DefaultTransferDir = k1.DefaultTransferDir
 	k.RefreshRate = k1.RefreshRate
 	k.APIServerTimeout = k1.APIServerTimeout
 	k.MaxConnRetry = k1.MaxConnRetry

--- a/internal/config/k9s_test.go
+++ b/internal/config/k9s_test.go
@@ -88,6 +88,7 @@ func TestK9sMerge(t *testing.T) {
 			k1: &config.K9s{
 				LiveViewAutoRefresh: false,
 				ScreenDumpDir:       "",
+				DefaultTransferDir:  "",
 				RefreshRate:         0,
 				MaxConnRetry:        0,
 				ReadOnly:            false,
@@ -102,12 +103,14 @@ func TestK9sMerge(t *testing.T) {
 			},
 			k2: &config.K9s{
 				LiveViewAutoRefresh: true,
+				DefaultTransferDir:  "/tmp/downloads",
 				MaxConnRetry:        100,
 				ShellPod:            config.NewShellPod(),
 			},
 			ek: &config.K9s{
 				LiveViewAutoRefresh: true,
 				ScreenDumpDir:       "",
+				DefaultTransferDir:  "/tmp/downloads",
 				RefreshRate:         0,
 				MaxConnRetry:        100,
 				ReadOnly:            false,

--- a/internal/config/testdata/configs/expected.yaml
+++ b/internal/config/testdata/configs/expected.yaml
@@ -3,6 +3,7 @@ k9s:
   gpuVendors:
     bozo: bozo/gpu.com
   screenDumpDir: /tmp/k9s-test/screen-dumps
+  defaultTransferDir: /tmp/k9s-test/downloads
   refreshRate: 100
   apiServerTimeout: 30s
   maxConnRetry: 5

--- a/internal/config/testdata/configs/k9s.yaml
+++ b/internal/config/testdata/configs/k9s.yaml
@@ -2,6 +2,7 @@ k9s:
   liveViewAutoRefresh: true
   gpuVendors: {}
   screenDumpDir: /tmp/k9s-test/screen-dumps
+  defaultTransferDir: /tmp/k9s-test/downloads
   refreshRate: 2
   apiServerTimeout: 10s
   maxConnRetry: 5

--- a/internal/ui/dialog/transfer.go
+++ b/internal/ui/dialog/transfer.go
@@ -25,6 +25,7 @@ type TransferArgs struct {
 type TransferDialogOpts struct {
 	Containers     []string
 	Pod            string
+	LocalPath      string
 	Title, Message string
 	Retries        int
 	Ack            TransferFn
@@ -46,20 +47,15 @@ func ShowUploads(styles *config.Dialog, pages *ui.Pages, opts *TransferDialogOpt
 
 	modal := tview.NewModalForm("<"+opts.Title+">", f)
 
-	args := TransferArgs{
-		From:    opts.Pod,
-		Retries: opts.Retries,
-	}
+	args := newTransferArgs(opts)
 	var fromField, toField *tview.InputField
-	args.Download = true
 	f.AddCheckbox("Download:", args.Download, func(_ string, flag bool) {
 		if flag {
 			modal.SetText(strings.Replace(opts.Message, "Upload", "Download", 1))
 		} else {
 			modal.SetText(strings.Replace(opts.Message, "Download", "Upload", 1))
 		}
-		args.Download = flag
-		args.From, args.To = args.To, args.From
+		args.setDownload(flag)
 		fromField.SetText(args.From)
 		toField.SetText(args.To)
 	})
@@ -120,6 +116,24 @@ func ShowUploads(styles *config.Dialog, pages *ui.Pages, opts *TransferDialogOpt
 	})
 	pages.AddPage(confirmKey, modal, false, false)
 	pages.ShowPage(confirmKey)
+}
+
+func newTransferArgs(opts *TransferDialogOpts) TransferArgs {
+	return TransferArgs{
+		From:     opts.Pod,
+		To:       opts.LocalPath,
+		Download: true,
+		Retries:  opts.Retries,
+	}
+}
+
+func (a *TransferArgs) setDownload(download bool) {
+	if a.Download == download {
+		return
+	}
+
+	a.From, a.To = a.To, a.From
+	a.Download = download
 }
 
 func dismissConfirm(pages *ui.Pages) {

--- a/internal/ui/dialog/transfer_test.go
+++ b/internal/ui/dialog/transfer_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package dialog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testPodPath   = "default/pod:"
+	testLocalPath = "/tmp/downloads"
+)
+
+func TestTransferArgsKeepConfiguredPathOnLocalSide(t *testing.T) {
+	opts := TransferDialogOpts{
+		Pod:       testPodPath,
+		LocalPath: testLocalPath,
+		Retries:   2,
+	}
+
+	args := newTransferArgs(&opts)
+	assert.Equal(t, TransferArgs{
+		From:     testPodPath,
+		To:       testLocalPath,
+		Download: true,
+		Retries:  2,
+	}, args)
+
+	args.setDownload(false)
+	assert.Equal(t, TransferArgs{
+		From:    testLocalPath,
+		To:      testPodPath,
+		Retries: 2,
+	}, args)
+
+	args.setDownload(true)
+	assert.Equal(t, TransferArgs{
+		From:     testPodPath,
+		To:       testLocalPath,
+		Download: true,
+		Retries:  2,
+	}, args)
+}
+
+func TestTransferArgsPreserveEmptyLocalPath(t *testing.T) {
+	args := newTransferArgs(&TransferDialogOpts{Pod: testPodPath})
+
+	assert.Empty(t, args.To)
+}

--- a/internal/view/pod.go
+++ b/internal/view/pod.go
@@ -342,6 +342,7 @@ func (p *Pod) transferCmd(*tcell.EventKey) *tcell.EventKey {
 		Containers: fetchContainers(&pod.ObjectMeta, &pod.Spec, false),
 		Message:    "Download Files",
 		Pod:        fmt.Sprintf("%s/%s:", ns, n),
+		LocalPath:  p.App().Config.K9s.DefaultTransferDir,
 		Ack:        ack,
 		Retries:    defaultTxRetries,
 		Cancel:     func() {},


### PR DESCRIPTION
Adds an optional `k9s.defaultTransferDir` setting and uses it to prefill the local side of the pod file transfer dialog. The configured path stays on the local side when switching between download and upload. Leaving the setting unset preserves the existing empty-field behavior.

The change also updates config merging, YAML round-trip fixtures, the JSON schema, and the README configuration example. Focused tests cover configured and unset paths as well as both transfer directions.

Validation:

- `go test ./internal/ui/dialog ./internal/config ./internal/config/json ./internal/view`
- `go vet ./internal/ui/dialog ./internal/config ./internal/config/json ./internal/view`
- `go build ./...`
- `golangci-lint run --new-from-rev=origin/master`

`go test ./...` has two unrelated failures in `internal/config/data`: `TestEnsureDirPathNone` and `TestEnsureDirPathNoOpt` observe the shared `/tmp/k9s-test` directory as `0700` instead of `0744`. The same failures reproduce on a clean `origin/master` worktree.

Fixes #4111
