### PR TITLE
fix(view): don't panic on an invalid filter regex

### DIFF
--- a/internal/model/tree.go
+++ b/internal/model/tree.go
@@ -278,7 +278,10 @@ func (t *Tree) getMeta(ctx context.Context, gvr *client.GVR) (ResourceMeta, erro
 // Helpers...
 
 func rxMatch(q, path string) bool {
-	rx := regexp.MustCompile(`(?i)` + q)
+	rx, err := regexp.Compile(`(?i)` + q)
+	if err != nil {
+		return false
+	}
 
 	tokens := strings.Split(path, "::")
 	for _, t := range tokens {

--- a/internal/model/tree_int_test.go
+++ b/internal/model/tree_int_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The tree query is user typed, so an invalid regex must filter nothing out
+// instead of panicking.
+func TestRxMatchInvalidRx(t *testing.T) {
+	uu := map[string]struct {
+		q string
+		e bool
+	}{
+		"valid":           {q: "nginx", e: true},
+		"unclosed class":  {q: "[", e: false},
+		"dangling repeat": {q: "*", e: false},
+		"unclosed group":  {q: "(", e: false},
+	}
+
+	const path = "v1/pods::default/nginx"
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, rxMatch(u.q, path))
+		})
+	}
+}

--- a/internal/view/xray.go
+++ b/internal/view/xray.go
@@ -773,7 +773,10 @@ func fuzzyFilter(q, path string) bool {
 }
 
 func rxFilter(q, path string) bool {
-	rx := regexp.MustCompile(`(?i)` + q)
+	rx, err := regexp.Compile(`(?i)` + q)
+	if err != nil {
+		return false
+	}
 	tokens := strings.Split(path, xray.PathSeparator)
 	for _, t := range tokens {
 		if rx.MatchString(t) {
@@ -786,7 +789,10 @@ func rxFilter(q, path string) bool {
 
 func rxInverseFilter(q, path string) bool {
 	q = strings.TrimSpace(q[1:])
-	rx := regexp.MustCompile(`(?i)` + q)
+	rx, err := regexp.Compile(`(?i)` + q)
+	if err != nil {
+		return true
+	}
 	tokens := strings.Split(path, xray.PathSeparator)
 	for _, t := range tokens {
 		if rx.MatchString(t) {

--- a/internal/view/xray_int_test.go
+++ b/internal/view/xray_int_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The filter text comes straight from the command buffer, so an unfinished
+// regex like "[" is ordinary user input and must not take k9s down.
+func TestXrayRxFilterInvalidRx(t *testing.T) {
+	uu := map[string]struct {
+		q       string
+		e, eInv bool
+	}{
+		"valid":           {q: "pod", e: true, eInv: false},
+		"unclosed class":  {q: "[", e: false, eInv: true},
+		"dangling repeat": {q: "*", e: false, eInv: true},
+		"unclosed group":  {q: "(", e: false, eInv: true},
+		"invalid repeat":  {q: "a{2,1}", e: false, eInv: true},
+		"unclosed escape": {q: `\`, e: false, eInv: true},
+	}
+
+	const path = "v1/pods::default/nginx"
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, rxFilter(u.q, path))
+			assert.Equal(t, u.eInv, rxInverseFilter("!"+u.q, path))
+		})
+	}
+}


### PR DESCRIPTION
Typing an unfinished regex in the xray or tree filter crashes k9s.

The filter text comes straight from the command buffer (`Xray.filter`, `internal/view/xray.go:531`), and three filter helpers hand it to `regexp.MustCompile`:

- `rxFilter` (`internal/view/xray.go:776`)
- `rxInverseFilter` (`internal/view/xray.go:789`)
- `rxMatch` (`internal/model/tree.go:281`)

So `[`, `*`, `(` or a trailing `\` — all states you pass through while typing a longer pattern — panic the process:

```
panic: regexp: Compile(`(?i)[`): error parsing regexp: missing closing ]: `[`
  internal/model/tree.go:281
```

The sibling helper already does this right: `rxFilter` in `internal/model/helpers.go:67-71` compiles with `regexp.Compile` and returns no matches on error, which is what the describe/yaml/values/text filters use. `TableData.rxFilter` (`internal/model1/table_data.go:174`) likewise compiles and reports the error. Only these three still use `MustCompile`.

This change makes them behave like their sibling: an expression that does not compile matches nothing, so the inverse filter (which is "show what does not match") keeps everything.

Tests: `internal/view/xray_int_test.go` and `internal/model/tree_int_test.go` cover a valid pattern plus five ways of typing an incomplete one. Both panic on master and pass with this change; `go test ./internal/...` is green across all 20 packages, `gofmt` and `go vet` clean.
