### PR TITLE
fix(skins): correct Rosé Pine Dawn palette and cover current skin schema

### DIFF
--- a/skins/rose-pine-dawn.yaml
+++ b/skins/rose-pine-dawn.yaml
@@ -1,17 +1,24 @@
 # -----------------------------------------------------------------------------
-# Rose Pine Dawn
-# https://rosepinetheme.com/palette/ingredients/
+# Rosé Pine Dawn
+# https://rosepinetheme.com/palette
 # -----------------------------------------------------------------------------
-#
-text: &text "#575279"
+
+# Palette...
 base: &base "#faf4ed"
+surface: &surface "#fffaf3"
 overlay: &overlay "#f2e9e1"
 muted: &muted "#9893a5"
+subtle: &subtle "#797593"
+text: &text "#464261"
+love: &love "#b4637a"
+gold: &gold "#ea9d34"
 rose: &rose "#d7827e"
 pine: &pine "#286983"
-gold: &gold "#ea9d34"
+foam: &foam "#56949f"
 iris: &iris "#907aa9"
-love: &love "#b4637a"
+highlight_low: &highlight_low "#f4ede8"
+highlight_med: &highlight_med "#dfdad9"
+highlight_high: &highlight_high "#cecacd"
 
 # Skin...
 k9s:
@@ -20,91 +27,132 @@ k9s:
     fgColor: *text
     bgColor: *base
     logoColor: *iris
+    logoColorMsg: *text
+    logoColorInfo: *pine
+    logoColorWarn: *gold
+    logoColorError: *love
   # Command prompt styles
   prompt:
     fgColor: *text
+    bgColor: *surface
+    suggestColor: *muted
+    border:
+      command: *iris
+      default: *pine
+  # Help view styles.
+  help:
+    fgColor: *text
     bgColor: *base
-    suggestColor: *iris
+    sectionColor: *pine
+    keyColor: *iris
+    numKeyColor: *rose
   # ClusterInfoView styles.
   info:
-    fgColor: *iris
-    sectionColor: *text
+    fgColor: *pine
+    sectionColor: *subtle
+    cpuColor: *foam
+    memColor: *iris
+    k9sRevColor: *rose
   # Dialog styles.
   dialog:
     fgColor: *text
-    bgColor: *base
-    buttonFgColor: *text
+    bgColor: *surface
+    buttonFgColor: *surface
     buttonBgColor: *iris
-    buttonFocusFgColor: *gold
-    buttonFocusBgColor: *iris
-    labelFgColor: *gold
+    buttonFocusFgColor: *surface
+    buttonFocusBgColor: *pine
+    labelFgColor: *love
     fieldFgColor: *text
   frame:
     # Borders styles.
     border:
-      fgColor: *overlay
-      focusColor: *overlay
+      fgColor: *highlight_high
+      focusColor: *iris
     menu:
       fgColor: *text
+      fgStyle: normal
       keyColor: *iris
       # Used for favorite namespaces
-      numKeyColor: *iris
+      numKeyColor: *rose
     # CrumbView attributes for history navigation.
     crumbs:
-      fgColor: *text
-      bgColor: *overlay
-      activeColor: *overlay
+      fgColor: *surface
+      bgColor: *subtle
+      activeColor: *pine
     # Resource status and update styles
     status:
-      newColor: *rose
+      newColor: *foam
       modifyColor: *iris
       addColor: *pine
+      pendingColor: *gold
       errorColor: *love
-      highlightcolor: *gold
+      highlightColor: *rose
       killColor: *muted
-      completedColor: *muted
+      completedColor: *subtle
     # Border title styles.
     title:
-      fgColor: *text
-      bgColor: *overlay
-      highlightColor: *gold
+      fgColor: *subtle
+      bgColor: *base
+      highlightColor: *love
       counterColor: *iris
-      filterColor: *iris
+      filterColor: *pine
   views:
     # Charts skins...
     charts:
-      bgColor: default
+      bgColor: *base
+      dialBgColor: *base
+      chartBgColor: *base
+      focusFgColor: *surface
+      focusBgColor: *iris
       defaultDialColors:
-        - *iris
+        - *pine
         - *love
       defaultChartColors:
-        - *iris
+        - *pine
         - *love
+      resourceColors:
+        cpu:
+          - *foam
+          - *iris
+        mem:
+          - *rose
+          - *love
     # TableView attributes.
     table:
       fgColor: *text
       bgColor: *base
+      cursorFgColor: *text
+      cursorBgColor: *highlight_med
+      markColor: *iris
       # Header row styles.
       header:
-        fgColor: *text
+        fgColor: *subtle
         bgColor: *base
         sorterColor: *rose
+        selectedSortColumnColor: *pine
     # Xray view attributes.
     xray:
       fgColor: *text
       bgColor: *base
-      cursorColor: *overlay
+      cursorColor: *highlight_med
+      cursorTextColor: *text
       graphicColor: *iris
-      showIcons: false
+    # Container picker styles.
+    picker:
+      mainColor: *text
+      focusColor: *iris
+      shortcutColor: *rose
     # YAML info styles.
     yaml:
-      keyColor: *iris
-      colonColor: *iris
+      keyColor: *pine
+      colonColor: *muted
       valueColor: *text
     # Logs styles.
     logs:
       fgColor: *text
       bgColor: *base
       indicator:
-        fgColor: *text
+        fgColor: *surface
         bgColor: *iris
+        toggleOnColor: *pine
+        toggleOffColor: *muted


### PR DESCRIPTION
## What

Updates `skins/rose-pine-dawn.yaml` on two axes: palette accuracy against upstream Rosé Pine, and coverage of skin fields added to k9s since the file was written.

## Why

**1. The `text` role hex is stale.**

The skin uses `#575279`. Upstream Rosé Pine darkened Dawn's `text` role to `#464261` (rose-pine/neovim commit `feat: use experimental darker text for dawn`, Feb 2025). The current value is what `rose-pine/palette` ships in `palette.json` and `dist/json/rose-pine-hex.json`, and what the reference Neovim port uses.

Note for anyone double-checking: `rose-pine/palette` still contains a stale `dist/css/rose-pine.css` that disagrees with its own `dist/json`, so the CSS file is not a reliable source. Side benefit of the correct value: contrast against `base` goes from 6.66:1 to 8.69:1.

**2. `highlightcolor` is silently ignored.**

The status block spells the key `highlightcolor` (lowercase `c`), but the struct tag is `highlightColor` and `gopkg.in/yaml.v3` matches keys against the tag case-sensitively. The key is dropped without error and `Status.HighlightColor` keeps the stock default `aqua`. Verified against yaml.v3 directly:

```
key 'highlightcolor' -> "aqua(stock-default)"
key 'highlightColor' -> "gold"
```

The same typo appears in the skin example on k9scli.io, which is likely where it came from. Other skins in this directory have it too; I kept this PR to the one file, happy to send a follow-up sweep if you want it.

**3. Fields added since the file was written fall back to dark-theme defaults.**

The skin sets 51 keys; the schema in v0.51 supports considerably more. Every unset field falls back to the stock skin, which is designed for a dark background, so on Dawn they surface as off-palette colors. Rendering k9s v0.51.0 in a truecolor terminal and collecting the emitted SGR sequences, the current file emits 9 distinct colors outside the Rosé Pine palette, including `black`, `aqua`, `cadetblue`, `dodgerblue`, `lightskyblue` and `seagreen`. Most visible cases:

| Surface | Missing | Rendered as |
| --- | --- | --- |
| Help view (`?`) | whole `help` block | black background, cadetblue text |
| Table cursor row | `cursorFgColor`, `cursorBgColor` | black on aqua |
| Filter/command prompt border | `prompt.border` | seagreen / aqua |
| Cluster info CPU/MEM | `cpuColor`, `memColor` | lawngreen / darkturquoise |
| Pending resources | `status.pendingColor` | darkorange |
| Marked rows | `table.markColor` | palegreen |
| Log indicator toggles | `toggleOnColor`, `toggleOffColor` | limegreen / gray |

After this change the same run emits zero colors outside the palette.

## Changes

- `text` -> `#464261`; added the `surface`, `subtle`, `foam` and `highlight_low/med/high` anchors so all 15 Rosé Pine roles are available
- fixed `highlightcolor` -> `highlightColor`
- filled in `help`, `prompt.border`, `body.logoColor{Msg,Info,Warn,Error}`, `info.cpuColor/memColor/k9sRevColor`, `status.pendingColor`, `table.cursorFgColor/cursorBgColor/markColor`, `header.selectedSortColumnColor`, `xray.cursorTextColor`, `views.picker`, `charts.dialBgColor/chartBgColor/focusFgColor/focusBgColor/resourceColors`, `logs.indicator.toggleOnColor/toggleOffColor`
- `charts.bgColor` switched from `default` to `base`: `default` keeps the terminal background, which on a light skin is inconsistent if the terminal is dark
- dropped `views.xray.showIcons`, which has no corresponding field on the `Xray` struct (icons are controlled by `k9s.ui.noIcons`)

Role assignment follows the upstream Rosé Pine spec: `love` errors, `gold` warnings and pending, `pine` additions, `foam` new, `iris` accents and modifications, `muted`/`subtle` killed and completed. `gold` is deliberately kept off body text since it only reaches about 2:1 against `base`.

## Testing

k9s v0.51.0 on macOS, isolated `XDG_CONFIG_HOME`, truecolor terminal, raw ANSI captured and every emitted 24-bit color checked against the official palette fetched from `rose-pine/palette`:

- skin loads with no schema validation errors
- all 15 anchors match the official palette exactly
- zero emitted colors outside the palette (context list, help view, filter prompt)