### PR TITLE
update kubectl in docker to match go package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk --no-cache add --update make libx11-dev git gcc libc-dev curl \
 # kubectl) even for the arm64 manifest entry, so we let it default to
 # $TARGETPLATFORM and use buildx's TARGETARCH to fetch the matching kubectl.
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
-ARG KUBECTL_VERSION="v1.32.2"
+ARG KUBECTL_VERSION="v1.35.3"
 ARG TARGETARCH
 
 COPY --from=build /k9s/execs/k9s /bin/k9s


### PR DESCRIPTION
Running the latest docker is drifting in kubectl version. I guess it would be good to align with #4171 
```
/ # k9s version
Version:    v0.51.0
/ # kubectl version
Client Version: v1.32.2
```