### PR TITLE
fix: sort wide columns

### DIFF
--- a/internal/model1/table_data.go
+++ b/internal/model1/table_data.go
@@ -105,7 +105,7 @@ func (t *TableData) RowsRange(f ReRangeFn) {
 }
 
 func (t *TableData) Sort(sc SortColumn) {
-	col, idx := t.HeadCol(sc.Name, false)
+	col, idx := t.HeadCol(sc.Name, true)
 	if idx < 0 {
 		return
 	}

--- a/internal/model1/table_data_test.go
+++ b/internal/model1/table_data_test.go
@@ -17,6 +17,51 @@ func init() {
 	slog.SetDefault(slog.New(slog.DiscardHandler))
 }
 
+func TestTableDataSortWideColumn(t *testing.T) {
+	newTableData := func() *TableData {
+		return NewTableDataWithRows(
+			client.NewGVR("test"),
+			Header{
+				HeaderColumn{Name: "NAME"},
+				HeaderColumn{Name: "OWNER_KIND", Attrs: Attrs{Wide: true}},
+			},
+			NewRowEventsWithEvts(
+				RowEvent{Row: Row{ID: "statefulset", Fields: Fields{"statefulset", "StatefulSet"}}},
+				RowEvent{Row: Row{ID: "daemonset", Fields: Fields{"daemonset", "DaemonSet"}}},
+				RowEvent{Row: Row{ID: "job", Fields: Fields{"job", "Job"}}},
+			),
+		)
+	}
+	assertOrder := func(t *testing.T, data *TableData) {
+		t.Helper()
+		var ids []string
+		data.RowsRange(func(_ int, re RowEvent) bool {
+			ids = append(ids, re.Row.ID)
+			return true
+		})
+		assert.Equal(t, []string{"daemonset", "job", "statefulset"}, ids)
+	}
+
+	t.Run("sorts selected wide column", func(t *testing.T) {
+		data := newTableData()
+		data.Sort(SortColumn{Name: "OWNER_KIND", ASC: true})
+		assertOrder(t, data)
+	})
+
+	t.Run("keeps manual sort after wide view is hidden", func(t *testing.T) {
+		data := newTableData()
+		sortCol := data.ComputeSortCol(
+			&config.ViewSetting{Columns: []string{"NAME", "OWNER_KIND"}, SortColumn: "NAME:asc"},
+			SortColumn{Name: "OWNER_KIND", ASC: true},
+			true,
+		)
+		assert.Equal(t, SortColumn{Name: "OWNER_KIND", ASC: true}, sortCol)
+
+		data.Sort(sortCol)
+		assertOrder(t, data)
+	})
+}
+
 func TestTableDataComputeSortCol(t *testing.T) {
 	uu := map[string]struct {
 		t1           *TableData

--- a/internal/model1/table_data_test.go
+++ b/internal/model1/table_data_test.go
@@ -18,48 +18,75 @@ func init() {
 }
 
 func TestTableDataSortWideColumn(t *testing.T) {
+	const (
+		nameColumn      = "NAME"
+		ownerKindColumn = "OWNER_KIND"
+		statefulSetID   = "statefulset"
+		daemonSetID     = "daemonset"
+		jobID           = "job"
+	)
+
+	wideSortColumn := SortColumn{Name: ownerKindColumn, ASC: true}
+	expectedIDs := []string{daemonSetID, jobID, statefulSetID}
 	newTableData := func() *TableData {
 		return NewTableDataWithRows(
 			client.NewGVR("test"),
 			Header{
-				HeaderColumn{Name: "NAME"},
-				HeaderColumn{Name: "OWNER_KIND", Attrs: Attrs{Wide: true}},
+				HeaderColumn{Name: nameColumn},
+				HeaderColumn{Name: ownerKindColumn, Attrs: Attrs{Wide: true}},
 			},
 			NewRowEventsWithEvts(
-				RowEvent{Row: Row{ID: "statefulset", Fields: Fields{"statefulset", "StatefulSet"}}},
-				RowEvent{Row: Row{ID: "daemonset", Fields: Fields{"daemonset", "DaemonSet"}}},
-				RowEvent{Row: Row{ID: "job", Fields: Fields{"job", "Job"}}},
+				RowEvent{Row: Row{ID: statefulSetID, Fields: Fields{statefulSetID, "StatefulSet"}}},
+				RowEvent{Row: Row{ID: daemonSetID, Fields: Fields{daemonSetID, "DaemonSet"}}},
+				RowEvent{Row: Row{ID: jobID, Fields: Fields{jobID, "Job"}}},
 			),
 		)
 	}
-	assertOrder := func(t *testing.T, data *TableData) {
-		t.Helper()
-		var ids []string
-		data.RowsRange(func(_ int, re RowEvent) bool {
-			ids = append(ids, re.Row.ID)
-			return true
-		})
-		assert.Equal(t, []string{"daemonset", "job", "statefulset"}, ids)
+
+	tests := map[string]struct {
+		viewSetting        *config.ViewSetting
+		initialSortColumn  SortColumn
+		manual             bool
+		expectedSortColumn SortColumn
+		expectedIDs        []string
+	}{
+		"sorts selected wide column": {
+			initialSortColumn:  wideSortColumn,
+			expectedSortColumn: wideSortColumn,
+			expectedIDs:        expectedIDs,
+		},
+		"keeps manual sort after wide view is hidden": {
+			viewSetting: &config.ViewSetting{
+				Columns:    []string{nameColumn, ownerKindColumn},
+				SortColumn: "NAME:asc",
+			},
+			initialSortColumn:  wideSortColumn,
+			manual:             true,
+			expectedSortColumn: wideSortColumn,
+			expectedIDs:        expectedIDs,
+		},
 	}
 
-	t.Run("sorts selected wide column", func(t *testing.T) {
-		data := newTableData()
-		data.Sort(SortColumn{Name: "OWNER_KIND", ASC: true})
-		assertOrder(t, data)
-	})
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			data := newTableData()
+			sortColumn := test.initialSortColumn
+			if test.viewSetting != nil {
+				sortColumn = data.ComputeSortCol(test.viewSetting, sortColumn, test.manual)
+			}
+			if !assert.Equal(t, test.expectedSortColumn, sortColumn, "unexpected resolved sort column") {
+				return
+			}
 
-	t.Run("keeps manual sort after wide view is hidden", func(t *testing.T) {
-		data := newTableData()
-		sortCol := data.ComputeSortCol(
-			&config.ViewSetting{Columns: []string{"NAME", "OWNER_KIND"}, SortColumn: "NAME:asc"},
-			SortColumn{Name: "OWNER_KIND", ASC: true},
-			true,
-		)
-		assert.Equal(t, SortColumn{Name: "OWNER_KIND", ASC: true}, sortCol)
-
-		data.Sort(sortCol)
-		assertOrder(t, data)
-	})
+			data.Sort(sortColumn)
+			var ids []string
+			data.RowsRange(func(_ int, re RowEvent) bool {
+				ids = append(ids, re.Row.ID)
+				return true
+			})
+			assert.Equal(t, test.expectedIDs, ids, "unexpected row order after sorting by %q", sortColumn.Name)
+		})
+	}
 }
 
 func TestTableDataComputeSortCol(t *testing.T) {


### PR DESCRIPTION
## Summary

- allow the existing table sorter to resolve explicitly selected wide columns
- preserve manual wide-column sorting when returning to the standard view
- add TableData coverage for both paths

Fixes #4166.

## Testing

- `go test ./internal/model1 -run TestTableDataSortWideColumn -count=1`
- `go test ./internal/model1 -count=1`
- `go test ./internal/ui ./internal/view -count=1`
- `make test`
- `CGO_ENABLED=0 make test`
- `golangci-lint v2.6.2 run`
- `go vet ./...`
- `make build` with the default static and netgo settings
- `go test -race ./internal/model1 ./internal/ui ./internal/view -count=1`: internal/model1 and internal/view pass; internal/ui reports the existing TestFlash race between tview GetText and SetText, which also reproduces independently on the unchanged test and implementation files.