### PR TITLE
Add stale workflow exemption labels

### DIFF
--- a/.github/workflows/stales-issues.yml
+++ b/.github/workflows/stales-issues.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 14
+          exempt-issue-labels: "accepted"
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."

--- a/.github/workflows/stales-prs.yml
+++ b/.github/workflows/stales-prs.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           days-before-pr-stale: 30
           days-before-pr-close: 14
+          exempt-pr-labels: "accepted"
           stale-pr-label: "stale"
           stale-pr-message: "This PR is stale because it has been open for 30 days with no activity."
           close-pr-message: "This PR was closed because it has been inactive for 14 days since being marked as stale."


### PR DESCRIPTION
## Issue

The GitHub stale action comments on issues and PRs when there hasn't been any activity in some time.
This is commonly followed up by a user comment i.e. "Still relevant" (with "stale" label added and removed notifications)

This leads to a lot of comments that do not add to the conversation in any way and drown actually relevant comments.

## Changes

Added exempt labels to the stale workflow.
When an issue or a PR are determined to be useful to the project is their current state they can be labeled "accepted".
This will prevent them from becoming spammed with stale / not-stale comments.

This is especially helpful for low-priority feature requests, that are expected to be stale for some time, but also shouldn't be closed.

## Example

https://github.com/derailed/k9s/issues/1017