### PR TITLE
fix(render): sort CR Age column by duration regardless of column name casing

### DIFF
--- a/internal/render/table.go
+++ b/internal/render/table.go
@@ -17,9 +17,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-const ageTableCol = "Age"
+const ageTableCol = "age"
 
-var ageCols = sets.New("Last Seen", "First Seen", "Age")
+var ageCols = sets.New("last seen", "first seen", "age")
 
 // Table renders a tabular resource to screen.
 type Table struct {
@@ -69,11 +69,11 @@ func (t *Table) defaultHeader() model1.Header {
 	}
 	h := make(model1.Header, 0, len(t.table.ColumnDefinitions))
 	for i, c := range t.table.ColumnDefinitions {
-		if c.Name == ageTableCol {
+		if strings.EqualFold(c.Name, ageTableCol) {
 			t.setAgeIndex(i)
 			continue
 		}
-		timeCol := ageCols.Has(c.Name)
+		timeCol := ageCols.Has(strings.ToLower(c.Name))
 		h = append(h, model1.HeaderColumn{Name: strings.ToUpper(c.Name), Attrs: model1.Attrs{Time: timeCol, Wide: c.Priority > 0}})
 	}
 	if t.getAgeIndex() > 0 {

--- a/internal/render/table_int_test.go
+++ b/internal/render/table_int_test.go
@@ -43,6 +43,34 @@ func Test_defaultHeader(t *testing.T) {
 			},
 		},
 
+		"age-case-insensitive": {
+			cdefs: []metav1.TableColumnDefinition{
+				{Name: "Fred"},
+				{Name: "Blee"},
+				{Name: "age"},
+			},
+			e: model1.Header{
+				model1.HeaderColumn{Name: "FRED"},
+				model1.HeaderColumn{Name: "BLEE"},
+				model1.HeaderColumn{Name: "AGE", Attrs: model1.Attrs{Time: true}},
+			},
+		},
+
+		"time-cols-case-insensitive": {
+			cdefs: []metav1.TableColumnDefinition{
+				{Name: "LAST SEEN"},
+				{Name: "Fred"},
+				{Name: "AGE"},
+				{Name: "first seen"},
+			},
+			e: model1.Header{
+				model1.HeaderColumn{Name: "LAST SEEN", Attrs: model1.Attrs{Time: true}},
+				model1.HeaderColumn{Name: "FRED"},
+				model1.HeaderColumn{Name: "FIRST SEEN", Attrs: model1.Attrs{Time: true}},
+				model1.HeaderColumn{Name: "AGE", Attrs: model1.Attrs{Time: true}},
+			},
+		},
+
 		"time-cols": {
 			cdefs: []metav1.TableColumnDefinition{
 				{Name: "Last Seen"},


### PR DESCRIPTION
## Summary
Fixes `timeCol` detection to be case insensitive. When a CRD defines the age column as something other than `Age` (e.g. `"age"` or `"AGE"`) the sorting defaulted to lexicographic sorting (really `sortorder.NaturalLess`) which was wrong. For example, `140m` would be considered older than `46h`.

## Testing
- Added new test case
- Built and ran a local version and confirmed sorting works as expected without having to update the CRD column name to `"Age"`