### PR TITLE
fix: report a stalled informer sync instead of spinning forever

### DIFF
--- a/internal/view/browser.go
+++ b/internal/view/browser.go
@@ -43,6 +43,7 @@ type Browser struct {
 	mx         sync.RWMutex
 	updating   bool
 	firstView  atomic.Int32
+	syncStall  syncStallTracker
 }
 
 // NewBrowser returns a new browser.
@@ -173,6 +174,7 @@ func (b *Browser) Start() {
 
 	b.Stop()
 	b.firstView.Store(0) // Reset first view counter on each start
+	b.syncStall.reset()
 	b.GetModel().AddListener(b)
 	b.Table.Start()
 	b.CmdBuff().AddListener(b)
@@ -313,15 +315,33 @@ func (b *Browser) TableNoData(mdata *model1.TableData) {
 	// While the informer cache hasn't synced yet, show a neutral status
 	// instead of a misleading "no resources found" warning.
 	if synced, err := b.app.factory.HasSynced(b.GVR(), b.GetNamespace()); !synced {
+		gvr, ns := b.GVR(), b.GetNamespace()
+		// A sync that never completes reports no error at all, so a wait this
+		// long is surfaced rather than left as an endless spinner.
+		stalled, first := false, false
+		if err == nil {
+			stalled, first = b.syncStall.stalled(gvr.String()+"@"+ns, time.Now())
+		}
+		if first {
+			slog.Warn("Informer cache is still out of sync",
+				slogs.GVR, gvr,
+				slogs.Namespace, ns,
+				slogs.Duration, syncStallDelay,
+			)
+		}
 		b.app.QueueUpdateDraw(func() {
-			if err != nil {
-				b.app.Flash().Warnf("Unable to sync %s: %s", b.GVR(), err)
-				return
+			switch {
+			case err != nil:
+				b.app.Flash().Warnf("Unable to sync %s: %s", gvr, err)
+			case stalled:
+				b.app.Flash().Warnf(syncStallMsg, gvr, syncStallDelay)
+			default:
+				b.app.Flash().Infof("Synchronizing %s in %q namespace...", gvr, client.PrintNamespace(ns))
 			}
-			b.app.Flash().Infof("Synchronizing %s in %q namespace...", b.GVR(), client.PrintNamespace(b.GetNamespace()))
 		})
 		return
 	}
+	b.syncStall.reset()
 
 	cdata := b.Update(mdata, b.app.Conn().HasMetrics())
 	b.app.QueueUpdateDraw(func() {

--- a/internal/view/sync_stall.go
+++ b/internal/view/sync_stall.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"sync"
+	"time"
+)
+
+// syncStallDelay is how long an informer cache may stay unsynced before k9s
+// stops reporting a plain synchronizing status and calls the wait out instead.
+// Some api servers accept a watch-list request, stream the initial events and
+// then never send the k8s.io/initial-events-end bookmark the reflector blocks
+// on. The cache stays unsynced for good and no error is ever raised, so a wait
+// that runs past this delay is reported rather than spun on silently.
+const syncStallDelay = 30 * time.Second
+
+// syncStallMsg is the status shown once a sync wait runs past syncStallDelay. It
+// names the escape hatch, since the most common cause is an api server that
+// accepts watch-list requests without ever ending the initial event stream.
+const syncStallMsg = "Still synchronizing %s after %s. If your api server never ends the watch-list stream, restart k9s with KUBE_FEATURE_WatchListClient=false"
+
+// syncStallTracker tracks how long a single resource has been waiting on its
+// informer cache, so a wait that is never going to end can be called out.
+type syncStallTracker struct {
+	mx     sync.Mutex
+	key    string
+	since  time.Time
+	logged bool
+}
+
+// stalled records a sync wait for the given key and reports whether that wait
+// has now run past syncStallDelay, along with whether this is the first time it
+// has. The clock is supplied by the caller to keep this testable. Switching keys
+// starts a fresh wait, since the previous resource is no longer on screen.
+func (s *syncStallTracker) stalled(key string, now time.Time) (stalled, first bool) {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	if s.key != key || s.since.IsZero() {
+		s.key, s.since, s.logged = key, now, false
+		return false, false
+	}
+	if now.Sub(s.since) < syncStallDelay {
+		return false, false
+	}
+	first, s.logged = !s.logged, true
+
+	return true, first
+}
+
+// reset drops any pending sync wait.
+func (s *syncStallTracker) reset() {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	s.key, s.since, s.logged = "", time.Time{}, false
+}

--- a/internal/view/sync_stall_int_test.go
+++ b/internal/view/sync_stall_int_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of K9s
+
+package view
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSyncStallTrackerBelowDelay(t *testing.T) {
+	var s syncStallTracker
+	now := time.Now()
+
+	stalled, first := s.stalled("v1/pods@fred", now)
+	assert.False(t, stalled)
+	assert.False(t, first)
+
+	stalled, first = s.stalled("v1/pods@fred", now.Add(syncStallDelay-time.Second))
+	assert.False(t, stalled)
+	assert.False(t, first)
+}
+
+func TestSyncStallTrackerPastDelay(t *testing.T) {
+	var s syncStallTracker
+	now := time.Now()
+
+	s.stalled("v1/pods@fred", now)
+
+	stalled, first := s.stalled("v1/pods@fred", now.Add(syncStallDelay))
+	assert.True(t, stalled)
+	assert.True(t, first, "the first stalled wait must be reported once")
+
+	stalled, first = s.stalled("v1/pods@fred", now.Add(2*syncStallDelay))
+	assert.True(t, stalled)
+	assert.False(t, first, "a wait already reported must not be reported again")
+}
+
+func TestSyncStallTrackerNewKeyRestartsWait(t *testing.T) {
+	var s syncStallTracker
+	now := time.Now()
+
+	s.stalled("v1/pods@fred", now)
+
+	stalled, first := s.stalled("v1/svc@fred", now.Add(2*syncStallDelay))
+	assert.False(t, stalled, "switching resource must start a fresh wait")
+	assert.False(t, first)
+
+	stalled, first = s.stalled("v1/svc@fred", now.Add(3*syncStallDelay))
+	assert.True(t, stalled)
+	assert.True(t, first)
+}
+
+func TestSyncStallTrackerNewNamespaceRestartsWait(t *testing.T) {
+	var s syncStallTracker
+	now := time.Now()
+
+	s.stalled("v1/pods@fred", now)
+
+	stalled, _ := s.stalled("v1/pods@blee", now.Add(2*syncStallDelay))
+	assert.False(t, stalled, "switching namespace must start a fresh wait")
+}
+
+func TestSyncStallTrackerReset(t *testing.T) {
+	var s syncStallTracker
+	now := time.Now()
+
+	s.stalled("v1/pods@fred", now)
+	stalled, _ := s.stalled("v1/pods@fred", now.Add(syncStallDelay))
+	assert.True(t, stalled)
+
+	s.reset()
+
+	stalled, first := s.stalled("v1/pods@fred", now.Add(syncStallDelay))
+	assert.False(t, stalled, "a reset tracker must start a fresh wait")
+	assert.False(t, first)
+
+	stalled, first = s.stalled("v1/pods@fred", now.Add(2*syncStallDelay))
+	assert.True(t, stalled)
+	assert.True(t, first, "a reset tracker must report its next stalled wait")
+}


### PR DESCRIPTION
Fixes the silent half of #4044.

Since client-go v0.35 the `WatchListClient` gate defaults on, so every reflector built by `internal/watch/factory.go:286` opens a watch-list stream instead of LIST plus WATCH. `Reflector.watchList` only leaves its retry loop when `watchListBookmarkReceived` is true. An api server that accepts `sendInitialEvents`, streams the initial `ADDED` events and never sends the bookmark carrying `k8s.io/initial-events-end` produces no error, so the loop re-establishes on every watch timeout, `r.store.Replace` is never reached, and `HasSynced` stays false with a nil error for as long as k9s runs.

`Browser.TableNoData` reads that as a sync in progress and flashes "Synchronizing ..." forever. No deadline, no error, nothing in the debug log after the view is exec'd; the reporter and two others reached `KUBE_FEATURE_WatchListClient=false` only after reading client-go.

Not only old clusters: #4044 was filed against v1.18, but a later comment reports the same hang on GKE Autopilot v1.35.6 while GKE Standard on the same version is fine, and the linked Teleport issue is a proxy dropping the bookmark.

This changes only what k9s reports. Informer and client construction are untouched. `TableNoData` tracks how long the current resource has waited on its cache; under 30 seconds nothing changes, past it the status becomes a warning naming the likely cause and the escape hatch, plus one `slog.Warn`. The wait restarts on resource or namespace change and clears when the cache syncs, so a slow first list on a large cluster is still reported as a plain sync. The tracker takes its clock as an argument, so timing is unit-tested rather than slept through. Same shape as #4160, which surfaced the RBAC-denied variant in the same function.

It does not get the user unstuck on its own. It turns a silent hang into a diagnosed one.

`go build ./...`, `go vet ./...`, `go test ./...` green. `golangci-lint run ./internal/view/...` is byte-identical to clean `master` (59 pre-existing `goconst` findings in test files, zero added). `internal/view/sync_stall_int_test.go` covers a wait under the delay staying quiet, a wait past it reporting once and not again, resource and namespace changes starting a fresh wait, and a reset tracker counting from zero.

Not verified against a live api server that swallows the bookmark, since I do not have one. The reproduction is protocol-level and three people confirmed the env-var workaround, so the mechanism is not in doubt, but a maintainer with such a cluster would be checking the warning appears, not that the cache recovers.

On an actual opt-out, which I stopped short of because it is your call: client-go has a per-client escape that does not touch the process-wide gate — a `dynamic.Interface` also implementing `IsWatchListSemanticsUnSupported() bool` disables watch-list for k9s informers alone, and wrapping the client from `DynDial` is a few lines. Auto-detecting the stall and rebuilding informers is the option with no user-visible cost, but `Factory.Terminate` is the only teardown primitive and it closes a stop channel shared by all namespaces and calls `forwarders.DeleteAll`, so automatic fallback would kill live port-forwards until informer lifetime is separated from forwarder lifetime. Happy to follow up with whichever you prefer.
