### PR TITLE
fix: judge Pod health against declared containers, not raw status count

### DIFF
--- a/internal/render/pod.go
+++ b/internal/render/pod.go
@@ -162,6 +162,13 @@ func (p *Pod) defaultRow(pwm *PodWithMetrics, row *model1.Row) error {
 	iReady, iTotal, iRestarts := p.initContainerStats(spec.InitContainers, st.InitContainerStatuses)
 	cReady += iReady
 	allCounts := len(spec.Containers) + iTotal
+	// Some providers report extra, provider-managed entries in
+	// status.containerStatuses that have no matching entry in spec.containers
+	// (e.g. an injected sidecar). Health must only be judged against the
+	// containers the Pod actually declares, or that extra status entry makes
+	// an otherwise healthy Pod look unready. The READY column above still
+	// shows the raw counts so the discrepancy stays visible.
+	specReady := p.matchedContainerStats(spec.Containers, st.ContainerStatuses) + iReady
 	rgr, rgt := p.readinessGateStats(spec, &st)
 	ready := hasPodReadyCondition(st.Conditions)
 
@@ -200,7 +207,7 @@ func (p *Pod) defaultRow(pwm *PodWithMetrics, row *model1.Row) error {
 		asReadinessGate(spec, &st),
 		p.mapQOS(st.QOSClass),
 		mapToStr(pwm.Raw.GetLabels()),
-		AsStatus(p.diagnose(phase, cReady, allCounts, ready, rgr, rgt)),
+		AsStatus(p.diagnose(phase, specReady, allCounts, ready, rgr, rgt)),
 		ToAge(pwm.Raw.GetCreationTimestamp()),
 	}
 
@@ -419,6 +426,27 @@ func (*Pod) ContainerStats(cc []v1.ContainerStatus) (readyCnt, terminatedCnt, re
 		}
 	}
 
+	return
+}
+
+// matchedContainerStats reports how many status entries that match a
+// container declared in the Pod spec are ready. This ignores any
+// provider-managed status entries that have no corresponding spec container,
+// so Pod health isn't skewed by containers the Pod itself didn't ask for.
+func (*Pod) matchedContainerStats(cc []v1.Container, cos []v1.ContainerStatus) (ready int) {
+	mm := make(map[string]struct{}, len(cc))
+	for i := range cc {
+		mm[cc[i].Name] = struct{}{}
+	}
+
+	for i := range cos {
+		if _, ok := mm[cos[i].Name]; !ok {
+			continue
+		}
+		if cos[i].Ready {
+			ready++
+		}
+	}
 	return
 }
 

--- a/internal/render/pod_test.go
+++ b/internal/render/pod_test.go
@@ -215,6 +215,27 @@ func TestPodSidecarRender(t *testing.T) {
 	assert.Equal(t, e, r.Fields[:21])
 }
 
+// TestPodExtraStatusContainerRender guards against a provider (e.g. a virtual
+// node injecting a logging sidecar) reporting a container in
+// status.containerStatuses that has no matching entry in spec.containers.
+// READY should still surface the discrepancy (3/2), but the Pod must not be
+// flagged unhealthy in the VALID column when every *declared* container is
+// ready. See https://github.com/derailed/k9s/issues/4145.
+func TestPodExtraStatusContainerRender(t *testing.T) {
+	pom := render.PodWithMetrics{
+		Raw: load(t, "po_extra_status"),
+	}
+
+	po := render.NewPod()
+	r := model1.NewRow(26)
+	err := po.Render(&pom, "", &r)
+	require.NoError(t, err)
+
+	assert.Equal(t, "default/nginx", r.ID)
+	assert.Equal(t, "3/2", r.Fields[4])
+	assert.Empty(t, r.Fields[24])
+}
+
 func TestCheckPodStatus(t *testing.T) {
 	uu := map[string]struct {
 		pod v1.Pod

--- a/internal/render/testdata/po_extra_status.json
+++ b/internal/render/testdata/po_extra_status.json
@@ -1,0 +1,151 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"image\":\"nginx:alpine\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}],\"volumeMounts\":[{\"mountPath\":\"/usr/share/nginx/html\",\"name\":\"index\"}]}],\"terminationGracePeriodSeconds\":0,\"volumes\":[{\"name\":\"index\",\"persistentVolumeClaim\":{\"claimName\":\"web\"}}]}}\n"
+    },
+    "creationTimestamp": "2019-08-09T05:12:19Z",
+    "name": "nginx",
+    "namespace": "default",
+    "resourceVersion": "1482816",
+    "selfLink": "/api/v1/namespaces/default/pods/nginx",
+    "uid": "614908ed-415b-4506-8370-e3e36fa8cc13"
+  },
+  "spec": {
+    "containers": [
+      {
+        "image": "nginx:alpine",
+        "imagePullPolicy": "IfNotPresent",
+        "name": "app",
+        "resources": {},
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File"
+      },
+      {
+        "image": "nginx:alpine",
+        "imagePullPolicy": "IfNotPresent",
+        "name": "sidecar",
+        "resources": {},
+        "terminationMessagePath": "/dev/termination-log",
+        "terminationMessagePolicy": "File"
+      }
+    ],
+    "dnsPolicy": "ClusterFirst",
+    "enableServiceLinks": true,
+    "nodeName": "minikube",
+    "priority": 0,
+    "restartPolicy": "Always",
+    "schedulerName": "default-scheduler",
+    "securityContext": {},
+    "serviceAccount": "default",
+    "serviceAccountName": "default",
+    "terminationGracePeriodSeconds": 0,
+    "tolerations": [
+      {
+        "effect": "NoExecute",
+        "key": "node.kubernetes.io/not-ready",
+        "operator": "Exists",
+        "tolerationSeconds": 300
+      },
+      {
+        "effect": "NoExecute",
+        "key": "node.kubernetes.io/unreachable",
+        "operator": "Exists",
+        "tolerationSeconds": 300
+      }
+    ],
+    "volumes": [
+      {
+        "name": "index",
+        "persistentVolumeClaim": {
+          "claimName": "web"
+        }
+      },
+      {
+        "name": "default-token-9ph8s",
+        "secret": {
+          "defaultMode": 420,
+          "secretName": "default-token-9ph8s"
+        }
+      }
+    ]
+  },
+  "status": {
+    "conditions": [
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:19Z",
+        "status": "True",
+        "type": "Initialized"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:21Z",
+        "status": "True",
+        "type": "Ready"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:21Z",
+        "status": "True",
+        "type": "ContainersReady"
+      },
+      {
+        "lastProbeTime": null,
+        "lastTransitionTime": "2019-08-09T05:12:19Z",
+        "status": "True",
+        "type": "PodScheduled"
+      }
+    ],
+    "containerStatuses": [
+      {
+        "name": "app",
+        "ready": true,
+        "restartCount": 0,
+        "state": {
+          "running": {
+            "startedAt": "2019-08-09T05:12:20Z"
+          }
+        },
+        "image": "nginx:alpine",
+        "imageID": "docker-pullable://nginx@sha256:x",
+        "lastState": {},
+        "containerID": "docker://x1"
+      },
+      {
+        "name": "sidecar",
+        "ready": true,
+        "restartCount": 0,
+        "state": {
+          "running": {
+            "startedAt": "2019-08-09T05:12:20Z"
+          }
+        },
+        "image": "nginx:alpine",
+        "imageID": "docker-pullable://nginx@sha256:x",
+        "lastState": {},
+        "containerID": "docker://x2"
+      },
+      {
+        "name": "provider-agent",
+        "ready": true,
+        "restartCount": 0,
+        "state": {
+          "running": {
+            "startedAt": "2019-08-09T05:12:20Z"
+          }
+        },
+        "image": "provider/agent:latest",
+        "imageID": "docker-pullable://agent@sha256:x",
+        "lastState": {},
+        "containerID": "docker://x3"
+      }
+    ],
+    "hostIP": "192.168.64.104",
+    "phase": "Running",
+    "podIP": "172.17.0.6",
+    "qosClass": "BestEffort",
+    "startTime": "2019-08-09T05:12:19Z"
+  }
+}


### PR DESCRIPTION
Fixes #4145

## Problem

When `status.containerStatuses` has an entry that doesn't match any container in `spec.containers` (a provider injecting a status-only container, e.g. a logging sidecar on a virtual node), the Pod row is colored unhealthy even though every container the Pod actually declares is ready and `Ready`/`ContainersReady` conditions are both `True`.

`defaultRow` computes `cReady` from all of `status.containerStatuses` and compares it against `allCounts`, which is `len(spec.Containers) + iTotal`. Those two numbers come from different universes: one counts every status entry, the other counts only declared containers. Any extra status-only entry breaks the comparison.

## Fix

Added `matchedContainerStats`, which counts ready status entries that match a container name declared in `spec.Containers` (same pattern already used by `initContainerStats` for init containers). The health check (`diagnose`) now uses this matched count instead of the raw one.

The `READY` column still shows the raw counts (e.g. `3/2`), so the extra container stays visible, per the request in the issue. Only the health/color determination changes.

`Healthy()` (used elsewhere) already compared against `len(st.ContainerStatuses)`, so it wasn't affected by this particular case, only `defaultRow`'s inline check was.

## Testing

Added `TestPodExtraStatusContainerRender` with a fixture (`po_extra_status.json`) that reproduces the issue's scenario: 2 declared containers, 3 ready status entries. Confirmed the test fails against the old comparison and passes with the fix.

```
go test ./internal/render/...
ok  	github.com/derailed/k9s/internal/render	0.104s
```
