### PR TITLE
Make scale replicas field responsive

### DIFF
--- a/internal/view/scale_extender.go
+++ b/internal/view/scale_extender.go
@@ -163,7 +163,7 @@ func (s *ScaleExtender) makeScaleForm(fqns []string) (*tview.Form, error) {
 		SetLabelColor(styles.LabelFgColor.Color()).
 		SetFieldTextColor(styles.FieldFgColor.Color())
 
-	f.AddInputField("Replicas:", factor, 4, func(textToCheck string, _ rune) bool {
+	f.AddInputField("Replicas:", factor, 0, func(textToCheck string, _ rune) bool {
 		_, err := strconv.Atoi(textToCheck)
 		return err == nil
 	}, func(changed string) {


### PR DESCRIPTION
The scale dialog limited the replicas field to four visible characters, which obscured larger current values. Use tview's standard zero field width so the input consumes available dialog width.