### PR TITLE
feat: add flags for flux reconcile helmrelease / kustomization

### DIFF
--- a/plugins/flux.yaml
+++ b/plugins/flux.yaml
@@ -63,6 +63,19 @@ plugins:
       - helmreleases
     command: bash
     background: false
+    inputs:
+      - name: force
+        label: Force install/upgrade
+        type: bool
+        default: false
+      - name: reset
+        label: Reset failure count
+        type: bool
+        default: false
+      - name: source
+        label: Reconcile source as well
+        type: bool
+        default: false
     args:
       - -c
       - >-
@@ -70,6 +83,9 @@ plugins:
         reconcile helmrelease
         --context $CONTEXT
         -n $NAMESPACE $NAME
+        $([ "$INPUT_FORCE" = "true" ] && echo "--force")
+        $([ "$INPUT_RESET" = "true" ] && echo "--reset")
+        $([ "$INPUT_SOURCE" = "true" ] && echo "--with-source")
         | less -K
   reconcile-helm-repo:
     shortCut: Shift-Z
@@ -111,6 +127,11 @@ plugins:
       - kustomizations
     command: bash
     background: false
+    inputs:
+      - name: source
+        label: Reconcile source as well
+        type: bool
+        default: false
     args:
       - -c
       - >-
@@ -118,6 +139,7 @@ plugins:
         reconcile kustomization
         --context $CONTEXT
         -n $NAMESPACE $NAME
+        $([ "$INPUT_SOURCE" = "true" ] && echo "--with-source")
         | less -K
   reconcile-ir:
     shortCut: Shift-R


### PR DESCRIPTION
Added plugin inputs to pass additional flags to `flux reconcile` commands

The plugin is known to give "Plugin load failed" error, fixed in https://github.com/derailed/k9s/pull/3951