### PR TITLE
fix(schema): Allow optional defaults for boolean plugin inputs

### DIFF
--- a/internal/config/json/schemas/plugin-multi.json
+++ b/internal/config/json/schemas/plugin-multi.json
@@ -37,7 +37,10 @@
             }
           },
           "required": ["name", "type"],
-          "if": { "required": ["default"] },
+          "if": {
+            "required": ["default"],
+            "properties": { "type": { "enum": ["string", "number", "dropdown"] } }
+          },
           "then": {
             "properties": { "required": { "const": true } },
             "required": ["required"]

--- a/internal/config/json/schemas/plugin.json
+++ b/internal/config/json/schemas/plugin.json
@@ -37,7 +37,10 @@
             }
           },
           "required": ["name", "type"],
-          "if": { "required": ["default"] },
+          "if": {
+            "required": ["default"],
+            "properties": { "type": { "enum": ["string", "number", "dropdown"] } }
+          },
           "then": {
             "properties": { "required": { "const": true } },
             "required": ["required"]

--- a/internal/config/json/schemas/plugins.json
+++ b/internal/config/json/schemas/plugins.json
@@ -41,7 +41,10 @@
                 }
               },
               "required": ["name", "type"],
-              "if": { "required": ["default"] },
+              "if": {
+                "required": ["default"],
+                "properties": { "type": { "enum": ["string", "number", "dropdown"] } }
+              },
               "then": {
                 "properties": { "required": { "const": true } },
                 "required": ["required"]


### PR DESCRIPTION
I missed this during the review of #4174 and forgot the earlier discussion with Fernand in #3853.

This updates the plugin schemas so boolean inputs may define a default without requiring `required: true`. Non-boolean inputs retain the existing validation rule because their defaults are passed to the command even when unchanged.

This also fixes test validation of `plugins/flux.yaml`.

Related discussion: https://github.com/derailed/k9s/pull/3853#pullrequestreview-3870580977